### PR TITLE
Investigate why scaler halts when using YMQ Python Interface

### DIFF
--- a/scaler/io/sync_object_storage_connector.py
+++ b/scaler/io/sync_object_storage_connector.py
@@ -9,6 +9,7 @@ from threading import Lock
 from typing import Iterable, List, Optional, Tuple
 
 from scaler.io.mixins import SyncObjectStorageConnector
+from scaler.io.ymq import ymq
 from scaler.protocol.capnp._python import _object_storage  # noqa
 from scaler.protocol.python.object_storage import ObjectRequestHeader, ObjectResponseHeader, to_capnp_object_id
 from scaler.utility.exceptions import ObjectStorageException
@@ -25,26 +26,23 @@ class PySyncObjectStorageConnector(SyncObjectStorageConnector):
         self._host = host
         self._port = port
 
-        self._identity: bytes = f"{os.getpid()}|{socket.gethostname().split('.')[0]}|{uuid.uuid4()}".encode()
-
-        self._socket: Optional[socket.socket] = socket.create_connection((self._host, self._port))
-        self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self._identity: str = f"{os.getpid()}|{socket.gethostname().split('.')[0]}|{uuid.uuid4()}"
 
         self._next_request_id = 0
 
         self._socket_lock = Lock()
 
-        self.__send_buffers([struct.pack("<Q", len(self._identity)), self._identity])
-        self.__read_framed_message()  # receive server identity
+        self._io_context = ymq.IOContext()
+        self._io_socket = self._io_context.createIOSocket_sync(self._identity, ymq.IOSocketType.Connector)
+        self._io_socket.connect_sync(self.address)
 
     def __del__(self):
         self.destroy()
 
     def destroy(self):
         with self._socket_lock:
-            if self._socket is not None:
-                self._socket.close()
-                self._socket = None
+            if self._io_socket is not None:
+                self._io_socket = None
 
     @property
     def address(self) -> str:
@@ -116,7 +114,7 @@ class PySyncObjectStorageConnector(SyncObjectStorageConnector):
         self.__ensure_empty_payload(response_payload)
 
     def __ensure_is_connected(self):
-        if self._socket is None:
+        if self._io_socket is None:
             raise ObjectStorageException("connector is closed.")
 
     def __ensure_response_type(
@@ -137,7 +135,7 @@ class PySyncObjectStorageConnector(SyncObjectStorageConnector):
         payload: Optional[bytes] = None,
     ):
         self.__ensure_is_connected()
-        assert self._socket is not None
+        assert self._io_socket is not None
 
         request_id = self._next_request_id
         self._next_request_id += 1
@@ -147,56 +145,13 @@ class PySyncObjectStorageConnector(SyncObjectStorageConnector):
         header_bytes = header.get_message().to_bytes()
 
         if payload is not None:
-            self.__send_buffers([struct.pack("<Q", len(header_bytes)),
-                                 header_bytes,
-                                 struct.pack("<Q", len(payload)),
-                                 payload])
+            self._io_socket.send_sync(ymq.Message(address=b"", payload=header_bytes))
+            self._io_socket.send_sync(ymq.Message(address=b"", payload=payload))
         else:
-            self.__send_buffers([struct.pack("<Q", len(header_bytes)), header_bytes])
-
-    def __send_buffers(self, buffers: List[bytes]) -> None:
-        if len(buffers) < 1:
-            return
-
-        total_size = sum(len(buffer) for buffer in buffers)
-
-        # If the message is small enough, first try to send it at once with sendmsg(). This would ensure the message can
-        # be transmitted within a single TCP segment.
-        if total_size < MAX_CHUNK_SIZE:
-            sent = self._socket.sendmsg(buffers)
-
-            if sent <= 0:
-                self.__raise_connection_failure()
-
-            remaining_buffers = collections.deque(buffers)
-            while sent > len(remaining_buffers[0]):
-                removed_buffer = remaining_buffers.popleft()
-                sent -= len(removed_buffer)
-
-            if sent > 0:
-                # Truncate the first partially sent buffer
-                remaining_buffers[0] = memoryview(remaining_buffers[0])[sent:]
-
-            buffers = list(remaining_buffers)
-
-        # Send the remaining buffers sequentially
-        for buffer in buffers:
-            self.__send_buffer(buffer)
-
-    def __send_buffer(self, buffer: bytes) -> None:
-        buffer_view = memoryview(buffer)
-
-        total_sent = 0
-        while total_sent < len(buffer):
-            sent = self._socket.send(buffer_view[total_sent : MAX_CHUNK_SIZE + total_sent])
-
-            if sent <= 0:
-                self.__raise_connection_failure()
-
-            total_sent += sent
+            self._io_socket.send_sync(ymq.Message(address=b"", payload=header_bytes))
 
     def __receive_response(self) -> Tuple[ObjectResponseHeader, bytearray]:
