### PR TITLE
Core reports error when user call sendMessage on Binder with no address

### DIFF
--- a/scaler/io/ymq/error.h
+++ b/scaler/io/ymq/error.h
@@ -32,6 +32,7 @@ struct Error: public std::exception {
         RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery,
         ConnectorSocketClosedByRemoteEnd,
         IOSocketStopRequested,
+        BinderSendMessageWithNoAddress,
     };
 
     // NOTE:
@@ -83,6 +84,8 @@ struct Error: public std::exception {
             case ErrorCode::ConnectorSocketClosedByRemoteEnd:
                 return "You have an IOSocket with Connector type but the only connection is closed by remote end";
             case ErrorCode::IOSocketStopRequested: return "Current IOSocket is requested to stop by another thread";
+            case ErrorCode::BinderSendMessageWithNoAddress:
+                return "You call sendMessage with a Binder IOSocket but failed to provide an address";
         }
         fprintf(stderr, "Unrecognized ErrorCode value, program exits\n");
         std::exit(1);

--- a/scaler/io/ymq/io_socket.cpp
+++ b/scaler/io/ymq/io_socket.cpp
@@ -43,6 +43,10 @@ void IOSocket::sendMessage(Message message, SendMessageCallback onMessageSent) n
                 callback(std::unexpected {Error::ErrorCode::ConnectorSocketClosedByRemoteEnd});
                 return;
             }
+            if (!message.address.data() && this->socketType() == IOSocketType::Binder) {
+                callback(std::unexpected {Error::ErrorCode::BinderSendMessageWithNoAddress});
+            }
+
             MessageConnectionTCP* conn = nullptr;
 
             std::string address = std::string((char*)message.address.data(), message.address.len());

--- a/scaler/io/ymq/pymod_ymq/ymq.h
+++ b/scaler/io/ymq/pymod_ymq/ymq.h
@@ -285,6 +285,8 @@ static int YMQ_createErrorCodeEnum(PyObject* pyModule, YMQState* state)
         {"RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery",
          (int)Error::ErrorCode::RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery},
         {"ConnectorSocketClosedByRemoteEnd", (int)Error::ErrorCode::ConnectorSocketClosedByRemoteEnd},
+        {"IOSocketStopRequested", (int)Error::ErrorCode::IOSocketStopRequested},
+        {"BinderSendMessageWithNoAddress", (int)Error::ErrorCode::BinderSendMessageWithNoAddress},
     };
 
     if (YMQ_createIntEnum(pyModule, &state->PyErrorCodeType, "ErrorCode", errorCodeValues) < 0)

--- a/scaler/io/ymq/ymq.pyi
+++ b/scaler/io/ymq/ymq.pyi
@@ -96,6 +96,8 @@ class ErrorCode(IntEnum):
     IPv6NotSupported = 13
     RemoteEndDisconnectedOnSocketWithoutGuaranteedDelivery = 14
     ConnectorSocketClosedByRemoteEnd = 15
+    IOSocketStopRequested = 16
+    BinderSendMessageWithNoAddress = 17
 
     def explanation(self) -> str: ...
 


### PR DESCRIPTION
# READY FOR REVIEW

This fixes `test_no_address` in the Python interface test.

The IOSocket fills an error immediately after it detects there are no address in a message when a `Binder` tries to call `sendMessage` with it.