### PR TITLE
YMQ Python Module Fixes

### DIFF
--- a/scaler/io/ymq/CMakeLists.txt
+++ b/scaler/io/ymq/CMakeLists.txt
@@ -70,6 +70,27 @@ if(LINUX)
   
   set_target_properties(ymq PROPERTIES  PREFIX "")
   set_target_properties(ymq PROPERTIES LINKER_LANGUAGE CXX)
+find_package(Python3 COMPONENTS Development.Module REQUIRED)
+
+target_sources(ymq PRIVATE pymod_ymq/async.h
+                           pymod_ymq/bytes.h
+                           pymod_ymq/exception.h
+                           pymod_ymq/message.h
+                           pymod_ymq/io_context.h
+                           pymod_ymq/io_socket.h
+                           pymod_ymq/utils.h
+                           pymod_ymq/ymq.h
+                           pymod_ymq/ymq.cpp
+)
+target_include_directories(ymq PRIVATE ${Python3_INCLUDE_DIRS})
+target_link_libraries(ymq PRIVATE cc_ymq
+                          PRIVATE ${Python3_LIBRARIES}
+)
+
+target_link_options(ymq PRIVATE "-Wl,-rpath,$ORIGIN")
+
+install(TARGETS ymq
+       LIBRARY DESTINATION scaler/io/ymq)
 
   target_sources(ymq PRIVATE pymod_ymq/async.h
                              pymod_ymq/bytes.h

--- a/scaler/io/ymq/bytes.h
+++ b/scaler/io/ymq/bytes.h
@@ -30,7 +30,7 @@ class Bytes {
     explicit Bytes(uint8_t* data, size_t len): _data(data), _len(len) {}
 
 public:
-    Bytes(char* data, size_t len): _data(datadup((uint8_t*)data, len)), _len(len) {}
+    Bytes(char* data, size_t len): _data(data ? datadup((uint8_t*)data, len) : nullptr), _len(len) {}
 
     Bytes(): _data {}, _len {} {}
 

--- a/scaler/io/ymq/common.h
+++ b/scaler/io/ymq/common.h
@@ -8,6 +8,7 @@
 // C++
 #include <cstdlib>
 #include <cstring>
+#include <format>
 #include <iostream>
 #include <source_location>
 #include <string>
@@ -35,18 +36,19 @@ inline void print_trace(void)
 
 // this is an unrecoverable error that exits the program
 // prints a message plus the source location
-[[noreturn]] inline void panic(
-    std::string message, const std::source_location& location = std::source_location::current())
-{
+template <typename... Args>
+[[noreturn]] inline void panic(std::format_string<Args...> fmt = "panic", Args&&... args) {
+    const std::source_location& location = std::source_location::current();
+
     auto file_name = std::string(location.file_name());
     file_name      = file_name.substr(file_name.find_last_of("/") + 1);
 
     std::cout << "panic at " << file_name << ":" << location.line() << ":" << location.column() << " in function ["
-              << location.function_name() << "]: " << message << std::endl;
+              << location.function_name() << "]: " << std::format(fmt, std::forward<Args>(args)...) << std::endl;
 
     print_trace();
 
-    std::abort();
+    std::exit(EXIT_FAILURE);
 }
 
 [[nodiscard("Memory is allocated but not used, likely causing a memory leak")]]

--- a/scaler/io/ymq/epoll_context.cpp
+++ b/scaler/io/ymq/epoll_context.cpp
@@ -30,13 +30,15 @@ void EpollContext::loop()
         const int myErrno = errno;
         switch (myErrno) {
             case EINTR:
-                unrecoverableError({
-                    Error::ErrorCode::SignalNotSupported,
-                    "Originated from",
-                    "epoll_wait(2)",
-                    "Errno is",
-                    strerror(errno),
-                });
+                // unrecoverableError({
+                //     Error::ErrorCode::SignalNotSupported,
+                //     "Originated from",
+                //     "epoll_wait(2)",
+                //     "Errno is",
+                //     strerror(errno),
+                // });
+
+                // not an error for now
                 break;
             case EBADF:
             case EFAULT:

--- a/scaler/io/ymq/pymod_ymq/async.h
+++ b/scaler/io/ymq/pymod_ymq/async.h
@@ -14,56 +14,49 @@
 // wraps an async callback that accepts a Python asyncio future
 static PyObject* async_wrapper(PyObject* self, const std::function<void(YMQState* state, PyObject* future)>& callback)
 {
-    // replace with PyType_GetModuleByDef(Py_TYPE(self), &ymq_module) in a newer Python version
-    // https://docs.python.org/3/c-api/type.html#c.PyType_GetModuleByDef
-    PyObject* pyModule = PyType_GetModule(Py_TYPE(self));
-    if (!pyModule) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module for Message type");
+    auto state = YMQStateFromSelf(self);
+    if (!state)
         return nullptr;
-    }
 
-    auto state = (YMQState*)PyModule_GetState(pyModule);
-    if (!state) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
-        return nullptr;
-    }
-
-    PyObject* loop = PyObject_CallMethod(state->asyncioModule, "get_event_loop", nullptr);
-
+    OwnedPyObject loop = PyObject_CallMethod(*state->asyncioModule, "get_event_loop", nullptr);
     if (!loop) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to get event loop");
         return nullptr;
     }
 
-    PyObject* future = PyObject_CallMethod(loop, "create_future", nullptr);
+    OwnedPyObject future = PyObject_CallMethod(*loop, "create_future", nullptr);
 
     if (!future) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to create future");
         return nullptr;
     }
 
-    // borrow the future, we'll decref this after the C++ thread is done
-    Py_INCREF(future);
+    // create the awaitable before calling the callback
+    // this ensures that we create a new strong reference to the future before the callback decrefs it
+    auto awaitable = PyObject_CallFunction(*state->PyAwaitableType, "O", *future);
 
     // async
-    callback(state, future);
+    // we transfer ownership of the future to the callback
+    callback(state, future.take());
 
-    return PyObject_CallFunction(state->PyAwaitableType, "O", future);
+    return awaitable;
 }
 
 struct Awaitable {
     PyObject_HEAD;
-    PyObject* future;
+    OwnedPyObject<> future;
 };
 
 extern "C" {
 
 static int Awaitable_init(Awaitable* self, PyObject* args, PyObject* kwds)
 {
-    if (!PyArg_ParseTuple(args, "O", &self->future)) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to parse arguments for Iterable");
+    PyObject* future = nullptr;
+    if (!PyArg_ParseTuple(args, "O", &future))
         return -1;
-    }
+
+    new (&self->future) OwnedPyObject<>();
+    self->future = OwnedPyObject<>::fromBorrowed(future);
 
     return 0;
 }
@@ -72,13 +65,20 @@ static PyObject* Awaitable_await(Awaitable* self)
 {
     // Easy: coroutines are just iterators and we don't need anything fancy
     // so we can just return the future's iterator!
-    return PyObject_GetIter(self->future);
+    return PyObject_GetIter(*self->future);
 }
 
 static void Awaitable_dealloc(Awaitable* self)
 {
-    Py_DECREF(self->future);
-    Py_TYPE(self)->tp_free((PyObject*)self);
+    try {
+        self->future.~OwnedPyObject();
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to deallocate Awaitable");
+    }
+
+    auto* tp = Py_TYPE(self);
+    tp->tp_free(self);
+    Py_DECREF(tp);
 }
 }
 

