### PR TITLE
Fix AWS HPC Batch entry point references, task cancel bug, and docs updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ eggs/
 .venv/
 venv*/
 .vscode/
+.kiro/
 
 dask-worker-space/*
 .pre-commit-config.yaml
@@ -34,3 +35,7 @@ CMakeFiles/
 .vs/
 src/scaler/protocol/capnp/*.c++
 src/scaler/protocol/capnp/*.h
+
+# AWS HPC test-generated files
+.scaler_aws_batch_config.json
+.scaler_aws_hpc.env

--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -201,7 +201,7 @@ The following table maps each Scaler command to its corresponding section name i
      - ``[symphony_worker_adapter]``
    * - ``scaler_worker_adapter_ecs``
      - ``[ecs_worker_adapter]``
-   * - ``python -m scaler.entry_points.worker_adapter_aws_hpc``
+   * - ``python -m scaler.entry_points.worker_manager_aws_hpc_batch``
      - ``[aws_hpc_worker_adapter]``
 
 

--- a/docs/source/tutorials/worker_adapters/aws_hpc/index.rst
+++ b/docs/source/tutorials/worker_adapters/aws_hpc/index.rst
@@ -28,8 +28,8 @@ To start the AWS HPC worker adapter from the command line:
 
 .. code-block:: bash
 
-    python -m scaler.entry_points.worker_adapter_aws_hpc \
-        --scheduler-address tcp://<SCHEDULER_IP>:8516 \
+    python -m scaler.entry_points.worker_manager_aws_hpc_batch \
+        tcp://<SCHEDULER_IP>:8516 \
         --job-queue my-scaler-queue \
         --job-definition my-scaler-job-def \
         --s3-bucket my-scaler-tasks-bucket \
@@ -39,7 +39,7 @@ Equivalent configuration using a TOML file:
 
 .. code-block:: bash
 
-    python -m scaler.entry_points.worker_adapter_aws_hpc --config config.toml
+    python -m scaler.entry_points.worker_manager_aws_hpc_batch --config config.toml
 
 .. code-block:: toml
 
@@ -55,7 +55,7 @@ Equivalent configuration using a TOML file:
 Key Arguments:
 ~~~~~~~~~~~~~~
 
-*   ``--scheduler-address``: The address of the Scaler scheduler.
+*   ``scheduler_address``: The address of the Scaler scheduler (positional argument).
 *   ``--job-queue`` (``-q``): The name of the AWS Batch job queue to submit tasks to.
 *   ``--job-definition`` (``-d``): The name of the AWS Batch job definition to use.
 *   ``--s3-bucket``: The S3 bucket used for task payload and result storage.

--- a/docs/source/tutorials/worker_adapters/aws_hpc/setup.rst
+++ b/docs/source/tutorials/worker_adapters/aws_hpc/setup.rst
@@ -67,6 +67,55 @@ Prerequisites
     *   ECR (create repository, push images)
 *   AWS CLI configured with credentials on host (for provisioning only)
 
+Required IAM Permissions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The provisioner (Step 1) requires broad permissions to create resources.
+
+.. tip::
+    For quick testing, an IAM user/role with ``AdministratorAccess`` works. For production, create a scoped policy with only the permissions listed below.
+
+.. note:: Minimum IAM actions needed
+
+    **S3:**
+
+    *   ``s3:CreateBucket``, ``s3:PutBucketLifecycleConfiguration``
+    *   ``s3:PutObject``, ``s3:GetObject``, ``s3:DeleteObject`` (for task data at runtime)
+    *   ``s3:ListBucket``, ``s3:DeleteBucket`` (for cleanup)
+
+    **IAM:**
+
+    *   ``iam:CreateRole``, ``iam:AttachRolePolicy``, ``iam:PutRolePolicy``
+    *   ``iam:CreateInstanceProfile``, ``iam:AddRoleToInstanceProfile``
+    *   ``iam:PassRole`` (to assign roles to Batch jobs and EC2 instances)
+    *   ``iam:DeleteRole``, ``iam:DetachRolePolicy``, ``iam:DeleteRolePolicy``, ``iam:RemoveRoleFromInstanceProfile``, ``iam:DeleteInstanceProfile`` (for cleanup)
+
+    **ECR:**
+
+    *   ``ecr:CreateRepository``, ``ecr:GetAuthorizationToken``, ``ecr:PutLifecyclePolicy``
+    *   ``ecr:BatchCheckLayerAvailability``, ``ecr:PutImage``, ``ecr:InitiateLayerUpload``, ``ecr:UploadLayerPart``, ``ecr:CompleteLayerUpload``
+    *   ``ecr:DeleteRepository`` (for cleanup)
+
+    **AWS Batch:**
+
+    *   ``batch:CreateComputeEnvironment``, ``batch:DescribeComputeEnvironments``
+    *   ``batch:CreateJobQueue``, ``batch:DescribeJobQueues``
+    *   ``batch:RegisterJobDefinition``, ``batch:DescribeJobDefinitions``, ``batch:DeregisterJobDefinition``
+    *   ``batch:SubmitJob``, ``batch:DescribeJobs``, ``batch:TerminateJob`` (at runtime)
+    *   ``batch:UpdateComputeEnvironment``, ``batch:DeleteComputeEnvironment``, ``batch:UpdateJobQueue``, ``batch:DeleteJobQueue`` (for cleanup)
+
+    **EC2** (used by Batch compute environment):
+
+    *   ``ec2:DescribeSubnets``, ``ec2:DescribeSecurityGroups``
+
+    **CloudWatch Logs:**
+
+    *   ``logs:CreateLogGroup``, ``logs:PutRetentionPolicy`` (for job log retention)
+
+    **STS:**
+
+    *   ``sts:GetCallerIdentity`` (to determine account ID)
+
 Quick Overview
 --------------
 
@@ -118,7 +167,7 @@ This creates:
 *   EC2 compute environment
 *   Job queue and job definition
 *   ``tests/worker_manager_adapter/aws_hpc/.scaler_aws_hpc.env`` file with configuration
-*   ``.scaler_aws_batch_config.json`` file with full resource details (used for cleanup)
+*   ``tests/worker_manager_adapter/aws_hpc/.scaler_aws_batch_config.json`` file with full resource details (used for cleanup)
 
 **Memory Configuration:**
 
@@ -227,19 +276,20 @@ All commands in the **same terminal** inside the container:
     source tests/worker_manager_adapter/aws_hpc/.scaler_aws_hpc.env
 
     # Start AWS Batch worker in background (default job timeout: 60 minutes)
-    python -m scaler.entry_points.worker_adapter_aws_hpc \
-        --scheduler-address tcp://127.0.0.1:2345 \
+    python -m scaler.entry_points.worker_manager_aws_hpc_batch \
+        tcp://127.0.0.1:2345 \
         --job-queue $SCALER_JOB_QUEUE \
         --job-definition $SCALER_JOB_DEFINITION \
         --s3-bucket $SCALER_S3_BUCKET \
         --aws-region $SCALER_AWS_REGION \
         --max-concurrent-jobs 100 \
-        --log-level INFO &
+        --logging-level INFO &
 
     # To override job timeout (e.g., 10 minutes):
-    # python -m scaler.entry_points.worker_adapter_aws_hpc \
+    # python -m scaler.entry_points.worker_manager_aws_hpc_batch \
+    #     tcp://127.0.0.1:2345 \
     #     ... \
-    #     --job-timeout 10 &
+    #     --job-timeout-minutes 10 &
 
 You should see log output indicating both are running.
 
@@ -410,26 +460,44 @@ Provisioner Options
 | ``--job-timeout``    | 60             | Job timeout in minutes (default: 1 hour, overridden by worker at runtime)|
 +----------------------+----------------+--------------------------------------------------------------------------+
 
-Worker Options
-~~~~~~~~~~~~~~
+AWS HPC Batch Options (``worker_manager_aws_hpc_batch``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+----------------------------+----------------+-------------------------------------------------------------------+
-| Option                     | Default        | Description                                                       |
-+============================+================+===================================================================+
-| ``--scheduler-address``    | required       | Scheduler address                                                 |
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--job-queue``            | required       | AWS Batch job queue                                               |
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--job-definition``       | required       | AWS Batch job definition                                          |
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--s3-bucket``            | required       | S3 bucket for task data                                           |
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--s3-prefix``            | scaler-tasks   | S3 prefix                                                         |
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--max-concurrent-jobs``  | 100            | Max concurrent Batch jobs                                         |
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--job-timeout``          | 60             | Job timeout in minutes (default: 1 hour, overrides job definition)|
-+----------------------------+----------------+-------------------------------------------------------------------+
-| ``--aws-region``           | us-east-1      | AWS region                                                        |
-+----------------------------+----------------+-------------------------------------------------------------------+
++------------------------------------+----------------+-------------------------------------------------------------------+
+| Option                             | Default        | Description                                                       |
++====================================+================+===================================================================+
+| ``scheduler_address``              | required       | Scheduler address (positional argument)                           |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--job-queue``                    | required       | AWS Batch job queue                                               |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--job-definition``               | required       | AWS Batch job definition                                          |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--s3-bucket``                    | required       | S3 bucket for task data                                           |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--backend``                      | batch          | AWS HPC backend                                                   |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--name``                         | None           | Worker name (auto: aws-batch-worker)                              |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--aws-region``                   | us-east-1      | AWS region                                                        |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--s3-prefix``                    | scaler-tasks   | S3 prefix                                                         |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--max-concurrent-jobs``          | 100            | Max concurrent Batch jobs                                         |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--job-timeout-minutes``          | 60             | Job timeout in minutes (overrides job definition)                 |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--heartbeat-interval-seconds``   | 2              | Heartbeat interval in seconds                                     |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--death-timeout-seconds``        | 300            | Seconds without scheduler contact before shutdown                 |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--task-queue-size``              | 1000           | Size of the internal task queue                                   |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--worker-io-threads``            | 1              | Number of IO threads for the worker                               |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--event-loop``                   | builtin        | Event loop type (builtin or uvloop)                               |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--logging-level``                | INFO           | Logging level (CRITICAL, ERROR, WARNING, INFO, DEBUG)             |
++------------------------------------+----------------+-------------------------------------------------------------------+
+| ``--logging-paths``                | /dev/stdout    | Log output paths                                                  |
++------------------------------------+----------------+-------------------------------------------------------------------+
 

--- a/src/run_worker_manager_aws_hpc_batch.py
+++ b/src/run_worker_manager_aws_hpc_batch.py
@@ -1,4 +1,4 @@
-from scaler.entry_points.worker_adapter_aws_hpc import main
+from scaler.entry_points.worker_manager_aws_hpc_batch import main
 from scaler.utility.debug import pdb_wrapped
 
 if __name__ == "__main__":

--- a/src/scaler/worker_manager_adapter/aws_hpc/task_manager.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/task_manager.py
@@ -167,15 +167,16 @@ class AWSHPCTaskManager(Looper, TaskManager):
 
         # Handle processing task cancellation
         if task_processing:
-            future = self._task_id_to_future[task_cancel.task_id]
-            future.cancel()
+            future = self._task_id_to_future.get(task_cancel.task_id)
+            if future is not None:
+                future.cancel()
 
             # Cancel AWS Batch job if it exists
             if task_cancel.task_id in self._task_id_to_batch_job_id:
                 batch_job_id = self._task_id_to_batch_job_id[task_cancel.task_id]
                 await self._cancel_batch_job(batch_job_id)
 
-            self._processing_task_ids.remove(task_cancel.task_id)
+            self._processing_task_ids.discard(task_cancel.task_id)
             self._canceled_task_ids.add(task_cancel.task_id)
 
         result = TaskCancelConfirm.new_msg(

--- a/tests/worker_manager_adapter/aws_hpc/aws_hpc_test_harness.py
+++ b/tests/worker_manager_adapter/aws_hpc/aws_hpc_test_harness.py
@@ -66,7 +66,7 @@ def run_map_test(client: Client, timeout: int) -> bool:
     print("\n--- Test: map ---")
     print("  Submitting: client.map(simple_task, [0,1,2,3,4])")
     try:
-        results = client.map(simple_task, [(x,) for x in range(5)])
+        results = client.map(simple_task, list(range(5)))
         print(f"  Results: {results}")
         expected = [0, 2, 4, 6, 8]
         passed = results == expected


### PR DESCRIPTION
## Summary
Fixes broken references after the `worker_adapter` → `worker_manager_adapter` restructuring, a task cancellation bug, and improves documentation.

## Changes

### Bug Fix
- Fix `KeyError` in `task_manager.py` when scheduler sends cancel for an already-failed task (use `.get()` and `.discard()` instead of direct lookup/remove)

### Broken References
- Fix `run_worker_manager_aws_hpc_batch.py` import (was referencing deleted `worker_adapter_aws_hpc` module)
- Update `setup.rst`, `index.rst`, and `configuration.rst` to use new entry point `worker_manager_aws_hpc_batch`
- Update CLI args: `--scheduler-address` → positional, `--log-level` → `--logging-level`, `--job-timeout` → `--job-timeout-minutes`

### Documentation
- Add detailed IAM permissions section to setup guide
- Add complete AWS HPC Batch options table with all parameters and defaults
- Fix `.scaler_aws_batch_config.json` path in setup guide
- Fix deprecated `client.map()` call in test harness

### Housekeeping
- Add `.kiro/`, `.scaler_aws_batch_config.json`, `.scaler_aws_hpc.env` to `.gitignore`

## Testing
Tested provisioning and worker startup with corrected entry point in devcontainer.
