### PR TITLE
fix: catch KeyboardInterrupt in ObjectStorageServerProcess.run()

### DIFF
--- a/src/scaler/cluster/object_storage_server.py
+++ b/src/scaler/cluster/object_storage_server.py
@@ -48,11 +48,14 @@ class ObjectStorageServerProcess(multiprocessing.get_context("spawn").Process): 
         log_format_str, log_level_str, logging_paths = get_logger_info(logging.getLogger())
 
         self._server = ObjectStorageServer()
-        self._server.run(
-            self._object_storage_address.host,
-            self._object_storage_address.port,
-            self._object_storage_address.identity,
-            log_level_str,
-            log_format_str,
-            logging_paths,
-        )
+        try:
+            self._server.run(
+                self._object_storage_address.host,
+                self._object_storage_address.port,
+                self._object_storage_address.identity,
+                log_level_str,
+                log_format_str,
+                logging_paths,
+            )
+        except KeyboardInterrupt:
+            logging.info("ObjectStorageServer: received KeyboardInterrupt, shutting down")


### PR DESCRIPTION
## Summary

- `ObjectStorageServerProcess.run()` now wraps `self._server.run(...)` in a `try/except KeyboardInterrupt` block
- On SIGINT, the server logs a clean shutdown message instead of propagating an unhandled exception to the multiprocessing bootstrap
- Consistent with the existing handling in `src/scaler/entry_points/object_storage_server.py`

## Related Issue

Closes #659