--- a/scaler/io/ymq/pymod_ymq/bytes.h
+++ b/scaler/io/ymq/pymod_ymq/bytes.h
@@ -19,46 +19,38 @@ extern "C" {
 
 static int PyBytesYMQ_init(PyBytesYMQ* self, PyObject* args, PyObject* kwds)
 {
-    PyObject* bytes        = nullptr;
+    Py_buffer view {.buf = nullptr};
     const char* keywords[] = {"bytes", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", (char**)keywords, &bytes)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|y*", (char**)keywords, &view)) {
         return -1;  // Error parsing arguments
     }
 
-    if (!bytes) {
+    if (!view.buf) {
         // If no bytes were provided, initialize with an empty Bytes object
-        self->bytes = Bytes((char*)nullptr, 0);
+        self->bytes = Bytes {(char*)nullptr, 0};
         return 0;
-    }
-
-    if (!PyBytes_Check(bytes)) {
-        bytes = PyObject_Bytes(bytes);
-
-        if (!bytes) {
-            PyErr_SetString(PyExc_TypeError, "Expected bytes or bytes-like object");
-            return -1;
-        }
-    }
-
-    char* data     = nullptr;
-    Py_ssize_t len = 0;
-
-    if (PyBytes_AsStringAndSize(bytes, &data, &len) < 0) {
-        PyErr_SetString(PyExc_TypeError, "Failed to get bytes data");
-        return -1;
     }
 
     // copy the data into the Bytes object
     // it might be possible to make this zero-copy in the future
-    self->bytes = Bytes(data, len);
+    self->bytes = Bytes((char*)view.buf, view.len);
 
+    PyBuffer_Release(&view);
     return 0;
 }
 
 static void PyBytesYMQ_dealloc(PyBytesYMQ* self)
 {
-    self->bytes.~Bytes();  // Call the destructor of Bytes
-    Py_TYPE(self)->tp_free(self);
+    try {
+        self->bytes.~Bytes();  // Call the destructor to free the Bytes object
+    } catch (...) {
+        // set the error and continue to free the object
+        PyErr_SetString(PyExc_RuntimeError, "Failed to deallocate Bytes");
+    }
+
+    auto* tp = Py_TYPE(self);
+    tp->tp_free(self);
+    Py_DECREF(tp);
 }
 
 static PyObject* PyBytesYMQ_repr(PyBytesYMQ* self)
@@ -72,7 +64,16 @@ static PyObject* PyBytesYMQ_repr(PyBytesYMQ* self)
 
 static PyObject* PyBytesYMQ_data_getter(PyBytesYMQ* self)
 {
+    if (self->bytes.is_empty()) {
+        Py_RETURN_NONE;
+    }
+
     return PyBytes_FromStringAndSize((const char*)self->bytes.data(), self->bytes.len());
+}
+
+static Py_ssize_t PyBytesYMQ_len(PyBytesYMQ* self)
+{
+    return self->bytes.len();
 }
 
 static PyObject* PyBytesYMQ_len_getter(PyBytesYMQ* self)
@@ -84,6 +85,10 @@ static int PyBytesYMQ_getbuffer(PyBytesYMQ* self, Py_buffer* view, int flags)
 {
     return PyBuffer_FillInfo(view, (PyObject*)self, (void*)self->bytes.data(), self->bytes.len(), true, flags);
 }
+
+static void PyBytesYMQ_releasebuffer(PyBytesYMQ* self, Py_buffer* view)
+{
+}
 }
 
 static PyGetSetDef PyBytesYMQ_properties[] = {
@@ -94,15 +99,17 @@ static PyGetSetDef PyBytesYMQ_properties[] = {
 
 static PyBufferProcs PyBytesYMQBufferProcs = {
     .bf_getbuffer     = (getbufferproc)PyBytesYMQ_getbuffer,
-    .bf_releasebuffer = (releasebufferproc) nullptr,
+    .bf_releasebuffer = (releasebufferproc)PyBytesYMQ_releasebuffer,
 };
 
 static PyType_Slot PyBytesYMQ_slots[] = {
     {Py_tp_init, (void*)PyBytesYMQ_init},
     {Py_tp_dealloc, (void*)PyBytesYMQ_dealloc},
     {Py_tp_repr, (void*)PyBytesYMQ_repr},
+    {Py_mp_length, (void*)PyBytesYMQ_len},
     {Py_tp_getset, (void*)PyBytesYMQ_properties},
-    {Py_bf_getbuffer, (void*)&PyBytesYMQBufferProcs},
+    {Py_bf_getbuffer, (void*)PyBytesYMQ_getbuffer},
+    {Py_bf_releasebuffer, (void*)PyBytesYMQ_releasebuffer},
     {0, nullptr},
 };
 

--- a/scaler/io/ymq/pymod_ymq/exception.h
+++ b/scaler/io/ymq/pymod_ymq/exception.h
@@ -10,7 +10,7 @@
 
 // First-party
 #include "scaler/io/ymq/pymod_ymq/ymq.h"
-#include "ymq.h"
+#include "scaler/io/ymq/pymod_ymq/utils.h"
 
 // the order of the members in the exception args tuple
 const Py_ssize_t YMQException_errorCodeIndex = 0;
@@ -24,27 +24,18 @@ extern "C" {
 
 static int YMQException_init(YMQException* self, PyObject* args, PyObject* kwds)
 {
-    // check the args
+    auto state = YMQStateFromSelf((PyObject*)self);
+    if (!state)
+        return -1;
+
+    // no need to incref these because we don't store them
+    // Furthermore, this fn does not create a strong reference to the args
     PyObject* code    = nullptr;
     PyObject* message = nullptr;
     if (!PyArg_ParseTuple(args, "OO", &code, &message))
         return -1;
 
-    // replace with PyType_GetModuleByDef(Py_TYPE(self), &ymq_module) in a newer Python version
-    // https://docs.python.org/3/c-api/type.html#c.PyType_GetModuleByDef
-    PyObject* pyModule = PyType_GetModule(Py_TYPE(self));
-    if (!pyModule) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module for Message type");
-        return -1;
-    }
-
-    auto state = (YMQState*)PyModule_GetState(pyModule);
-    if (!state) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
-        return -1;
-    }
-
-    if (!PyObject_IsInstance(code, state->PyErrorCodeType)) {
+    if (!PyObject_IsInstance(code, *state->PyErrorCodeType)) {
         PyErr_SetString(PyExc_TypeError, "expected code to be of type ErrorCode");
         return -1;
     }
@@ -60,7 +51,11 @@ static int YMQException_init(YMQException* self, PyObject* args, PyObject* kwds)
 
 static void YMQException_dealloc(YMQException* self)
 {
-    Py_TYPE(self)->tp_free((PyObject*)self);
+    self->ob_base.ob_type->tp_base->tp_dealloc((PyObject*)self);
+
+    // we still need to release the reference to the heap type
+    auto* tp = Py_TYPE(self);
+    Py_DECREF(tp);
 }
 
 static PyObject* YMQException_code_getter(YMQException* self, void* Py_UNUSED(closure))
@@ -90,52 +85,43 @@ static PyType_Slot YMQException_slots[] = {
 static PyType_Spec YMQException_spec = {
     "ymq.YMQException", sizeof(YMQException), 0, Py_TPFLAGS_DEFAULT, YMQException_slots};
 
-PyObject* YMQException_argtupleFromCoreError(const Error* error)
+OwnedPyObject<> YMQException_argtupleFromCoreError(YMQState* state, const Error* error)
 {
-    PyObject* code = PyLong_FromLong(static_cast<long>(error->_errorCode));
+    OwnedPyObject code = PyLong_FromLong(static_cast<long>(error->_errorCode));
 
     if (!code)
         return nullptr;
 
-    PyObject* message = PyUnicode_FromString(error->what());
+    OwnedPyObject pyCode = PyObject_CallFunction(*state->PyErrorCodeType, "O", *code);
 
-    if (!message) {
-        Py_DECREF(code);
+    if (!pyCode)
         return nullptr;
-    }
 
-    PyObject* tuple = PyTuple_Pack(2, code, message);
+    OwnedPyObject message = PyUnicode_FromString(error->what());
 
-    if (!tuple) {
-        Py_DECREF(code);
-        Py_DECREF(message);
+    if (!message)
         return nullptr;
-    }
 
-    Py_DECREF(code);
-    Py_DECREF(message);
-
-    return tuple;
+    return PyTuple_Pack(2, *pyCode, *message);
 }
 
 void YMQException_setFromCoreError(YMQState* state, const Error* error)
 {
-    auto tuple = YMQException_argtupleFromCoreError(error);
+    auto tuple = YMQException_argtupleFromCoreError(state, error);
     if (!tuple)
         return;
 
-    PyErr_SetObject(state->PyExceptionType, tuple);
-    Py_DECREF(tuple);
+    PyErr_SetObject(*state->PyExceptionType, *tuple);
 }
 
 PyObject* YMQException_createFromCoreError(YMQState* state, const Error* error)
 {
-    auto tuple = YMQException_argtupleFromCoreError(error);
+    auto tuple = YMQException_argtupleFromCoreError(state, error);
     if (!tuple)
         return nullptr;
 
-    PyObject* exc = PyObject_CallObject(state->PyExceptionType, tuple);
-    Py_DECREF(tuple);
+    OwnedPyObject exc = PyObject_CallObject(*state->PyExceptionType, *tuple);
 
-    return exc;
+    // transfer ownership to caller
+    return exc.take();
 }

--- a/scaler/io/ymq/pymod_ymq/io_context.h
+++ b/scaler/io/ymq/pymod_ymq/io_context.h
@@ -1,20 +1,24 @@
 #pragma once
 
 // Python
-#include "io_socket.h"
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <structmember.h>
 
 // C++
+#include <functional>
 #include <future>
 #include <memory>
 
 // First-party
 #include "scaler/io/ymq/configuration.h"
 #include "scaler/io/ymq/io_context.h"
+#include "scaler/io/ymq/io_socket.h"
 #include "scaler/io/ymq/pymod_ymq/io_socket.h"
 #include "scaler/io/ymq/pymod_ymq/ymq.h"
+
+using namespace scaler::ymq;
+using Identity = Configuration::IOSocketIdentity;
 
 struct PyIOContext {
     PyObject_HEAD;
@@ -25,40 +29,35 @@ extern "C" {
 
 static int PyIOContext_init(PyIOContext* self, PyObject* args, PyObject* kwds)
 {
-    PyObject* numThreadsObj = nullptr;
-    const char* kwlist[]    = {"num_threads", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", (char**)kwlist, &numThreadsObj)) {
-        return -1;  // Error parsing arguments
+    // default to 1 thread if not specified
+    Py_ssize_t numThreads = 1;
+    const char* kwlist[]  = {"num_threads", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|n", (char**)kwlist, &numThreads))
+        return -1;
+
+    try {
+        new (&self->ioContext) std::shared_ptr<IOContext>();
+        self->ioContext = std::make_shared<IOContext>(numThreads);
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to create IOContext");
+        return -1;
     }
-
-    size_t numThreads = 1;  // Default to 1 thread if not specified
-
-    if (numThreadsObj) {
-        if (!PyLong_Check(numThreadsObj)) {
-            PyErr_SetString(PyExc_TypeError, "num_threads must be an integer");
-            return -1;
-        }
-        numThreads = PyLong_AsSize_t(numThreadsObj);
-        if (numThreads == static_cast<size_t>(-1) && PyErr_Occurred()) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to convert num_threads to size_t");
-            return -1;
-        }
-        if (numThreads <= 0) {
-            PyErr_SetString(PyExc_ValueError, "num_threads must be greater than 0");
-            return -1;
-        }
-    }
-
-    new (&self->ioContext) std::shared_ptr<IOContext>();
-    self->ioContext = std::make_shared<IOContext>(numThreads);
 
     return 0;
 }
 
 static void PyIOContext_dealloc(PyIOContext* self)
 {
-    self->ioContext.~shared_ptr();
-    Py_TYPE(self)->tp_free((PyObject*)self);  // Free the PyObject
+    try {
+        self->ioContext.~shared_ptr();
+    } catch (...) {
+        // set the error and continue to free the object
+        PyErr_SetString(PyExc_RuntimeError, "Failed to deallocate IOContext");
+    }
+
+    auto* tp = Py_TYPE(self);
+    tp->tp_free(self);
+    Py_DECREF(tp);
 }
 
 static PyObject* PyIOContext_repr(PyIOContext* self)
@@ -66,21 +65,74 @@ static PyObject* PyIOContext_repr(PyIOContext* self)
     return PyUnicode_FromFormat("<IOContext at %p>", (void*)self->ioContext.get());
 }
 
-// todo: how to parse keyword arguments?
-// https://docs.python.org/3/c-api/structures.html#c.METH_METHOD
-// https://docs.python.org/3.10/c-api/call.html#vectorcall
-// https://peps.python.org/pep-0590/
-static PyObject* PyIOContext_createIOSocket(
-    PyIOContext* self, PyTypeObject* clazz, PyObject* const* args, Py_ssize_t nargs, PyObject* kwnames)
+static PyObject* PyIOContext_createIOSocket_(
+    PyIOContext* self,
+    PyTypeObject* clazz,
+    PyObject* const* args,
+    Py_ssize_t nargs,
+    PyObject* kwnames,
+    std::function<PyObject*(PyIOSocket* ioSocket, Identity identity, IOSocketType socketType)> fn)
 {
     using Identity = Configuration::IOSocketIdentity;
-    if (nargs != 2) {
-        PyErr_SetString(PyExc_TypeError, "createIOSocket() requires exactly two arguments: identity and socket_type");
+
+    // note: references borrowed from args, so no need to manage their lifetime
+    PyObject* pyIdentity {};
+    PyObject* pySocketType {};
+    if (nargs == 1) {
+        pyIdentity = args[0];
+    } else if (nargs == 2) {
+        pyIdentity   = args[0];
+        pySocketType = args[1];
+    } else if (nargs > 2) {
+        PyErr_SetString(PyExc_TypeError, "createIOSocket() requires exactly two arguments");
         return nullptr;
     }
 
-    PyObject* pyIdentity   = args[0];
-    PyObject* pySocketType = args[1];
+    if (kwnames) {
+        auto n = PyTuple_Size(kwnames);
+
+        if (n < 0)
+            return nullptr;
+
+        for (int i = 0; i < n; ++i) {
+            // note: returns a borrowed reference
+            auto kw = PyTuple_GetItem(kwnames, i);
+            if (!kw)
+                return nullptr;
+
+            // ptr is callee-owned, no need to free it
+            const char* kwStr = PyUnicode_AsUTF8(kw);
+            if (!kwStr)
+                return nullptr;
+
+            if (std::strcmp(kwStr, "identity") == 0) {
+                if (pyIdentity) {
+                    PyErr_SetString(PyExc_TypeError, "Multiple values provided for identity argument");
+                    return nullptr;
+                }
+                pyIdentity = args[nargs + i];
+            } else if (std::strcmp(kwStr, "socket_type") == 0) {
+                if (pySocketType) {
+                    PyErr_SetString(PyExc_TypeError, "Multiple values provided for socket_type argument");
+                    return nullptr;
+                }
+                pySocketType = args[nargs + i];
+            } else {
+                PyErr_Format(PyExc_TypeError, "Unexpected keyword argument: %s", kwStr);
+                return nullptr;
+            }
+        }
+    }
+
+    if (!pyIdentity) {
+        PyErr_SetString(PyExc_TypeError, "createIOSocket() requires an identity argument");
+        return nullptr;
+    }
+
+    if (!pySocketType) {
+        PyErr_SetString(PyExc_TypeError, "createIOSocket() requires a socket_type argument");
+        return nullptr;
+    }
 
     if (!PyUnicode_Check(pyIdentity)) {
         PyErr_SetString(PyExc_TypeError, "Expected identity to be a string");
@@ -90,68 +142,104 @@ static PyObject* PyIOContext_createIOSocket(
     // get the module state from the class
     YMQState* state = (YMQState*)PyType_GetModuleState(clazz);
 
-    if (!state) {
-        // PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
+    if (!state)
         return nullptr;
-    }
 
-    if (!PyObject_IsInstance(pySocketType, state->PyIOSocketEnumType)) {
+    if (!PyObject_IsInstance(pySocketType, *state->PyIOSocketEnumType)) {
         PyErr_SetString(PyExc_TypeError, "Expected socket_type to be an instance of IOSocketType");
         return nullptr;
     }
 
     Py_ssize_t identitySize  = 0;
     const char* identityCStr = PyUnicode_AsUTF8AndSize(pyIdentity, &identitySize);
-
-    if (!identityCStr) {
-        PyErr_SetString(PyExc_TypeError, "Failed to convert identity to string");
+    if (!identityCStr)
         return nullptr;
-    }
 
-    PyObject* value = PyObject_GetAttrString(pySocketType, "value");
-
-    if (!value) {
-        PyErr_SetString(PyExc_TypeError, "Failed to get value from socket_type");
+    OwnedPyObject value = PyObject_GetAttrString(pySocketType, "value");
+    if (!value)
         return nullptr;
-    }
 
-    if (!PyLong_Check(value)) {
+    if (!PyLong_Check(*value)) {
         PyErr_SetString(PyExc_TypeError, "Expected socket_type to be an integer");
-        Py_DECREF(value);
         return nullptr;
     }
 
-    long socketTypeValue = PyLong_AsLong(value);
+    long socketTypeValue = PyLong_AsLong(*value);
 
-    if (socketTypeValue < 0 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_TypeError, "Failed to convert socket_type to integer");
-        Py_DECREF(value);
+    if (socketTypeValue < 0 && PyErr_Occurred())
         return nullptr;
-    }
-
-    Py_DECREF(value);
 
     Identity identity(identityCStr, identitySize);
     IOSocketType socketType = static_cast<IOSocketType>(socketTypeValue);
 
-    PyIOSocket* ioSocket = PyObject_New(PyIOSocket, (PyTypeObject*)state->PyIOSocketType);
-    if (!ioSocket) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create IOSocket instance");
+    OwnedPyObject<PyIOSocket> ioSocket = PyObject_New(PyIOSocket, (PyTypeObject*)*state->PyIOSocketType);
+    if (!ioSocket)
+        return nullptr;
+
+    try {
+        // ensure the fields are init
+        new (&ioSocket->socket) std::shared_ptr<IOSocket>();
+        new (&ioSocket->ioContext) std::shared_ptr<IOContext>();
+        ioSocket->ioContext = self->ioContext;
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to create IOSocket");
         return nullptr;
     }
 
-    // ensure the fields are init
-    new (&ioSocket->socket) std::shared_ptr<IOSocket>();
-    new (&ioSocket->ioContext) std::shared_ptr<IOContext>();
+    // move ownership of the ioSocket to the callback
+    return fn(ioSocket.take(), identity, socketType);
+}
 
-    return async_wrapper((PyObject*)self, [=](YMQState* state, PyObject* future) {
-        self->ioContext->createIOSocket(identity, socketType, [=](auto socket) {
-            future_set_result(future, [=] {
-                ioSocket->socket = socket;
-                return (PyObject*)ioSocket;
+static PyObject* PyIOContext_createIOSocket(
+    PyIOContext* self, PyTypeObject* clazz, PyObject* const* args, Py_ssize_t nargs, PyObject* kwnames)
+{
+    return PyIOContext_createIOSocket_(
+        self, clazz, args, nargs, kwnames, [self](auto ioSocket, Identity identity, IOSocketType socketType) {
+            return async_wrapper((PyObject*)self, [=](YMQState* state, auto future) {
+                self->ioContext->createIOSocket(identity, socketType, [=](std::shared_ptr<IOSocket> socket) {
+                    future_set_result(future, [=] {
+                        ioSocket->socket = std::move(socket);
+                        return (PyObject*)ioSocket;
+                    });
+                });
             });
         });
-    });
+}
+
+static PyObject* PyIOContext_createIOSocket_sync(
+    PyIOContext* self, PyTypeObject* clazz, PyObject* const* args, Py_ssize_t nargs, PyObject* kwnames)
+{
+    auto state = YMQStateFromSelf((PyObject*)self);
+    if (!state)
+        return nullptr;
+
+    return PyIOContext_createIOSocket_(
+        self, clazz, args, nargs, kwnames, [self, state](auto ioSocket, Identity identity, IOSocketType socketType) {
+            PyThreadState* _save = PyEval_SaveThread();
+
+            std::shared_ptr<IOSocket> socket {};
+            try {
+                Waiter waiter(state->wakeupfd_rd);
+
+                self->ioContext->createIOSocket(
+                    identity, socketType, [waiter, &socket](std::shared_ptr<IOSocket> s) mutable {
+                        socket = std::move(s);
+                        waiter.signal();
+                    });
+
+                if (waiter.wait())
+                    CHECK_SIGNALS;
+            } catch (...) {
+                PyEval_RestoreThread(_save);
+                PyErr_SetString(PyExc_RuntimeError, "Failed to bind to create io socket synchronously");
+                return (PyObject*)nullptr;
+            }
+
+            PyEval_RestoreThread(_save);
+
+            ioSocket->socket = socket;
+            return (PyObject*)ioSocket;
+        });
 }
 
 static PyObject* PyIOContext_numThreads_getter(PyIOContext* self, void* Py_UNUSED(closure))
@@ -163,6 +251,10 @@ static PyObject* PyIOContext_numThreads_getter(PyIOContext* self, void* Py_UNUSE
 static PyMethodDef PyIOContext_methods[] = {
     {"createIOSocket",
      (PyCFunction)PyIOContext_createIOSocket,
+     METH_METHOD | METH_FASTCALL | METH_KEYWORDS,
+     PyDoc_STR("Create a new IOSocket")},
+    {"createIOSocket_sync",
+     (PyCFunction)PyIOContext_createIOSocket_sync,
      METH_METHOD | METH_FASTCALL | METH_KEYWORDS,
      PyDoc_STR("Create a new IOSocket")},
     {nullptr, nullptr, 0, nullptr},

--- a/scaler/io/ymq/pymod_ymq/io_socket.h
+++ b/scaler/io/ymq/pymod_ymq/io_socket.h
@@ -8,10 +8,14 @@
 // C++
 #include <chrono>
 #include <expected>
-#include <latch>
 #include <memory>
 #include <thread>
 #include <utility>
+
+// C
+#include <semaphore.h>
+#include <sys/eventfd.h>
+#include <sys/poll.h>
 
 // First-party
 #include "scaler/io/ymq/bytes.h"
@@ -22,9 +26,11 @@
 #include "scaler/io/ymq/pymod_ymq/bytes.h"
 #include "scaler/io/ymq/pymod_ymq/exception.h"
 #include "scaler/io/ymq/pymod_ymq/message.h"
+#include "scaler/io/ymq/pymod_ymq/utils.h"
 #include "scaler/io/ymq/pymod_ymq/ymq.h"
 
 using namespace scaler::ymq;
+using namespace std::chrono_literals;
 
 struct PyIOSocket {
     PyObject_HEAD;
@@ -36,31 +42,46 @@ extern "C" {
 
 static void PyIOSocket_dealloc(PyIOSocket* self)
 {
-    self->ioContext->removeIOSocket(self->socket);
-    self->ioContext.~shared_ptr();
-    self->socket.~shared_ptr();
-    Py_TYPE(self)->tp_free((PyObject*)self);  // Free the PyObject
+    try {
+        self->ioContext->removeIOSocket(self->socket);
+        self->ioContext.~shared_ptr();
+        self->socket.~shared_ptr();
+    } catch (...) {
+        // set the error and continue to free the object
+        PyErr_SetString(PyExc_RuntimeError, "Failed to deallocate IOSocket");
+    }
+
+    auto* tp = Py_TYPE(self);
+    tp->tp_free(self);
+    Py_DECREF(tp);
 }
 
 static PyObject* PyIOSocket_send(PyIOSocket* self, PyObject* args, PyObject* kwargs)
 {
+    // borrowed reference
     PyMessage* message   = nullptr;
     const char* kwlist[] = {"message", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &message)) {
-        Py_RETURN_NONE;
-    }
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &message))
+        return nullptr;
 
-    return async_wrapper((PyObject*)self, [&](YMQState* state, PyObject* future) {
-        self->socket->sendMessage(
-            {.address = std::move(message->address->bytes), .payload = std::move(message->payload->bytes)},
-            [&](auto result) {
-                if (result) {
-                    future_set_result(future, []() { Py_RETURN_NONE; });
-                } else {
-                    future_raise_exception(
-                        future, [state, result]() { return YMQException_createFromCoreError(state, &result.error()); });
-                }
+    auto address = message->address.is_none() ? Bytes {(char*)nullptr, 0} : std::move(message->address->bytes);
+    auto payload = std::move(message->payload->bytes);
+
+    return async_wrapper((PyObject*)self, [=](YMQState* state, auto future) {
+        try {
+            self->socket->sendMessage({.address = std::move(address), .payload = std::move(payload)}, [=](auto result) {
+                future_set_result(future, [=] -> std::expected<PyObject*, PyObject*> {
+                    if (result) {
+                        Py_RETURN_NONE;
+                    } else {
+                        return std::unexpected {YMQException_createFromCoreError(state, &result.error())};
+                    }
+                });
             });
+        } catch (...) {
+            future_raise_exception(
+                future, [] { return PyErr_CreateFromString(PyExc_RuntimeError, "Failed to send message"); });
+        }
     });
 }
 
@@ -70,33 +91,38 @@ static PyObject* PyIOSocket_send_sync(PyIOSocket* self, PyObject* args, PyObject
     if (!state)
         return nullptr;
 
+    // borrowed reference
     PyMessage* message   = nullptr;
     const char* kwlist[] = {"message", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &message)) {
-        Py_RETURN_NONE;
-    }
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &message))
+        return nullptr;
 
-    std::latch waiter(1);
-    std::expected<void, Error> result {};
+    Bytes address = message->address.is_none() ? Bytes {(char*)nullptr, 0} : std::move(message->address->bytes);
+    Bytes payload = std::move(message->payload->bytes);
 
-    self->socket->sendMessage(
-        {.address = message->address ? std::move(message->address->bytes) : Bytes((char*)nullptr, 0),
-         .payload = std::move(message->payload->bytes)},
-        [&](auto r) {
-            result = r;
-            waiter.count_down();
+    PyThreadState* _save = PyEval_SaveThread();
+
+    std::shared_ptr<std::expected<void, Error>> result = std::make_shared<std::expected<void, Error>>();
+    try {
+        Waiter waiter(state->wakeupfd_rd);
+
+        self->socket->sendMessage({.address = std::move(address), .payload = std::move(payload)}, [=](auto r) mutable {
+            *result = std::move(r);
+            waiter.signal();
         });
 
-    // block the thread until the callback is called
-    try {
-        waiter.wait();
-    } catch (const std::exception& e) {
+        if (waiter.wait())
+            CHECK_SIGNALS;
+    } catch (...) {
+        PyEval_RestoreThread(_save);
         PyErr_SetString(PyExc_RuntimeError, "Failed to bind to send synchronously");
         return nullptr;
     }
 
+    PyEval_RestoreThread(_save);
+
     if (!result) {
-        YMQException_setFromCoreError(state, &result.error());
+        YMQException_setFromCoreError(state, &result->error());
         return nullptr;
     }
 
@@ -105,38 +131,41 @@ static PyObject* PyIOSocket_send_sync(PyIOSocket* self, PyObject* args, PyObject
 
 static PyObject* PyIOSocket_recv(PyIOSocket* self, PyObject* args)
 {
-    return async_wrapper((PyObject*)self, [&](YMQState* state, PyObject* future) {
-        self->socket->recvMessage([&](auto result) {
-            if (result.second._errorCode == Error::ErrorCode::Uninit) {
-                auto message = result.first;
-                future_set_result(future, [&]() {
-                    PyBytesYMQ* address = (PyBytesYMQ*)PyObject_CallNoArgs(state->PyBytesYMQType);
-                    if (!address) {
-                        Py_RETURN_NONE;
+    return async_wrapper((PyObject*)self, [=](YMQState* state, auto future) {
+        self->socket->recvMessage([=](auto result) {
+            try {
+                future_set_result(future, [=] -> std::expected<PyObject*, PyObject*> {
+                    if (result.second._errorCode != Error::ErrorCode::Uninit) {
+                        return std::unexpected {YMQException_createFromCoreError(state, &result.second)};
                     }
 
-                    PyBytesYMQ* payload = (PyBytesYMQ*)PyObject_CallNoArgs(state->PyBytesYMQType);
-                    if (!payload) {
-                        Py_DECREF(address);
-                        Py_RETURN_NONE;
-                    }
+                    auto message                      = result.first;
+                    OwnedPyObject<PyBytesYMQ> address = (PyBytesYMQ*)PyObject_CallNoArgs(*state->PyBytesYMQType);
+                    if (!address)
+                        return PyErr_GetRaisedException();
 
                     address->bytes = std::move(message.address);
+
+                    OwnedPyObject<PyBytesYMQ> payload = (PyBytesYMQ*)PyObject_CallNoArgs(*state->PyBytesYMQType);
+                    if (!payload)
+                        return PyErr_GetRaisedException();
+
                     payload->bytes = std::move(message.payload);
 
-                    PyMessage* message =
-                        (PyMessage*)PyObject_CallFunction(state->PyMessageType, "OO", address, payload);
-                    if (!message) {
-                        Py_DECREF(address);
-                        Py_DECREF(payload);
-                        Py_RETURN_NONE;
-                    }
+                    OwnedPyObject<PyMessage> pyMessage =
+                        (PyMessage*)PyObject_CallFunction(*state->PyMessageType, "OO", *address, *payload);
+                    if (!pyMessage)
+                        return PyErr_GetRaisedException();
 
-                    return (PyObject*)message;
+                    // leak -- why is this necessary?
+                    address.forget();
+                    payload.forget();
+
+                    return (PyObject*)pyMessage.take();
                 });
-            } else {
+            } catch (...) {
                 future_raise_exception(
-                    future, [state, result] { return YMQException_createFromCoreError(state, &result.second); });
+                    future, [] { return PyErr_CreateFromString(PyExc_RuntimeError, "Failed to receive message"); });
             }
         });
     });
@@ -148,86 +177,81 @@ static PyObject* PyIOSocket_recv_sync(PyIOSocket* self, PyObject* args)
     if (!state)
         return nullptr;
 
-    std::pair<Message, Error> result {};
-    std::latch waiter(1);
+    PyThreadState* _save = PyEval_SaveThread();
 
-    self->socket->recvMessage([&](auto r) {
-        result = std::move(r);
-        waiter.count_down();
-    });
-
-    // block the thread until the callback is called
+    std::shared_ptr<std::pair<Message, Error>> result = std::make_shared<std::pair<Message, Error>>();
     try {
-        waiter.wait();
-    } catch (const std::exception& e) {
+        Waiter waiter(state->wakeupfd_rd);
+
+        self->socket->recvMessage([=](auto r) mutable {
+            *result = std::move(r);
+            waiter.signal();
+        });
+
+        if (waiter.wait())
+            CHECK_SIGNALS;
+    } catch (...) {
+        PyEval_RestoreThread(_save);
         PyErr_SetString(PyExc_RuntimeError, "Failed to bind to recv synchronously");
         return nullptr;
     }
 
-    if (result.second._errorCode != Error::ErrorCode::Uninit) {
-        YMQException_setFromCoreError(state, &result.second);
+    PyEval_RestoreThread(_save);
+
+    if (result->second._errorCode != Error::ErrorCode::Uninit) {
+        YMQException_setFromCoreError(state, &result->second);
         return nullptr;
     }
 
-    auto message = result.first;
+    auto message = result->first;
 
-    PyBytesYMQ* address = (PyBytesYMQ*)PyObject_CallNoArgs(state->PyBytesYMQType);
-    if (!address) {
-        Py_RETURN_NONE;
-    }
-
-    PyBytesYMQ* payload = (PyBytesYMQ*)PyObject_CallNoArgs(state->PyBytesYMQType);
-    if (!payload) {
-        Py_DECREF(address);
-        Py_RETURN_NONE;
-    }
+    OwnedPyObject<PyBytesYMQ> address = (PyBytesYMQ*)PyObject_CallNoArgs(*state->PyBytesYMQType);
+    if (!address)
+        return nullptr;
 
     address->bytes = std::move(message.address);
+
+    OwnedPyObject<PyBytesYMQ> payload = (PyBytesYMQ*)PyObject_CallNoArgs(*state->PyBytesYMQType);
+    if (!payload)
+        return nullptr;
+
     payload->bytes = std::move(message.payload);
 
-    PyMessage* pyMessage = (PyMessage*)PyObject_CallFunction(state->PyMessageType, "OO", address, payload);
-    if (!pyMessage) {
-        Py_DECREF(address);
-        Py_DECREF(payload);
-        Py_RETURN_NONE;
-    }
+    OwnedPyObject<PyMessage> pyMessage =
+        (PyMessage*)PyObject_CallFunction(*state->PyMessageType, "OO", *address, *payload);
+    if (!pyMessage)
+        return nullptr;
 
-    return (PyObject*)pyMessage;
+    // leak -- why is this necessary?
+    address.forget();
+    payload.forget();
+
+    return (PyObject*)pyMessage.take();
 }
 
 static PyObject* PyIOSocket_bind(PyIOSocket* self, PyObject* args, PyObject* kwargs)
 {
-    PyObject* addressObj = nullptr;
-    const char* kwlist[] = {"address", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &addressObj)) {
-        PyErr_SetString(PyExc_TypeError, "expected one argument: address");
-        Py_RETURN_NONE;
-    }
-
-    if (!PyUnicode_Check(addressObj)) {
-        Py_DECREF(addressObj);
-
-        PyErr_SetString(PyExc_TypeError, "argument must be a str");
-        Py_RETURN_NONE;
-    }
-
+    const char* address   = nullptr;
     Py_ssize_t addressLen = 0;
-    const char* address   = PyUnicode_AsUTF8AndSize(addressObj, &addressLen);
+    const char* kwlist[]  = {"address", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s#", (char**)kwlist, &address, &addressLen))
+        return nullptr;
 
-    if (!address)
-        Py_RETURN_NONE;
+    return async_wrapper((PyObject*)self, [=](YMQState* state, auto future) {
+        try {
+            self->socket->bindTo(std::string(address, addressLen), [=](auto result) {
+                future_set_result(future, [=] -> std::expected<PyObject*, PyObject*> {
+                    if (!result) {
+                        return std::unexpected {YMQException_createFromCoreError(state, &result.error())};
+                    }
 
-    return async_wrapper((PyObject*)self, [=](YMQState* state, PyObject* future) {
-        self->socket->bindTo(std::string(address, addressLen), [=](auto error) {
-            future_set_result(future, [=]() {
-                if (error) {
-                    PyErr_SetString(PyExc_RuntimeError, "Failed to bind to address");
-                    return (PyObject*)nullptr;
-                }
-
-                Py_RETURN_NONE;
+                    Py_RETURN_NONE;
+                });
             });
-        });
+        } catch (...) {
+            future_raise_exception(
+                future, [] { return PyErr_CreateFromString(PyExc_RuntimeError, "Failed to bind to address"); });
+        }
     });
 }
 
@@ -237,44 +261,35 @@ static PyObject* PyIOSocket_bind_sync(PyIOSocket* self, PyObject* args, PyObject
     if (!state)
         return nullptr;
 
-    PyObject* addressObj = nullptr;
-    const char* kwlist[] = {"address", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &addressObj)) {
-        PyErr_SetString(PyExc_TypeError, "expected one argument: address");
-        Py_RETURN_NONE;
-    }
-
-    if (!PyUnicode_Check(addressObj)) {
-        Py_DECREF(addressObj);
-
-        PyErr_SetString(PyExc_TypeError, "argument must be a str");
-        Py_RETURN_NONE;
-    }
-
+    const char* address   = nullptr;
     Py_ssize_t addressLen = 0;
-    const char* address   = PyUnicode_AsUTF8AndSize(addressObj, &addressLen);
+    const char* kwlist[]  = {"address", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s#", (char**)kwlist, &address, &addressLen))
+        return nullptr;
 
-    if (!address)
-        Py_RETURN_NONE;
+    PyThreadState* _save = PyEval_SaveThread();
 
-    std::expected<void, Error> result {};
-    std::latch waiter(1);
-
-    self->socket->bindTo(std::string(address, addressLen), [&](auto r) {
-        result = r;
-        waiter.count_down();
-    });
-
-    // block the thread until the callback is called
+    std::shared_ptr<std::expected<void, Error>> result = std::make_shared<std::expected<void, Error>>();
     try {
-        waiter.wait();
-    } catch (const std::exception& e) {
+        Waiter waiter(state->wakeupfd_rd);
+
+        self->socket->bindTo(std::string(address, addressLen), [=](auto r) mutable {
+            *result = std::move(r);
+            waiter.signal();
+        });
+
+        if (waiter.wait())
+            CHECK_SIGNALS;
+    } catch (...) {
+        PyEval_RestoreThread(_save);
         PyErr_SetString(PyExc_RuntimeError, "Failed to bind to address synchronously");
         return nullptr;
     }
 
+    PyEval_RestoreThread(_save);
+
     if (!result) {
-        YMQException_setFromCoreError(state, &result.error());
+        YMQException_setFromCoreError(state, &result->error());
         return nullptr;
     }
 
@@ -283,35 +298,27 @@ static PyObject* PyIOSocket_bind_sync(PyIOSocket* self, PyObject* args, PyObject
 
 static PyObject* PyIOSocket_connect(PyIOSocket* self, PyObject* args, PyObject* kwargs)
 {
-    PyObject* addressObj = nullptr;
-    const char* kwlist[] = {"address", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &addressObj)) {
-        PyErr_SetString(PyExc_TypeError, "expected one argument: address");
-        Py_RETURN_NONE;
-    }
-
-    if (!PyUnicode_Check(addressObj)) {
-        Py_DECREF(addressObj);
-
-        PyErr_SetString(PyExc_TypeError, "argument must be a str");
-        Py_RETURN_NONE;
-    }
-
+    const char* address   = nullptr;
     Py_ssize_t addressLen = 0;
-    const char* address   = PyUnicode_AsUTF8AndSize(addressObj, &addressLen);
+    const char* kwlist[]  = {"address", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s#", (char**)kwlist, &address, &addressLen))
+        return nullptr;
 
-    if (!address)
-        Py_RETURN_NONE;
-
-    return async_wrapper((PyObject*)self, [=](YMQState* state, PyObject* future) {
-        self->socket->connectTo(std::string(address, addressLen), [=](auto result) {
-            if (result) {
-                future_set_result(future, []() { Py_RETURN_NONE; });
-            } else {
-                future_raise_exception(
-                    future, [=] { return YMQException_createFromCoreError(state, &result.error()); });
-            }
-        });
+    return async_wrapper((PyObject*)self, [=](YMQState* state, auto future) {
+        try {
+            self->socket->connectTo(std::string(address, addressLen), [=](auto result) {
+                future_set_result(future, [=] -> std::expected<PyObject*, PyObject*> {
+                    if (result || result.error()._errorCode == Error::ErrorCode::InitialConnectFailedWithInProgress) {
+                        Py_RETURN_NONE;
+                    } else {
+                        return std::unexpected {YMQException_createFromCoreError(state, &result.error())};
+                    }
+                });
+            });
+        } catch (...) {
+            future_raise_exception(
+                future, [] { return PyErr_CreateFromString(PyExc_RuntimeError, "Failed to connect to address"); });
+        }
     });
 }
 
@@ -321,44 +328,35 @@ static PyObject* PyIOSocket_connect_sync(PyIOSocket* self, PyObject* args, PyObj
     if (!state)
         return nullptr;
 
-    PyObject* addressObj = nullptr;
-    const char* kwlist[] = {"address", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", (char**)kwlist, &addressObj)) {
-        PyErr_SetString(PyExc_TypeError, "expected one argument: address");
-        Py_RETURN_NONE;
-    }
-
-    if (!PyUnicode_Check(addressObj)) {
-        Py_DECREF(addressObj);
-
-        PyErr_SetString(PyExc_TypeError, "argument must be a str");
-        Py_RETURN_NONE;
-    }
-
+    const char* address   = nullptr;
     Py_ssize_t addressLen = 0;
-    const char* address   = PyUnicode_AsUTF8AndSize(addressObj, &addressLen);
+    const char* kwlist[]  = {"address", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s#", (char**)kwlist, &address, &addressLen))
+        return nullptr;
 
-    if (!address)
-        Py_RETURN_NONE;
+    PyThreadState* _save = PyEval_SaveThread();
 
-    std::expected<void, Error> result {};
-    std::latch waiter(1);
-
-    self->socket->connectTo(std::string(address, addressLen), [&](auto r) {
-        result = r;
-        waiter.count_down();
-    });
-
-    // block the thread until the callback is called
+    std::shared_ptr<std::expected<void, Error>> result = std::make_shared<std::expected<void, Error>>();
     try {
-        waiter.wait();
-    } catch (const std::exception& e) {
+        Waiter waiter(state->wakeupfd_rd);
+
+        self->socket->connectTo(std::string(address, addressLen), [=](auto r) mutable {
+            *result = std::move(r);
+            waiter.signal();
+        });
+
+        if (waiter.wait())
+            CHECK_SIGNALS;
+    } catch (...) {
+        PyEval_RestoreThread(_save);
         PyErr_SetString(PyExc_RuntimeError, "Failed to bind to connect synchronously");
         return nullptr;
     }
 
-    if (!result) {
-        YMQException_setFromCoreError(state, &result.error());
+    PyEval_RestoreThread(_save);
+
+    if (!result && result->error()._errorCode != Error::ErrorCode::InitialConnectFailedWithInProgress) {
+        YMQException_setFromCoreError(state, &result->error());
         return nullptr;
     }
 
@@ -377,37 +375,17 @@ static PyObject* PyIOSocket_identity_getter(PyIOSocket* self, void* closure)
 
 static PyObject* PyIOSocket_socket_type_getter(PyIOSocket* self, void* closure)
 {
-    // replace with PyType_GetModuleByDef(Py_TYPE(self), &ymq_module) in a newer Python version
-    // https://docs.python.org/3/c-api/type.html#c.PyType_GetModuleByDef
-    PyObject* pyModule = PyType_GetModule(Py_TYPE(self));
-    if (!pyModule) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module for Message type");
+    auto state = YMQStateFromSelf((PyObject*)self);
+    if (!state)
         return nullptr;
-    }
 
-    auto state = (YMQState*)PyModule_GetState(pyModule);
-    if (!state) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
+    IOSocketType socketType        = self->socket->socketType();
+    OwnedPyObject socketTypeIntObj = PyLong_FromLong((long)socketType);
+
+    if (!socketTypeIntObj)
         return nullptr;
-    }
 
-    IOSocketType socketType    = self->socket->socketType();
-    PyObject* socketTypeIntObj = PyLong_FromLong((long)socketType);
-
-    if (!socketTypeIntObj) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to convert socket type to a Python integer");
-        return nullptr;
-    }
-
-    PyObject* socketTypeObj = PyObject_CallOneArg(state->PyIOSocketEnumType, socketTypeIntObj);
-    Py_DECREF(socketTypeIntObj);
-
-    if (!socketTypeObj) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create IOSocketType object");
-        return nullptr;
-    }
-
-    return socketTypeObj;
+    return PyObject_CallOneArg(*state->PyIOSocketEnumType, *socketTypeIntObj);
 }
 }
 

--- a/scaler/io/ymq/pymod_ymq/message.h
+++ b/scaler/io/ymq/pymod_ymq/message.h
@@ -7,76 +7,75 @@
 
 // First-party
 #include "scaler/io/ymq/pymod_ymq/bytes.h"
+#include "scaler/io/ymq/pymod_ymq/utils.h"
 #include "scaler/io/ymq/pymod_ymq/ymq.h"
 
 struct PyMessage {
     PyObject_HEAD;
-    PyBytesYMQ* address;  // Address of the message
-    PyBytesYMQ* payload;  // Payload of the message
+    OwnedPyObject<PyBytesYMQ> address;  // Address of the message; can be None
+    OwnedPyObject<PyBytesYMQ> payload;  // Payload of the message
 };
 
 extern "C" {
 
 static int PyMessage_init(PyMessage* self, PyObject* args, PyObject* kwds)
 {
-    // replace with PyType_GetModuleByDef(Py_TYPE(self), &ymq_module) in a newer Python version
-    // https://docs.python.org/3/c-api/type.html#c.PyType_GetModuleByDef
-    PyObject* pyModule = PyType_GetModule(Py_TYPE(self));
-    if (!pyModule) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module for Message type");
+    auto state = YMQStateFromSelf((PyObject*)self);
+    if (!state)
         return -1;
-    }
 
-    auto state = (YMQState*)PyModule_GetState(pyModule);
-    if (!state) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
-        return -1;
-    }
-
-    PyObject *address = nullptr, *payload = nullptr;
+    PyObject* address      = nullptr;
+    PyObject* payload      = nullptr;
     const char* keywords[] = {"address", "payload", nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO", (char**)keywords, &address, &payload)) {
-        PyErr_SetString(PyExc_TypeError, "Expected two Bytes objects: address and payload");
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO", (char**)keywords, &address, &payload))
         return -1;
-    }
 
+    // address can be None, which means the message has no address
     // check if the address and payload are of type PyBytesYMQ
-    if (!PyObject_IsInstance(address, state->PyBytesYMQType)) {
-        PyObject* args = PyTuple_Pack(1, address);
-        address        = PyObject_CallObject(state->PyBytesYMQType, args);
-        Py_DECREF(args);
+    if (PyObject_IsInstance(address, *state->PyBytesYMQType)) {
+        self->address = OwnedPyObject<PyBytesYMQ>::fromBorrowed((PyBytesYMQ*)address);
+    } else if (address == Py_None) {
+        self->address = OwnedPyObject<PyBytesYMQ>::none();
+    } else {
+        OwnedPyObject args = PyTuple_Pack(1, address);
+        self->address      = (PyBytesYMQ*)PyObject_CallObject(*state->PyBytesYMQType, *args);
 
-        if (!address) {
+        if (!self->address)
+            return -1;
+    }
+
+    if (PyObject_IsInstance(payload, *state->PyBytesYMQType)) {
+        self->payload = OwnedPyObject<PyBytesYMQ>::fromBorrowed((PyBytesYMQ*)payload);
+    } else {
+        OwnedPyObject args = PyTuple_Pack(1, payload);
+        self->payload      = (PyBytesYMQ*)PyObject_CallObject(*state->PyBytesYMQType, *args);
+
+        if (!self->payload) {
             return -1;
         }
     }
-
-    if (!PyObject_IsInstance(payload, state->PyBytesYMQType)) {
-        PyObject* args = PyTuple_Pack(1, payload);
-        payload        = PyObject_CallObject(state->PyBytesYMQType, args);
-        Py_DECREF(args);
-
-        if (!payload) {
-            return -1;
-        }
-    }
-
-    self->address = (PyBytesYMQ*)address;
-    self->payload = (PyBytesYMQ*)payload;
 
     return 0;
 }
 
 static void PyMessage_dealloc(PyMessage* self)
 {
-    Py_XDECREF(self->address);
-    Py_XDECREF(self->payload);
-    Py_TYPE(self)->tp_free(self);
+    try {
+        self->address.~OwnedPyObject();
+        self->payload.~OwnedPyObject();
+    } catch (...) {
+        // set the error and continue to free the object
+        PyErr_SetString(PyExc_RuntimeError, "Failed to deallocate Message");
+    }
+
+    auto* tp = Py_TYPE(self);
+    tp->tp_free(self);
+    Py_DECREF(tp);
 }
 
 static PyObject* PyMessage_repr(PyMessage* self)
 {
-    return PyUnicode_FromFormat("<Message address=%R payload=%R>", self->address, self->payload);
+    return PyUnicode_FromFormat("<Message address=%R payload=%R>", *self->address, *self->payload);
 }
 }
 

--- a/scaler/io/ymq/pymod_ymq/utils.h
+++ b/scaler/io/ymq/pymod_ymq/utils.h
@@ -1,0 +1,176 @@
+#pragma once
+
+// Python
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+// C++
+#include <memory>
+
+// C
+#include <sys/eventfd.h>
+#include <sys/poll.h>
+
+// First-party
+#include "scaler/io/ymq/common.h"
+#include "scaler/io/ymq/pymod_ymq/ymq.h"
+
+// an owned handle to a PyObject with automatic reference counting via RAII
+template <typename T = PyObject>
+class OwnedPyObject {
+    T* _ptr;
+
+    void free()
+    {
+        if (!_ptr)
+            return;
+
+        if (!PyGILState_Check())
+            return;
+
+        Py_CLEAR(_ptr);
+    }
+
+public:
+    OwnedPyObject(): _ptr(nullptr) {}
+
+    // steals a reference
+    OwnedPyObject(T* ptr): _ptr(ptr) {}
+
+    OwnedPyObject(const OwnedPyObject& other) { this->_ptr = Py_XNewRef(other._ptr); }
+    OwnedPyObject(OwnedPyObject&& other) noexcept: _ptr(other._ptr) { other._ptr = nullptr; }
+    OwnedPyObject& operator=(const OwnedPyObject& other)
+    {
+        if (this == &other)
+            return *this;
+
+        this->free();
+        this->_ptr = Py_XNewRef(other._ptr);
+        return *this;
+    }
+    OwnedPyObject& operator=(OwnedPyObject&& other) noexcept
+    {
+        if (this == &other)
+            return *this;
+
+        this->free();
+        this->_ptr = other._ptr;
+        other._ptr = nullptr;
+        return *this;
+    }
+
+    ~OwnedPyObject() { this->free(); }
+
+    // creates a new OwnedPyObject from a borrowed reference
+    static OwnedPyObject fromBorrowed(T* ptr) { return OwnedPyObject((T*)Py_XNewRef(ptr)); }
+
+    // convenience method for creating an OwnedPyObject that holds Py_None
+    static OwnedPyObject none() { return OwnedPyObject((T*)Py_NewRef(Py_None)); }
+
+    bool is_none() const { return (PyObject*)_ptr == Py_None; }
+
+    // takes the pointer out of the OwnedPyObject
+    // without decrementing the reference count
+    // use this to transfer ownership to C code
+    T* take()
+    {
+        T* ptr     = this->_ptr;
+        this->_ptr = nullptr;
+        return ptr;
+    }
+
+    void forget() { this->_ptr = nullptr; }
+
+    // operator T*() const { return _ptr; }
+    explicit operator bool() const { return _ptr != nullptr; }
+    bool operator!() const { return _ptr == nullptr; }
+
+    T* operator->() const { return _ptr; }
+    T* operator*() const { return _ptr; }
+};
+
+class Waiter {
+    std::shared_ptr<int> _waiter;
+    int _wakeFd;
+
+    static void destroy_efd(int* fd)
+    {
+        if (!fd)
+            return;
+
+        close(*fd);
+        delete fd;
+    }
+
+public:
+    Waiter(int wakeFd): _waiter(std::shared_ptr<int>(new int, &destroy_efd)), _wakeFd(wakeFd)
+    {
+        *_waiter = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    }
+
+    Waiter(const Waiter& other): _waiter(other._waiter), _wakeFd(other._wakeFd) {}
+    Waiter(Waiter&& other) noexcept: _waiter(std::move(other._waiter)), _wakeFd(other._wakeFd)
+    {
+        other._wakeFd = -1;  // invalidate the moved-from object
+    }
+
+    Waiter& operator=(const Waiter& other)
+    {
+        if (this == &other)
+            return *this;
+
+        this->_waiter = other._waiter;
+        this->_wakeFd = other._wakeFd;
+        return *this;
+    }
+
+    Waiter& operator=(Waiter&& other) noexcept
+    {
+        if (this == &other)
+            return *this;
+
+        this->_waiter = std::move(other._waiter);
+        this->_wakeFd = other._wakeFd;
+        other._wakeFd = -1;  // invalidate the moved-from object
+        return *this;
+    }
+
+    void signal()
+    {
+        if (eventfd_write(*_waiter, 1) < 0) {
+            std::println("Failed to signal waiter: {}", std::strerror(errno));
+        }
+    }
+
+    // true -> error
+    // false -> ok
+    bool wait()
+    {
+        pollfd pfds[2] = {
+            {
+                .fd      = *_waiter,
+                .events  = POLLIN,
+                .revents = 0,
+            },
+            {
+                .fd      = _wakeFd,
+                .events  = POLLIN,
+                .revents = 0,
+            }};
+
+        for (;;) {
+            int ready = poll(pfds, 2, -1);
+            if (ready < 0) {
+                if (errno == EINTR)
+                    continue;
+                throw std::runtime_error("poll failed");
+            }
+
+            if (pfds[0].revents & POLLIN)
+                return false;  // we got a message
+
+            if (pfds[1].revents & POLLIN)
+                return true; // signal received
+        }
+    }
+};

--- a/scaler/io/ymq/pymod_ymq/ymq.cpp
+++ b/scaler/io/ymq/pymod_ymq/ymq.cpp
@@ -18,5 +18,5 @@ PyMODINIT_FUNC PyInit_ymq(void)
 {
     unrecoverableErrorFunctionHookPtr = ymqUnrecoverableError;
 
-    return PyModuleDef_Init(&ymq_module);
+    return PyModuleDef_Init(&YMQ_module);
 }

--- a/scaler/io/ymq/pymod_ymq/ymq.h
+++ b/scaler/io/ymq/pymod_ymq/ymq.h
@@ -5,7 +5,12 @@
 #include <Python.h>
 #include <structmember.h>
 
+// C
+#include <fcntl.h>
+#include <unistd.h>
+
 // C++
+#include <expected>
 #include <format>
 #include <functional>
 #include <string>
@@ -14,79 +19,129 @@
 
 // First-party
 #include "scaler/io/ymq/error.h"
+#include "scaler/io/ymq/pymod_ymq/utils.h"
 
 struct YMQState {
-    PyObject* enumModule;     // Reference to the enum module
-    PyObject* asyncioModule;  // Reference to the asyncio module
+    int wakeupfd_wr;
+    int wakeupfd_rd;
 
-    PyObject* PyIOSocketEnumType;  // Reference to the IOSocketType enum
-    PyObject* PyErrorCodeType;     // Reference to the Error enum
-    PyObject* PyBytesYMQType;      // Reference to the PyBytesYMQ type
-    PyObject* PyMessageType;       // Reference to the Message type
-    PyObject* PyIOSocketType;      // Reference to the IOSocket type
-    PyObject* PyIOContextType;     // Reference to the IOContext type
-    PyObject* PyExceptionType;     // Reference to the Exception type
-    PyObject* PyAwaitableType;     // Reference to the Awaitable type
+    OwnedPyObject<> enumModule;     // Reference to the enum module
+    OwnedPyObject<> asyncioModule;  // Reference to the asyncio module
+
+    OwnedPyObject<> PyIOSocketEnumType;          // Reference to the IOSocketType enum
+    OwnedPyObject<> PyErrorCodeType;             // Reference to the Error enum
+    OwnedPyObject<> PyBytesYMQType;              // Reference to the PyBytesYMQ type
+    OwnedPyObject<> PyMessageType;               // Reference to the Message type
+    OwnedPyObject<> PyIOSocketType;              // Reference to the IOSocket type
+    OwnedPyObject<> PyIOContextType;             // Reference to the IOContext type
+    OwnedPyObject<> PyExceptionType;             // Reference to the Exception type
+    OwnedPyObject<> PyInterruptedExceptionType;  // Reference to the YMQInterruptedException type
+    OwnedPyObject<> PyAwaitableType;             // Reference to the Awaitable type
 };
+
+#define CHECK_SIGNALS                                                                                           \
+    do {                                                                                                        \
+        PyEval_RestoreThread(_save);                                                                            \
+        if (PyErr_CheckSignals() >= 0)                                                                          \
+            PyErr_SetString(                                                                                    \
+                *state->PyInterruptedExceptionType, "A synchronous YMQ operation was interrupted by a signal"); \
+        return (PyObject*)nullptr;                                                                              \
+    } while (0);
+
+static bool future_do_(PyObject* future_, const std::function<std::expected<PyObject*, PyObject*>()>& fn)
+{
+    // this is an owned reference to the future created in `async_wrapper()`
+    OwnedPyObject future(future_);
+    OwnedPyObject loop = PyObject_CallMethod(*future, "get_loop", nullptr);
+    if (!loop)
+        return true;
+
+    // if future is already done, no need to call the method
+    OwnedPyObject result1 = PyObject_CallMethod(*future, "done", nullptr);
+    if (*result1 == Py_True)
+        return false;
+
+    const char* method_name = nullptr;
+    OwnedPyObject arg {};
+
+    if (auto result = fn()) {
+        method_name = "set_result";
+        arg         = *result;
+    } else {
+        method_name = "set_exception";
+        arg         = result.error();
+    }
+
+    OwnedPyObject method = PyObject_GetAttrString(*future, method_name);
+    if (!method)
+        return true;
+
+    OwnedPyObject obj = PyObject_GetAttrString(*loop, "call_soon_threadsafe");
+
+    // auto result = PyObject_CallMethod(loop, "call_soon_threadsafe", "OO", method, fn());
+    OwnedPyObject result2 = PyObject_CallFunctionObjArgs(*obj, *method, *arg, nullptr);
+    if (!result2)
+        return true;
+
+    return false;
+}
 
 // this function must be called from a C++ thread
 // this function will lock the GIL, call `fn()` and use its return value to set the future's result/exception
-static void future_do(PyObject* future, const std::function<PyObject*()>& fn, const char* future_method)
+static void future_do(PyObject* future, const std::function<std::expected<PyObject*, PyObject*>()>& fn)
 {
     PyGILState_STATE gstate = PyGILState_Ensure();
     // begin python critical section
 
-    {
-        PyObject* loop = PyObject_CallMethod(future, "get_loop", nullptr);
-
-        if (!loop) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to get future's loop");
-            Py_DECREF(future);
-
-            // end python critical section
-            PyGILState_Release(gstate);
-            return;
-        }
-
-        PyObject* method = PyObject_GetAttrString(future, future_method);
-
-        if (!method) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to get future's method");
-            Py_DECREF(future);
-
-            // end python critical section
-            PyGILState_Release(gstate);
-            return;
-        }
-
-        PyObject_CallMethod(loop, "call_soon_threadsafe", "OO", method, fn());
-    }
-
-    Py_DECREF(future);
+    auto error = future_do_(future, fn);
+    if (error)
+        PyErr_WriteUnraisable(nullptr);
 
     // end python critical section
     PyGILState_Release(gstate);
 }
 
-static void future_set_result(PyObject* future, std::function<PyObject*()> fn)
+static void future_set_result(PyObject* future, std::function<std::expected<PyObject*, PyObject*>()> fn)
 {
-    return future_do(future, fn, "set_result");
+    return future_do(future, fn);
 }
 
 static void future_raise_exception(PyObject* future, std::function<PyObject*()> fn)
 {
-    return future_do(future, fn, "set_exception");
+    return future_do(future, [=] { return std::unexpected {fn()}; });
 }
 
 static YMQState* YMQStateFromSelf(PyObject* self)
 {
-    // replace with PyType_GetModuleByDef(Py_TYPE(self), &ymq_module) in a newer Python version
+    // replace with PyType_GetModuleByDef(Py_TYPE(self), &YMQ_module) in a newer Python version
     // https://docs.python.org/3/c-api/type.html#c.PyType_GetModuleByDef
     PyObject* pyModule = PyType_GetModule(Py_TYPE(self));
     if (!pyModule)
         return nullptr;
 
     return (YMQState*)PyModule_GetState(pyModule);
+}
+
+PyObject* PyErr_CreateFromString(PyObject* type, const char* message)
+{
+    OwnedPyObject args = Py_BuildValue("(s)", message);
+    if (!args)
+        return nullptr;
+
+    return PyObject_CallObject(type, *args);
+}
+
+// this is a polyfill for PyErr_GetRaisedException() added in Python 3.12+
+std::expected<PyObject*, PyObject*> PyErr_GetRaisedException()
+{
+    PyObject *excType, *excValue, *excTraceback;
+    PyErr_Fetch(&excType, &excValue, &excTraceback);
+    Py_XDECREF(excType);
+    Py_XDECREF(excTraceback);
+    if (!excValue)
+        Py_RETURN_NONE;
+
+    return std::unexpected {excValue};
 }
 
 // First-Party
@@ -99,88 +154,76 @@ static YMQState* YMQStateFromSelf(PyObject* self)
 
 extern "C" {
 
-static void ymq_free(YMQState* state)
+static void YMQ_free(YMQState* state)
 {
-    Py_XDECREF(state->enumModule);
-    Py_XDECREF(state->asyncioModule);
-    Py_XDECREF(state->PyIOSocketEnumType);
-    Py_XDECREF(state->PyBytesYMQType);
-    Py_XDECREF(state->PyMessageType);
-    Py_XDECREF(state->PyIOSocketType);
-    Py_XDECREF(state->PyIOContextType);
-    Py_XDECREF(state->PyExceptionType);
-    Py_XDECREF(state->PyAwaitableType);
+    try {
+        state->enumModule.~OwnedPyObject();
+        state->asyncioModule.~OwnedPyObject();
+        state->PyIOSocketEnumType.~OwnedPyObject();
+        state->PyErrorCodeType.~OwnedPyObject();
+        state->PyBytesYMQType.~OwnedPyObject();
+        state->PyMessageType.~OwnedPyObject();
+        state->PyIOSocketType.~OwnedPyObject();
+        state->PyIOContextType.~OwnedPyObject();
+        state->PyExceptionType.~OwnedPyObject();
+        state->PyInterruptedExceptionType.~OwnedPyObject();
+        state->PyAwaitableType.~OwnedPyObject();
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to free YMQState");
+        PyErr_WriteUnraisable(nullptr);
+    }
 
-    state->asyncioModule      = nullptr;
-    state->enumModule         = nullptr;
-    state->PyIOSocketEnumType = nullptr;
-    state->PyBytesYMQType     = nullptr;
-    state->PyMessageType      = nullptr;
-    state->PyIOSocketType     = nullptr;
-    state->PyIOContextType    = nullptr;
-    state->PyExceptionType    = nullptr;
-    state->PyAwaitableType    = nullptr;
+    if (close(state->wakeupfd_wr) < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to close waitfd_wr");
+        PyErr_WriteUnraisable(nullptr);
+    }
+
+    if (close(state->wakeupfd_rd) < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to close waitfd_rd");
+        PyErr_WriteUnraisable(nullptr);
+    }
 }
 
-static int ymq_createIntEnum(
-    PyObject* pyModule, PyObject** storage, std::string enumName, std::vector<std::pair<std::string, int>> entries)
+static int YMQ_createIntEnum(
+    PyObject* pyModule,
+    OwnedPyObject<>* storage,
+    std::string enumName,
+    std::vector<std::pair<std::string, int>> entries)
 {
     // create a python dictionary to hold the entries
-    auto enumDict = PyDict_New();
-    if (!enumDict) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create enum dictionary");
+    OwnedPyObject enumDict = PyDict_New();
+    if (!enumDict)
         return -1;
-    }
 
     // add each entry to the dictionary
     for (const auto& entry: entries) {
-        PyObject* value = PyLong_FromLong(entry.second);
-        if (!value) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to create enum value");
-            Py_DECREF(enumDict);
+        OwnedPyObject value = PyLong_FromLong(entry.second);
+        if (!value)
             return -1;
-        }
 
-        if (PyDict_SetItemString(enumDict, entry.first.c_str(), value) < 0) {
-            Py_DECREF(value);
-            Py_DECREF(enumDict);
-            PyErr_SetString(PyExc_RuntimeError, "Failed to set item in enum dictionary");
+        auto status = PyDict_SetItemString(*enumDict, entry.first.c_str(), *value);
+        if (status < 0)
             return -1;
-        }
-        Py_DECREF(value);
     }
 
     auto state = (YMQState*)PyModule_GetState(pyModule);
 
-    if (!state) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
-        Py_DECREF(enumDict);
+    if (!state)
         return -1;
-    }
 
     // create our class by calling enum.IntEnum(enumName, enumDict)
-    auto enumClass = PyObject_CallMethod(state->enumModule, "IntEnum", "sO", enumName.c_str(), enumDict);
-    Py_DECREF(enumDict);
-
-    if (!enumClass) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create IntEnum class");
+    OwnedPyObject enumClass = PyObject_CallMethod(*state->enumModule, "IntEnum", "sO", enumName.c_str(), *enumDict);
+    if (!enumClass)
         return -1;
-    }
 
     *storage = enumClass;
 
     // add the class to the module
     // this increments the reference count of enumClass
-    if (PyModule_AddObjectRef(pyModule, enumName.c_str(), enumClass) < 0) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to add IntEnum class to module");
-        Py_DECREF(enumClass);
-        return -1;
-    }
-
-    return 0;
+    return PyModule_AddObjectRef(pyModule, enumName.c_str(), *enumClass);
 }
 
-static int ymq_createIOSocketTypeEnum(PyObject* pyModule, YMQState* state)
+static int YMQ_createIOSocketTypeEnum(PyObject* pyModule, YMQState* state)
 {
     std::vector<std::pair<std::string, int>> ioSocketTypes = {
         {"Uninit", (int)IOSocketType::Uninit},
@@ -190,35 +233,24 @@ static int ymq_createIOSocketTypeEnum(PyObject* pyModule, YMQState* state)
         {"Multicast", (int)IOSocketType::Multicast},
     };
 
-    if (ymq_createIntEnum(pyModule, &state->PyIOSocketEnumType, "IOSocketType", ioSocketTypes) < 0) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create IOSocketType enum");
-        return -1;
-    }
-
-    return 0;
+    return YMQ_createIntEnum(pyModule, &state->PyIOSocketEnumType, "IOSocketType", ioSocketTypes);
 }
 
 static PyObject* YMQErrorCode_explanation(PyObject* self, PyObject* Py_UNUSED(args))
 {
-    auto pyValue = PyObject_GetAttrString(self, "value");
-    if (!pyValue) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get value attribute");
+    OwnedPyObject pyValue = PyObject_GetAttrString(self, "value");
+    if (!pyValue)
         return nullptr;
-    }
 
-    if (!PyLong_Check(pyValue)) {
+    if (!PyLong_Check(*pyValue)) {
         PyErr_SetString(PyExc_TypeError, "Expected an integer value");
-        Py_DECREF(pyValue);
         return nullptr;
     }
 
-    long value = PyLong_AsLong(pyValue);
-    Py_DECREF(pyValue);
+    long value = PyLong_AsLong(*pyValue);
 
-    if (value == -1 && PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to convert value to long");
+    if (value == -1 && PyErr_Occurred())
         return nullptr;
-    }
 
     std::string_view explanation = Error::convertErrorToExplanation(static_cast<Error::ErrorCode>(value));
     return PyUnicode_FromString(std::string(explanation).c_str());
@@ -226,19 +258,29 @@ static PyObject* YMQErrorCode_explanation(PyObject* self, PyObject* Py_UNUSED(ar
 
 // IDEA: CREATE AN INT ENUM AND ATTACH METHOD AFTERWARDS
 // OR: CREATE A NON-INT ENUM AND USE A TUPLE FOR THE VALUES
-static int ymq_createErrorCodeEnum(PyObject* pyModule, YMQState* state)
+static int YMQ_createErrorCodeEnum(PyObject* pyModule, YMQState* state)
 {
     std::vector<std::pair<std::string, int>> errorCodeValues = {
         {"Uninit", (int)Error::ErrorCode::Uninit},
         {"InvalidPortFormat", (int)Error::ErrorCode::InvalidPortFormat},
         {"InvalidAddressFormat", (int)Error::ErrorCode::InvalidAddressFormat},
         {"ConfigurationError", (int)Error::ErrorCode::ConfigurationError},
+        {"SignalNotSupported", (int)Error::ErrorCode::SignalNotSupported},
+        {"CoreBug", (int)Error::ErrorCode::CoreBug},
+        {"RepetetiveIOSocketIdentity", (int)Error::ErrorCode::RepetetiveIOSocketIdentity},
+        {"RedundantIOSocketRefCount", (int)Error::ErrorCode::RedundantIOSocketRefCount},
+        {"MultipleConnectToNotSupported", (int)Error::ErrorCode::MultipleConnectToNotSupported},
+        {"MultipleBindToNotSupported", (int)Error::ErrorCode::MultipleBindToNotSupported},
+        {"InitialConnectFailedWithInProgress", (int)Error::ErrorCode::InitialConnectFailedWithInProgress},
+        {"SendMessageRequestCouldNotComplete", (int)Error::ErrorCode::SendMessageRequestCouldNotComplete},
+        {"SetSockOptNonFatalFailure", (int)Error::ErrorCode::SetSockOptNonFatalFailure},
+        {"IPv6NotSupported", (int)Error::ErrorCode::IPv6NotSupported},
+        {"RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery",
+         (int)Error::ErrorCode::RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery},
     };
 
-    if (ymq_createIntEnum(pyModule, &state->PyErrorCodeType, "ErrorCode", errorCodeValues) < 0) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create Error enum");
+    if (YMQ_createIntEnum(pyModule, &state->PyErrorCodeType, "ErrorCode", errorCodeValues) < 0)
         return -1;
-    }
 
     static PyMethodDef YMQErrorCode_explanation_def = {
         "explanation",
@@ -246,47 +288,51 @@ static int ymq_createErrorCodeEnum(PyObject* pyModule, YMQState* state)
         METH_NOARGS,
         PyDoc_STR("Returns an explanation of a YMQ error code")};
 
-    auto iter = PyObject_GetIter(state->PyErrorCodeType);
-    if (!iter) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get iterator for Error enum");
+    OwnedPyObject iter = PyObject_GetIter(*state->PyErrorCodeType);
+    if (!iter)
         return -1;
-    }
 
     // is this the best way to add a method to each enum item?
     // in python you can just write: MyEnum.new_method = ...
     // for some reason this does not seem to work with the c api
     // docs and examples are unfortunately scarce for this
     // for now this will work just fine
-    PyObject* item = nullptr;
-    while ((item = PyIter_Next(iter)) != nullptr) {
-        auto fn = PyCMethod_New(&YMQErrorCode_explanation_def, item, pyModule, nullptr);
-        if (!fn) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to create description method");
+    OwnedPyObject item {};
+    while (item = PyIter_Next(*iter)) {
+        OwnedPyObject fn = PyCMethod_New(&YMQErrorCode_explanation_def, *item, pyModule, nullptr);
+        if (!fn)
             return -1;
-        }
 
-        if (PyObject_SetAttrString(item, "explanation", fn) < 0) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to set explanation method on Error enum item");
-            Py_DECREF(item);
-            Py_DECREF(fn);
-            Py_DECREF(iter);
+        auto status = PyObject_SetAttrString(*item, "explanation", *fn);
+        if (status < 0)
             return -1;
-        }
-        Py_DECREF(item);
-        Py_DECREF(fn);
     }
 
-    Py_DECREF(iter);
     return 0;
 }
 }
 
+static int YMQ_createInterruptedException(PyObject* pyModule, OwnedPyObject<>* storage)
+{
+    *storage = PyErr_NewExceptionWithDoc(
+        "ymq.YMQInterruptedException",
+        "Raised when a synchronous method is interrupted by a signal",
+        PyExc_Exception,
+        nullptr);
+
+    if (!*storage)
+        return -1;
+    if (PyModule_AddObjectRef(pyModule, "YMQInterruptedException", **storage) < 0)
+        return -1;
+    return 0;
+}
+
 // internal convenience function to create a type and add it to the module
-static int ymq_createType(
+static int YMQ_createType(
     // the module object
     PyObject* pyModule,
     // storage for the generated type object
-    PyObject** storage,
+    OwnedPyObject<>* storage,
     // the type's spec
     PyType_Spec* spec,
     // the name of the type, can be omitted if `add` is false
@@ -299,85 +345,97 @@ static int ymq_createType(
     assert(storage != nullptr);
 
     *storage = PyType_FromModuleAndSpec(pyModule, spec, bases);
-
-    if (!*storage) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to create type from spec");
+    if (!*storage)
         return -1;
-    }
 
     if (add)
-        if (PyModule_AddObjectRef(pyModule, name, *storage) < 0) {
-            PyErr_SetString(PyExc_RuntimeError, "Failed to add type to module");
-            Py_DECREF(*storage);
+        if (PyModule_AddObjectRef(pyModule, name, **storage) < 0)
             return -1;
-        }
 
     return 0;
 }
 
-static int ymq_exec(PyObject* pyModule)
+static int YMQ_setupWakeupFd(YMQState* state)
+{
+    int pipefd[2];
+    if (pipe2(pipefd, O_NONBLOCK | O_CLOEXEC) < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to create pipe for wakeup fd");
+        return -1;
+    }
+
+    state->wakeupfd_rd = pipefd[0];
+    state->wakeupfd_wr = pipefd[1];
+
+    OwnedPyObject signalModule = PyImport_ImportModule("signal");
+    if (!signalModule)
+        return -1;
+
+    OwnedPyObject result = PyObject_CallMethod(*signalModule, "set_wakeup_fd", "i", state->wakeupfd_wr);
+    if (!result)
+        return -1;
+    return 0;
+}
+
+static int YMQ_exec(PyObject* pyModule)
 {
     auto state = (YMQState*)PyModule_GetState(pyModule);
-
-    if (!state) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to get module state");
+    if (!state)
         return -1;
-    }
+
+    if (YMQ_setupWakeupFd(state) < 0)
+        return -1;
 
     state->enumModule = PyImport_ImportModule("enum");
-
-    if (!state->enumModule) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to import enum module");
+    if (!state->enumModule)
         return -1;
-    }
 
     state->asyncioModule = PyImport_ImportModule("asyncio");
-
-    if (!state->asyncioModule) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to import asyncio module");
-        return -1;
-    }
-
-    if (ymq_createIOSocketTypeEnum(pyModule, state) < 0)
+    if (!state->asyncioModule)
         return -1;
 
-    if (ymq_createErrorCodeEnum(pyModule, state) < 0)
+    if (YMQ_createIOSocketTypeEnum(pyModule, state) < 0)
         return -1;
 
-    if (ymq_createType(pyModule, &state->PyBytesYMQType, &PyBytesYMQ_spec, "Bytes") < 0)
+    if (YMQ_createErrorCodeEnum(pyModule, state) < 0)
         return -1;
 
-    if (ymq_createType(pyModule, &state->PyMessageType, &PyMessage_spec, "Message") < 0)
+    if (YMQ_createType(pyModule, &state->PyBytesYMQType, &PyBytesYMQ_spec, "Bytes") < 0)
         return -1;
 
-    if (ymq_createType(pyModule, &state->PyIOSocketType, &PyIOSocket_spec, "IOSocket") < 0)
+    if (YMQ_createType(pyModule, &state->PyMessageType, &PyMessage_spec, "Message") < 0)
         return -1;
 
-    if (ymq_createType(pyModule, &state->PyIOContextType, &PyIOContext_spec, "IOContext") < 0)
+    if (YMQ_createType(pyModule, &state->PyIOSocketType, &PyIOSocket_spec, "IOSocket") < 0)
         return -1;
 
-    if (ymq_createType(pyModule, &state->PyExceptionType, &YMQException_spec, "YMQException", true, PyExc_Exception) <
+    if (YMQ_createType(pyModule, &state->PyIOContextType, &PyIOContext_spec, "IOContext") < 0)
+        return -1;
+
+    if (YMQ_createType(pyModule, &state->PyExceptionType, &YMQException_spec, "YMQException", true, PyExc_Exception) <
         0)
         return -1;
 
-    if (ymq_createType(pyModule, &state->PyAwaitableType, &Awaitable_spec, "Awaitable", false) < 0)
+    if (YMQ_createInterruptedException(pyModule, &state->PyInterruptedExceptionType) < 0)
+        return -1;
+
+    if (YMQ_createType(pyModule, &state->PyAwaitableType, &Awaitable_spec, "Awaitable", false) < 0)
         return -1;
 
     return 0;
 }
 
-static PyModuleDef_Slot ymq_slots[] = {
-    {Py_mod_exec, (void*)ymq_exec},
+static PyModuleDef_Slot YMQ_slots[] = {
+    {Py_mod_exec, (void*)YMQ_exec},
     {0, nullptr},
 };
 
-static PyModuleDef ymq_module = {
+static PyModuleDef YMQ_module = {
     .m_base  = PyModuleDef_HEAD_INIT,
     .m_name  = "ymq",
     .m_doc   = PyDoc_STR("YMQ Python bindings"),
     .m_size  = sizeof(YMQState),
-    .m_slots = ymq_slots,
-    .m_free  = (freefunc)ymq_free,
+    .m_slots = YMQ_slots,
+    .m_free  = (freefunc)YMQ_free,
 };
 
 PyMODINIT_FUNC PyInit_ymq(void);

--- a/scaler/io/ymq/ymq.pyi
+++ b/scaler/io/ymq/ymq.pyi
@@ -15,11 +15,11 @@ class Bytes(Buffer):
     data: bytes
     len: int
 
-    def __init__(self, data: SupportsBytes) -> None: ...
+    def __init__(self, data: SupportsBytes | bytes) -> None: ...
     def __repr__(self) -> str: ...
 
 class Message:
-    address: Bytes
+    address: Bytes | None
     payload: Bytes
 
     def __init__(
@@ -42,6 +42,10 @@ class IOContext:
     def __repr__(self) -> str: ...
     def createIOSocket(self, /, identity: str, socket_type: IOSocketType) -> Awaitable[IOSocket]:
         """Create an io socket with an identity and socket type"""
+
+    def createIOSocket_sync(self, /, identity: str, socket_type: IOSocketType) -> IOSocket:
+        """Create an io socket with an identity and socket type synchronously"""
+
 
 class IOSocket:
     identity: str
@@ -77,6 +81,17 @@ class ErrorCode(IntEnum):
     InvalidPortFormat = 1
     InvalidAddressFormat = 2
     ConfigurationError = 3
+    SignalNotSupported = 4
+    CoreBug = 5
+    RepetetiveIOSocketIdentity = 6
+    RedundantIOSocketRefCount = 7
+    MultipleConnectToNotSupported = 8
+    MultipleBindToNotSupported = 9
+    InitialConnectFailedWithInProgress = 10
+    SendMessageRequestCouldNotComplete = 11
+    SetSockOptNonFatalFailure = 12
+    IPv6NotSupported = 13
+    RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery = 14
 
     def explanation(self) -> str: ...
 
@@ -87,3 +102,6 @@ class YMQException(Exception):
     def __init__(self, code: ErrorCode, message: str) -> None: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
+
+class YMQInterruptedException(YMQException):
+    def __init__(self) -> None: ...


### PR DESCRIPTION
This pull request consolidates several major improvements to the YMQ Python module made in the process of integrating with Scaler and writing unit tests. Major changes:

- Sync methods have been implemented using eventfds to communicate across threads and react to Python signals
  - Signal handling is extremely important for Scaler, and sync methods need to react when a signal (e.g. sigint or sigterm) arrives. We use Python's wakeup fd mechanism to receive notifications over a pipe and invoke Python's signal handlers, and subsequently raising `YMQInterruptedException` as necessary
- `OwnedPyObject<T>`: This is a RAII wrapper around `PyObject*` that decrements the reference count on destruction, and increments on construction in the case of `OwnedPyObject::from_borrowed()`. Most places use this now, save for a few where the reference counting needs to be explicit for clarity. Thank you to @rafa-be for this suggestion
- `EINTR` from `epoll_wait()` is not being considered an error for now, @gxuu 
- Fixes for YMQ's Python `Bytes`
  - `.data` returns `None` if the bytes is empty
  - The constructor now takes anything that implements the buffer protocol, as per Python's recommentation
    - Note: Zero-copy initialization remains to be investigated in the future
- `Bytes(nullptr, _)` no long creates a zero-length allocation, it's now correctly a nullptr internally, meaning that `is_empty()` works as intended
- Heap type'd object now decref their reference to the type on dealloc, as recommended by the spec
- Most methods need access to the module state for one reason or another, a new function, `YMQStateFromSelf()` to streamline places this is needed