-        assert self._socket is not None
+        assert self._io_socket is not None
 
         header = self.__read_response_header()
         payload = self.__read_response_payload(header)
@@ -204,7 +159,7 @@ class PySyncObjectStorageConnector(SyncObjectStorageConnector):
         return header, payload
 
     def __read_response_header(self) -> ObjectResponseHeader:
-        assert self._socket is not None
+        assert self._io_socket is not None
 
         header_bytearray = self.__read_framed_message()
 
@@ -224,25 +179,11 @@ class PySyncObjectStorageConnector(SyncObjectStorageConnector):
         else:
             return bytearray()
 
-    def __read_exactly(self, length: int) -> bytearray:
-        buffer = bytearray(length)
-
-        total_received = 0
-        while total_received < length:
-            chunk_size = min(MAX_CHUNK_SIZE, length - total_received)
-            received = self._socket.recv_into(memoryview(buffer)[total_received:], chunk_size)
-
-            if received <= 0:
-                self.__raise_connection_failure()
-
-            total_received += received
-
-        return buffer
-
     def __read_framed_message(self) -> bytearray:
-        length_bytes = self.__read_exactly(8)
-        (payload_length,) = struct.unpack("<Q", length_bytes)
-        return self.__read_exactly(payload_length) if payload_length > 0 else bytearray()
+        try:
+            bytearray(self._io_socket.recv_sync().payload.data)
+        except ymq.YMQInterruptedException:
+            return bytearray()
 
     @staticmethod
     def __raise_connection_failure():


### PR DESCRIPTION
# THIS PR IS NOT MEANT TO BE MERGED. READY TO REVIEW.
The PR should have been just an _issue_, but it involves code change and it is better to be viewed with a diff, so that everybody knows what's going on. Therefore, it's made as a PR.

## CONTEXT & ENVIRONMENT
#224 (now merged) makes OSS use `ymq` (before, it was using `asio`). The migration was half complete. Meaning that **the clients of OSS is still using plain socket**, mimicking the behaviour of `ymq` message passing protocol. The reason of not using `ymq` for the client side was due to the instabilities possibly introduced by _Python Interface For `ymq`_.  There are no evidence to support this claim. The unit tests passed when the client side of OSS is mimicking the protocol of `ymq`, and the unit test failed once the client side of OSS use YMQ. You can reproduce this by `cherry-pick`ing the first commit in this PR and run unit test through `python -m unittest discover -v tests`.

## CURRENT SETUP
For code in the `main` branch, the OSS server is using `ymq`, and the clients are still using plain sockets. For code in this branch, the OSS server is using `ymq`, and some clients (aka. clients that use `PySyncObjectStorageConnector`) is using `ymq`, wrapped with a Python interface authored by @magniloquency.

## SYMPTOMS:
When running unit tests, the program seems to halt _randomly_. That is, it is *NOT DETERMINISTIC*, and doesn't always happen on any of the test cases. Notably, it halts more frequently on complex cases like:
- ERROR: test_multiple_recursive_task (test_nested_task.TestNestedTask.test_multiple_recursive_task)
- ERROR: test_graph_error (test_graph.TestGraph.test_graph_error)
- ERROR: test_nested_task_arg_client (test_nested_task.TestNestedTask.test_nested_task_arg_client)
- ERROR: test_multiple_recursive_task (test_nested_task.TestNestedTask.test_multiple_recursive_task)

