### PR TITLE
Add botocore[crt] to aws dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ aws = [
 ]
 orb = [
     "orb-py~=1.5.1; python_version >= '3.10'",
-    "boto3; python_version >= '3.10'",
+    "boto3",
+    "botocore[crt]",
 ]
 all = [
     "opengris-scaler[aws]",


### PR DESCRIPTION
## Summary
- Adds `botocore[crt]` to the `aws` optional dependency group in `pyproject.toml`

## Test plan
- [ ] Verify `pip install opengris-scaler[aws]` installs `botocore[crt]` alongside `boto3`