### PR TITLE
Rename orb_aws_ec2 extras dependency group to orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ aws_region = "us-east-1"
 The ORB AWS EC2 adapter requires `orb-py` and `boto3` to be installed. You can install them with:
 
 ```bash
-$ pip install "opengris-scaler[orb_aws_ec2]"
+$ pip install "opengris-scaler[orb]"
 ```
 
 For more details on configuring ORB AWS EC2, including AWS credentials and instance templates, please refer to the [ORB AWS EC2 Worker Adapter documentation](https://finos.github.io/opengris-scaler/tutorials/worker_manager_adapter/orb_aws_ec2.html).

--- a/docs/source/tutorials/worker_managers/orb_aws_ec2.rst
+++ b/docs/source/tutorials/worker_managers/orb_aws_ec2.rst
@@ -10,11 +10,11 @@ Requirements
 
 Before using the ORB AWS EC2 worker adapter, ensure the following requirements are met on the machine that will run the adapter:
 
-1.  **orb-py and boto3**: The ``orb-py`` and ``boto3`` packages must be installed. These can be installed using the ``orb_aws_ec2`` optional dependency of Scaler:
+1.  **orb-py and boto3**: The ``orb-py`` and ``boto3`` packages must be installed. These can be installed using the ``orb`` optional dependency of Scaler:
 
     .. code-block:: bash
 
-        pip install "opengris-scaler[orb_aws_ec2]"
+        pip install "opengris-scaler[orb]"
 
 2.  **AWS CLI**: The AWS Command Line Interface must be installed and configured with a default profile that has permissions to launch, describe, and terminate EC2 instances.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ graphblas = [
 aws = [
     "boto3",
 ]
-orb_aws_ec2 = [
+orb = [
     "orb-py~=1.5.1; python_version >= '3.10'",
     "boto3; python_version >= '3.10'",
 ]
@@ -58,7 +58,7 @@ all = [
     "opengris-scaler[aws]",
     "opengris-scaler[graphblas]",
     "opengris-scaler[gui]",
-    "opengris-scaler[orb_aws_ec2]",
+    "opengris-scaler[orb]",
     "opengris-scaler[uvloop]",
 ]
 


### PR DESCRIPTION
## Summary
- Renames the `orb_aws_ec2` optional extras group in `pyproject.toml` to `orb`
- Updates the `all` extras reference from `opengris-scaler[orb_aws_ec2]` to `opengris-scaler[orb]`
- Updates `pip install` instructions in README and docs to use the new name

## Test plan
- [ ] Verify `pip install "opengris-scaler[orb]"` installs `orb-py` and `boto3`
- [ ] Verify `pip install "opengris-scaler[all]"` still works correctly