The logs when halt are different. For example, sometimes, there are no obvious errors printed in the log. Perhaps, it was swallowed by some `except` block:
```
test_capabilities (test_client.TestClient.test_capabilities) ... [INFO]2025-09-24 14:56:11+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:11+0800: TestClient:test_capabilities ==============================================
/usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=185721) is multi-threaded, use of fork() may lead to deadlocks in the child.
  self.pid = os.fork()
[INFO]2025-09-24 14:56:11+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:11+0800: ObjectStorageServer: start and listen to tcp://127.0.0.1:36235
[INFO]2025-09-24 14:56:11+0800: ObjectStorageServer: started
[INFO]2025-09-24 14:56:11+0800: SchedulerClusterCombo: started
[INFO]2025-09-24 14:56:11+0800: SchedulerClusterCombo: shutdown
[INFO]2025-09-24 14:56:11+0800: Cluster: received signal, shutting down
[INFO]2025-09-24 14:56:11+0800: ScalerClient: connect to scheduler at tcp://127.0.0.1:35109
[INFO]2025-09-24 14:56:11+0800: Cluster: shutting down WorkerID(185725|Worker|turing_0|6f734886636a466d9304ba0c7b97c998)
[INFO]2025-09-24 14:56:11+0800: VanillaClientController: exited
Exception ignored in: <function _WeakValueDictionary.__init__.<locals>.KeyedRef.remove at 0x7f09359d0b80>
Traceback (most recent call last):
[INFO]2025-09-24 14:56:11+0800: VanillaInformationController: exited
  File "<frozen importlib._bootstrap>", line 91, in remove
KeyboardInterrupt:
[INFO]2025-09-24 14:56:11+0800: ZMQAsyncBinder: exited
[INFO]2025-09-24 14:56:11+0800: PyAsyncObjectStorageConnector: exited
[INFO]2025-09-24 14:56:11+0800: VanillaGraphTaskController: exited
[INFO]2025-09-24 14:56:11+0800: VanillaBalanceController: exited
[INFO]2025-09-24 14:56:11+0800: VanillaObjectController: exited
[INFO]2025-09-24 14:56:11+0800: VanillaWorkerController: exited
[INFO]2025-09-24 14:56:11+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:11+0800: use event loop: builtin
[INFO]2025-09-24 14:56:11+0800: WorkerID(185725|Worker|turing_0|6f734886636a466d9304ba0c7b97c998): start Processor[185743]
[INFO]2025-09-24 14:56:11+0800: ZMQAsyncConnector: started
[INFO]2025-09-24 14:56:11+0800: PyAsyncObjectStorageConnector: started
[INFO]2025-09-24 14:56:11+0800: ZMQAsyncBinder: started
[INFO]2025-09-24 14:56:11+0800: VanillaHeartbeatManager: started
[INFO]2025-09-24 14:56:11+0800: VanillaTimeoutManager: started
[INFO]2025-09-24 14:56:11+0800: VanillaTaskManager: started
[INFO]2025-09-24 14:56:11+0800: VanillaProfilingManager: started
[INFO]2025-09-24 14:56:11+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:11+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:11+0800: use event loop: builtin
[INFO]2025-09-24 14:56:11+0800: Cluster: starting 3 workers, heartbeat_interval_seconds=2, task_timeout_seconds=0
[INFO]2025-09-24 14:56:11+0800: ConfigController: event_loop = builtin
[INFO]2025-09-24 14:56:11+0800: ConfigController: address = tcp://127.0.0.1:35109
[INFO]2025-09-24 14:56:11+0800: ConfigController: storage_address = ObjectStorageConfig(host='127.0.0.1', port=36235, identity='ObjectStorageServer')
[INFO]2025-09-24 14:56:11+0800: ConfigController: monitor_address = None
[INFO]2025-09-24 14:56:11+0800: ConfigController: adapter_webhook_url = None
[INFO]2025-09-24 14:56:11+0800: ConfigController: io_threads = 1
[INFO]2025-09-24 14:56:11+0800: ConfigController: max_number_of_tasks_waiting = -1
[INFO]2025-09-24 14:56:11+0800: ConfigController: client_timeout_seconds = 60
[INFO]2025-09-24 14:56:11+0800: ConfigController: worker_timeout_seconds = 60
[INFO]2025-09-24 14:56:11+0800: ConfigController: object_retention_seconds = 60
[INFO]2025-09-24 14:56:11+0800: ConfigController: load_balance_seconds = 1
[INFO]2025-09-24 14:56:11+0800: ConfigController: load_balance_trigger_times = 2
[INFO]2025-09-24 14:56:11+0800: ConfigController: protected = True
[INFO]2025-09-24 14:56:11+0800: ConfigController: allocate_policy = AllocatePolicy.even
[INFO]2025-09-24 14:56:11+0800: ConfigController: object_storage_address = tcp://127.0.0.1:36235
[INFO]2025-09-24 14:56:11+0800: ConfigController: updated `monitor_address` from `None` to `tcp://127.0.0.1:35111`
[INFO]2025-09-24 14:56:12+0800: Scheduler: listen to scheduler address tcp://127.0.0.1:35109
[INFO]2025-09-24 14:56:12+0800: Scheduler: connect to object storage server tcp://127.0.0.1:36235
[INFO]2025-09-24 14:56:12+0800: Scheduler: listen to scheduler monitor address tcp://127.0.0.1:35111
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncBinder: started
[INFO]2025-09-24 14:56:12+0800: WorkerID(185736|Worker|turing_0|87276d42997b41158938ae73f11f0cea) started
[INFO]2025-09-24 14:56:12+0800: PyAsyncObjectStorageConnector: started
[INFO]2025-09-24 14:56:12+0800: VanillaGraphTaskController: started
[INFO]2025-09-24 14:56:12+0800: VanillaBalanceController: started
[INFO]2025-09-24 14:56:12+0800: VanillaClientController: started
[INFO]2025-09-24 14:56:12+0800: WorkerID(185736|Worker|turing_1|14cf5b2e6d6344f58eeb162898425562) started
[INFO]2025-09-24 14:56:12+0800: VanillaObjectController: started
[INFO]2025-09-24 14:56:12+0800: WorkerID(185736|Worker|turing_2|ff7fa0221b20445cba509be0ed3bcd2d) started
[INFO]2025-09-24 14:56:12+0800: VanillaWorkerController: started
[INFO]2025-09-24 14:56:12+0800: VanillaInformationController: started
[INFO]2025-09-24 14:56:12+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:12+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:12+0800: use event loop: builtin
[INFO]2025-09-24 14:56:12+0800: WorkerID(185736|Worker|turing_2|ff7fa0221b20445cba509be0ed3bcd2d): start Processor[185756]
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncConnector: started
[INFO]2025-09-24 14:56:12+0800: PyAsyncObjectStorageConnector: started
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncBinder: started
[INFO]2025-09-24 14:56:12+0800: VanillaHeartbeatManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaTimeoutManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaTaskManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaProfilingManager: started
[INFO]2025-09-24 14:56:12+0800: worker WorkerID(185736|Worker|turing_2|ff7fa0221b20445cba509be0ed3bcd2d) connected
[INFO]2025-09-24 14:56:12+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:12+0800: use event loop: builtin
[INFO]2025-09-24 14:56:12+0800: WorkerID(185736|Worker|turing_0|87276d42997b41158938ae73f11f0cea): start Processor[185759]
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncConnector: started
[INFO]2025-09-24 14:56:12+0800: PyAsyncObjectStorageConnector: started
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncBinder: started
[INFO]2025-09-24 14:56:12+0800: VanillaHeartbeatManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaTimeoutManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaTaskManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaProfilingManager: started
[INFO]2025-09-24 14:56:12+0800: worker WorkerID(185736|Worker|turing_0|87276d42997b41158938ae73f11f0cea) connected
[INFO]2025-09-24 14:56:12+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:12+0800: use event loop: builtin
[INFO]2025-09-24 14:56:12+0800: WorkerID(185736|Worker|turing_1|14cf5b2e6d6344f58eeb162898425562): start Processor[185762]
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncConnector: started
[INFO]2025-09-24 14:56:12+0800: PyAsyncObjectStorageConnector: started
[INFO]2025-09-24 14:56:12+0800: ZMQAsyncBinder: started
[INFO]2025-09-24 14:56:12+0800: VanillaHeartbeatManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaTimeoutManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaTaskManager: started
[INFO]2025-09-24 14:56:12+0800: VanillaProfilingManager: started
[INFO]2025-09-24 14:56:12+0800: worker WorkerID(185736|Worker|turing_1|14cf5b2e6d6344f58eeb162898425562) connected
[INFO]2025-09-24 14:56:12+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:13+0800: logging to ('/dev/stdout',)
[INFO]2025-09-24 14:56:13+0800: logging to ('/dev/stdout',)
[EROR]2025-09-24 14:57:13+0800: ClientAgent: client timeout when connecting to tcp://127.0.0.1:56297
[INFO]2025-09-24 14:57:13+0800: ZMQAsyncConnector: exited
[INFO]2025-09-24 14:57:13+0800: ZMQAsyncConnector: exited

