### PR TITLE
Allows the compiler to be specified when building with `./script/build.sh`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,10 +93,27 @@
   ],
   "testPresets": [
     {
-      "name": "default-test",
+      "name": "linux-x86_64",
       "configurePreset": "linux-x86_64",
       "output": {
         "outputOnFailure": true
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "linux-aarch64",
+      "configurePreset": "linux-aarch64",
+      "output": {
+        "outputOnFailure": true
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
       }
     }
   ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,10 @@
 #
 # Usage:
 #      ./scripts/build.sh
+#
+# You can specify the C and C++ compilers by setting the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER environment variables.
+# For example:
+#      CMAKE_C_COMPILER=gcc CMAKE_CXX_COMPILER=g++ ./scripts/build.sh
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"   # e.g. linux or darwin
 ARCH="$(uname -m)"                              # e.g. x86_64 or arm64
@@ -15,7 +19,16 @@ echo "Build directory: $BUILD_DIR"
 echo "Build preset: $BUILD_PRESET"
 
 # Configure
-cmake --preset $BUILD_PRESET
+
+CMAKE_ARGS=()
+if [ -n "$CMAKE_C_COMPILER" ]; then
+  CMAKE_ARGS+=(-DCMAKE_C_COMPILER="$CMAKE_C_COMPILER")
+fi
+if [ -n "$CMAKE_CXX_COMPILER" ]; then
+  CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER="$CMAKE_CXX_COMPILER")
+fi
+
+cmake --preset $BUILD_PRESET "${CMAKE_ARGS[@]}"
 
 # Build
 cmake --build --preset $BUILD_PRESET
@@ -24,4 +37,4 @@ cmake --build --preset $BUILD_PRESET
 cmake --install $BUILD_DIR
 
 # Tests
-ctest --preset default-test
+ctest --preset $BUILD_PRESET


### PR DESCRIPTION
You can specify the C and C++ compilers by setting the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER environment variables.

```CMAKE_C_COMPILER=gcc CMAKE_CXX_COMPILER=g++ ./scripts/build.sh```