[INFO]2025-09-24 15:01:12+0800: WorkerID(185725|Worker|turing_0|6f734886636a466d9304ba0c7b97c998): timeout when connect to scheduler, quitting
[INFO]2025-09-24 15:01:12+0800: WorkerID(185725|Worker|turing_0|6f734886636a466d9304ba0c7b97c998): stop Processor[185743], reason: quit
[INFO]2025-09-24 15:01:12+0800: WorkerID(185725|Worker|turing_0|6f734886636a466d9304ba0c7b97c998): quit
[INFO]2025-09-24 15:01:12+0800: ZMQAsyncConnector: exited
[INFO]2025-09-24 15:01:12+0800: ZMQAsyncBinder: exited
[INFO]2025-09-24 15:01:12+0800: Cluster: shutdown


```

It is also possible that the Python interface throws exception `ymq.YMQInterruptedException`. Most of the time when this exception is thrown, the block happens on `_get_result_object`, which typically gets called when some tasks is cancelled due to exception during the execution of that task.

```
[INFO]2025-09-23 05:22:44+0800: logging to ('/dev/stdout',)
[INFO]2025-09-23 05:22:44+0800: ZMQAsyncConnector: exited
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/home/turing/projects/scaler/scaler/io/sync_object_storage_connector.py", line 157, in __send_request
    self._io_socket.send_sync(ymq.Message(address=b"", payload=header_bytes))
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ymq.YMQInterruptedException: A synchronous YMQ operation was interrupted by a signal

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/home/turing/projects/scaler/scaler/client/agent/client_agent.py", line 119, in run
    self.__run_loop()
    ~~~~~~~~~~~~~~~^^
  File "/home/turing/projects/scaler/scaler/client/agent/client_agent.py", line 114, in __run_loop
    self._loop.run_until_complete(self._task)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/home/turing/projects/scaler/scaler/client/agent/client_agent.py", line 210, in __get_loops
    raise exception
  File "/home/turing/projects/scaler/scaler/client/agent/client_agent.py", line 183, in __get_loops
    await asyncio.gather(*loops)
  File "/home/turing/projects/scaler/scaler/utility/event_loop.py", line 49, in loop
    await routine()
  File "/home/turing/projects/scaler/scaler/io/async_connector.py", line 77, in routine
    await self._callback(message)
  File "/home/turing/projects/scaler/scaler/client/agent/client_agent.py", line 163, in __on_receive_from_scheduler
    await self._task_manager.on_task_result(message)
  File "/home/turing/projects/scaler/scaler/client/agent/task_manager.py", line 57, in on_task_result
    self._future_manager.on_task_result(result)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/home/turing/projects/scaler/scaler/client/agent/future_manager.py", line 69, in on_task_result
    future.set_result_ready(result_object_id, TaskState.Success, profile_result)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/turing/projects/scaler/scaler/client/future.py", line 84, in set_result_ready
    self._get_result_object()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/turing/projects/scaler/scaler/client/future.py", line 219, in _get_result_object
    object_bytes = self._connector_storage.get_object(self._result_object_id)
  File "/home/turing/projects/scaler/scaler/io/sync_object_storage_connector.py", line 76, in get_object
    self.__send_request(object_id, max_payload_length, ObjectRequestHeader.ObjectRequestType.GetObject)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/turing/projects/scaler/scaler/io/sync_object_storage_connector.py", line 159, in __send_request
    self.__raise_connection_failure()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/turing/projects/scaler/scaler/io/sync_object_storage_connector.py", line 197, in __raise_connection_failure
    raise ObjectStorageException("connection failure to object storage server.")
scaler.utility.exceptions.ObjectStorageException: connection failure to object storage server.
[INFO]2025-09-23 05:22:44+0800: logging to ('/dev/stdout',)
[INFO]2025-09-23 05:22:44+0800: logging to ('/dev/stdout',)
[INFO]2025-09-23 05:23:44+0800: ClientID(171656|Client|f209239a5b9e40e6995ffe7c621940de) disconnected
[EROR]2025-09-23 05:23:44+0800: TaskID(9f8f34002bca418f822733cd0a4bc442): cannot find task in worker to cancel
[EROR]2025-09-23 05:23:44+0800: TaskID(b3cbbfe8f9d84ebd949877d800f2c582): cannot find task in worker to cancel
[EROR]2025-09-23 05:23:44+0800: TaskID(b68e8f1c34aa4e71a87db4a633f51914): cannot find task in worker to cancel

```

Some of the time, it seems like even the `storage_address` cannot be fetched. But I don't have a very good explanation for this block.
```
[INFO]2025-09-23 07:44:30+0800: Cluster: shutdown
^CTraceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3.13/unittest/__main__.py", line 18, in <module>
    main(module=None)
    ~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/main.py", line 104, in __init__
    self.runTests()
    ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/unittest/main.py", line 270, in runTests
    self.result = testRunner.run(self.test)
                  ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/runner.py", line 240, in run
    test(result)
    ~~~~^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 122, in run
    test(result)
    ~~~~^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 122, in run
    test(result)
    ~~~~^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/suite.py", line 122, in run
    test(result)
    ~~~~^^^^^^^^
  File "/usr/lib/python3.13/unittest/case.py", line 707, in __call__
    return self.run(*args, **kwds)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/home/turing/projects/scaler/tests/test_client.py", line 317, in test_capabilities
    with Client(self.address) as client:
         ~~~~~~^^^^^^^^^^^^^^
  File "/home/turing/projects/scaler/scaler/client/client.py", line 75, in __init__
    self.__initialize__(address, profiling, timeout_seconds, heartbeat_interval_seconds, serializer, stream_output)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/turing/projects/scaler/scaler/client/client.py", line 120, in __initialize__
    self._storage_address = self._agent.get_storage_address()
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/turing/projects/scaler/scaler/client/agent/client_agent.py", line 123, in get_storage_address
    return self._storage_address.result()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/concurrent/futures/_base.py", line 451, in result
    self._condition.wait(timeout)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.13/threading.py", line 359, in wait
    waiter.acquire()
    ~~~~~~~~~~~~~~^^
KeyboardInterrupt

```
I suspect that most of this can boils down to a single thing: We must guarantee the exception handling within those modules are sound, and the interface is correctly handling it (this means the interface should not translate internal error and signal interruption to exceptions, probably). It is worth noting that the plain socket in Python are doing signal handling as well, and the implementation translate the exception/signal to error code (see [this link](https://github.com/python/cpython/blob/c4f21d7c7c415a85a975fb878a1e578c12969d82/Modules/socketmodule.c#L1005)).