### PR TITLE
Logging with new format and named logger

### DIFF
--- a/src/cpp/scaler/logging/logging.h
+++ b/src/cpp/scaler/logging/logging.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <uv.h>
+
+#include <cctype>
 #include <cstddef>
 #include <fstream>
 #include <iostream>
@@ -26,10 +29,11 @@ public:
 #endif
 
     Logger(
-        std::string log_format             = "%(levelname)s: %(message)s",
+        std::string log_format             = "%(asctime)s %(levelname)s %(name)s[%(process)d]: %(message)s",
         std::vector<std::string> log_paths = {"/dev/stdout"},
-        LoggingLevel level                 = DEFAULT_LOGGING_LEVEL)
-        : _log_paths(std::move(log_paths)), _level(level)
+        LoggingLevel level                 = DEFAULT_LOGGING_LEVEL,
+        std::string name                   = "scaler")
+        : _log_paths(std::move(log_paths)), _level(level), _name(std::move(name))
     {
         preprocessFormat(log_format);
     }
@@ -81,12 +85,15 @@ public:
                         (output_stream << ... << std::forward<Args>(args));
                     }
                 } else if (part.content == "name") {
-                    output_stream << "cpp-logger";
+                    output_stream << _name;
+                } else if (part.content == "process") {
+                    uv_pid_t pid = uv_os_getpid();
+                    output_stream << pid;
                 } else if (part.content == "lineno") {
                     output_stream << "0";
                 } else {
-                    // Unknown token, print literally
-                    output_stream << "%(" << part.content << ")s";
+                    // Unknown token, print literally (with the original specifier)
+                    output_stream << "%(" << part.content << ")" << part.spec;
                 }
             } else {
                 output_stream << part.content;
@@ -115,11 +122,15 @@ private:
     struct FormatPart {
         std::string content;
         bool is_token;
+        // For tokens, the format specifier letter that followed ')' (e.g. 's' in "%(name)s",
+        // 'd' in "%(process)d"). Kept so that unknown tokens can be emitted verbatim.
+        char spec = '\0';
     };
 
     std::vector<FormatPart> _processed_format;
     std::vector<std::string> _log_paths;
     LoggingLevel _level;
+    std::string _name;
 
     void preprocessFormat(const std::string& format)
     {
@@ -138,11 +149,12 @@ private:
             }
 
             if (format.length() > find_pos + 1 && format[find_pos + 1] == '(') {
-                size_t token_end = format.find(")s", find_pos + 2);
-                if (token_end != std::string::npos) {
-                    std::string token = format.substr(find_pos + 2, token_end - (find_pos + 2));
-                    _processed_format.push_back({token, true});
-                    last_pos = token_end + 2;
+                size_t close_paren = format.find(')', find_pos + 2);
+                if (close_paren != std::string::npos && close_paren + 1 < format.length() &&
+                    std::isalpha(static_cast<unsigned char>(format[close_paren + 1]))) {
+                    std::string token = format.substr(find_pos + 2, close_paren - (find_pos + 2));
+                    _processed_format.push_back({token, true, format[close_paren + 1]});
+                    last_pos = close_paren + 2;
                     continue;
                 }
             }

--- a/src/scaler/__init__.py
+++ b/src/scaler/__init__.py
@@ -1,7 +1,14 @@
+import logging
 from importlib import import_module
 from typing import Any
 
 from .about import __version__
+
+# Library-mode safety: attach a NullHandler to the "scaler" logger so importing
+# scaler (e.g. `from scaler import Client`) never emits "no handler" warnings
+# and never alters the host application's root logger. Daemon entry points
+# replace this with real handlers via `setup_logger`.
+logging.getLogger("scaler").addHandler(logging.NullHandler())
 
 __all__ = ["__version__", "Client", "ScalerFuture", "Serializer", "SchedulerClusterCombo", "Scheduler"]
 

--- a/src/scaler/client/agent/client_agent.py
+++ b/src/scaler/client/agent/client_agent.py
@@ -31,6 +31,8 @@ from scaler.utility.event_loop import create_async_loop_routine, run_task_foreve
 from scaler.utility.exceptions import ClientCancelledException, ClientQuitException, ClientShutdownException
 from scaler.utility.identifiers import ClientID
 
+logger = logging.getLogger(__name__)
+
 
 class ClientAgent(threading.Thread):
     def __init__(
@@ -206,16 +208,16 @@ class ClientAgent(threading.Thread):
             # asyncio.CancelledError is a BaseException (not Exception) in Python 3.8+, so it
             # cannot go into set_all_futures_with_exception directly. Translate to the
             # public-facing ClientCancelledException.
-            logging.error("ClientAgent: async. loop cancelled")
+            logger.error("ClientAgent: async. loop cancelled")
             cancelled = ClientCancelledException("client cancelled")
             self._future_manager.set_all_futures_with_exception(cancelled)
             public_exception = cancelled
         elif isinstance(exception, (ClientQuitException, ClientShutdownException)):
-            logging.info("ClientAgent: client quitting")
+            logger.info("ClientAgent: client quitting")
             self._future_manager.set_all_futures_with_exception(exception)
             public_exception = exception
         elif isinstance(exception, (TimeoutError, YMQException)):
-            logging.error(f"ClientAgent: client timeout when connecting to {self._scheduler_address!r}")
+            logger.error(f"ClientAgent: client timeout when connecting to {self._scheduler_address!r}")
             self._future_manager.set_all_futures_with_exception(TimeoutError())
             public_exception = exception
         else:

--- a/src/scaler/client/agent/future_manager.py
+++ b/src/scaler/client/agent/future_manager.py
@@ -11,6 +11,8 @@ from scaler.utility.exceptions import WorkerDiedError
 from scaler.utility.identifiers import ObjectID, TaskID
 from scaler.utility.metadata.profile_result import retrieve_profiling_result_from_task_result
 
+logger = logging.getLogger(__name__)
+
 
 class ClientFutureManager(FutureManager):
     def __init__(self, serializer: Serializer):
@@ -32,7 +34,7 @@ class ClientFutureManager(FutureManager):
         # Actually cancelling the futures should occur without holding the future manager's lock. That's because
         # `cancel()` is blocking, and requires the manager to process result and cancel confirm messages.
 
-        logging.info(f"canceling {len(futures_to_cancel)} task(s)")
+        logger.info(f"canceling {len(futures_to_cancel)} task(s)")
         for future in futures_to_cancel:
             try:
                 future.cancel()
@@ -100,11 +102,11 @@ class ClientFutureManager(FutureManager):
                 future.set_canceled()
 
             elif cancel_confirm_type == TaskCancelConfirmType.cancelNotFound:
-                logging.error(f"{task_id!r}: task to cancel not found")
+                logger.error(f"{task_id!r}: task to cancel not found")
                 future.set_canceled()
 
             elif cancel_confirm_type == TaskCancelConfirmType.cancelFailed:
-                logging.error(f"{task_id!r}: task cancel failed")
+                logger.error(f"{task_id!r}: task cancel failed")
                 self._task_id_to_future[task_id] = future
 
             else:

--- a/src/scaler/client/client.py
+++ b/src/scaler/client/client.py
@@ -33,6 +33,8 @@ if sys.platform != "emscripten":
 else:
     Processor = None  # type: ignore[assignment]
 
+logger = logging.getLogger(__name__)
+
 _T = TypeVar("_T")
 
 
@@ -137,14 +139,14 @@ class Client:
         )
         self._bridge.start()
 
-        logging.info(f"ScalerClient: connect to scheduler at {self._scheduler_address}")
+        logger.info(f"ScalerClient: connect to scheduler at {self._scheduler_address}")
 
         # Blocks until the agent receives the object storage address
         self._object_storage_address = self._bridge.get_object_storage_address()
 
         self._connector_agent = self._bridge.connector
 
-        logging.info(f"ScalerClient: connect to object storage at {self._object_storage_address}")
+        logger.info(f"ScalerClient: connect to object storage at {self._object_storage_address}")
         self._connector_storage = self._backend.create_sync_object_storage_connector(
             identity=self._identity, address=self._object_storage_address
         )
@@ -367,7 +369,7 @@ class Client:
         try:
             results = [fut.result() for fut in futures]
         except Exception as e:
-            logging.exception(f"Error occured during scaler client.starmap:\n{e}")
+            logger.exception(f"Error occured during scaler client.starmap:\n{e}")
             self.disconnect()
             raise e
 
@@ -456,7 +458,7 @@ class Client:
         try:
             results = {k: v.result() for k, v in futures.items()}
         except Exception as e:
-            logging.exception(f"error happened when do scaler client.get:\n{e}")
+            logger.exception(f"error happened when do scaler client.get:\n{e}")
             self.disconnect()
             raise e
 
@@ -514,7 +516,7 @@ class Client:
             self.__destroy()
             return
 
-        logging.info(f"ScalerClient: disconnect from {self._scheduler_address!r}")
+        logger.info(f"ScalerClient: disconnect from {self._scheduler_address!r}")
 
         self._future_manager.cancel_all_futures()
 
@@ -556,7 +558,7 @@ class Client:
             self.__destroy()
             return
 
-        logging.info(f"ScalerClient: request shutdown for {self._scheduler_address!r}")
+        logger.info(f"ScalerClient: request shutdown for {self._scheduler_address!r}")
 
         self._future_manager.cancel_all_futures()
 

--- a/src/scaler/cluster/combo.py
+++ b/src/scaler/cluster/combo.py
@@ -35,6 +35,8 @@ from scaler.config.types.worker import WorkerCapabilities
 from scaler.utility.network_util import get_available_tcp_port
 from scaler.worker_manager_adapter.baremetal.native import NativeWorkerManager
 
+logger = logging.getLogger(__name__)
+
 SCHEDULER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 10
 
 
@@ -155,7 +157,7 @@ class SchedulerClusterCombo:
 
         self._scheduler.start()
         self._worker_manager_process.start()
-        logging.info(f"{self.__get_prefix()} started")
+        logger.info(f"{self.__get_prefix()} started")
 
     def __del__(self):
         if not self._shutdown_called:
@@ -164,7 +166,7 @@ class SchedulerClusterCombo:
     def shutdown(self):
         self._shutdown_called = True
 
-        logging.info(f"{self.__get_prefix()} shutdown")
+        logger.info(f"{self.__get_prefix()} shutdown")
         if self._worker_manager_process.is_alive():
             # On POSIX, multiprocessing.Process.terminate() sends SIGTERM and the worker manager's
             # signal handler iterates self._workers and terminates each child worker, which in turn

--- a/src/scaler/cluster/object_storage_server.py
+++ b/src/scaler/cluster/object_storage_server.py
@@ -8,6 +8,8 @@ from scaler.config.types.address import AddressConfig
 from scaler.object_storage.object_storage_server import ObjectStorageServer
 from scaler.utility.logging.utility import get_logger_info, setup_logger
 
+logger = logging.getLogger(__name__)
+
 
 class ObjectStorageServerProcess(multiprocessing.get_context("spawn").Process):  # type: ignore[misc]
     def __init__(
@@ -47,12 +49,12 @@ class ObjectStorageServerProcess(multiprocessing.get_context("spawn").Process): 
         setup_logger(
             self._logging_paths, self._logging_config_file, self._logging_level, process_name="object_storage_server"
         )
-        logging.info(f"ObjectStorageServer: start and listen to {self._bind_address!r}")
+        logger.info(f"ObjectStorageServer: start and listen to {self._bind_address!r}")
 
-        log_format_str, log_level_str, logging_paths = get_logger_info(logging.getLogger())
+        log_format_str, log_level_str, logging_paths = get_logger_info(logging.getLogger("scaler"))
 
         self._server = ObjectStorageServer()
         try:
             self._server.run(repr(self._bind_address), self._ident, log_level_str, log_format_str, logging_paths)
         except KeyboardInterrupt:
-            logging.info("ObjectStorageServer: received KeyboardInterrupt, shutting down")
+            logger.info("ObjectStorageServer: received KeyboardInterrupt, shutting down")

--- a/src/scaler/cluster/object_storage_server.py
+++ b/src/scaler/cluster/object_storage_server.py
@@ -44,7 +44,9 @@ class ObjectStorageServerProcess(multiprocessing.get_context("spawn").Process): 
         raise TimeoutError(f"ObjectStorageServer at {self._bind_address!r} failed to start within 30 seconds")
 
     def run(self) -> None:
-        setup_logger(self._logging_paths, self._logging_config_file, self._logging_level)
+        setup_logger(
+            self._logging_paths, self._logging_config_file, self._logging_level, process_name="object_storage_server"
+        )
         logging.info(f"ObjectStorageServer: start and listen to {self._bind_address!r}")
 
         log_format_str, log_level_str, logging_paths = get_logger_info(logging.getLogger())

--- a/src/scaler/cluster/scheduler.py
+++ b/src/scaler/cluster/scheduler.py
@@ -77,7 +77,7 @@ class SchedulerProcess(multiprocessing.get_context("spawn").Process):  # type: i
         await self._task
 
     def __initialize(self) -> None:
-        setup_logger(self._logging_paths, self._logging_config_file, self._logging_level)
+        setup_logger(self._logging_paths, self._logging_config_file, self._logging_level, process_name="scheduler")
         register_event_loop(self._scheduler_config.event_loop)
 
     def __register_signal(self):

--- a/src/scaler/entry_points/object_storage_server.py
+++ b/src/scaler/entry_points/object_storage_server.py
@@ -17,7 +17,7 @@ def main():
         process_name="object_storage_server",
     )
 
-    log_format_str, log_level_str, log_paths = get_logger_info(logging.getLogger())
+    log_format_str, log_level_str, log_paths = get_logger_info(logging.getLogger("scaler"))
 
     try:
         ObjectStorageServer().run(

--- a/src/scaler/entry_points/object_storage_server.py
+++ b/src/scaler/entry_points/object_storage_server.py
@@ -11,7 +11,10 @@ def main():
     oss_config = ObjectStorageServerConfig.parse("Scaler Object Storage Server", "object_storage_server")
 
     setup_logger(
-        oss_config.logging_config.paths, oss_config.logging_config.config_file, oss_config.logging_config.level
+        oss_config.logging_config.paths,
+        oss_config.logging_config.config_file,
+        oss_config.logging_config.level,
+        process_name="object_storage_server",
     )
 
     log_format_str, log_level_str, log_paths = get_logger_info(logging.getLogger())

--- a/src/scaler/entry_points/scaler.py
+++ b/src/scaler/entry_points/scaler.py
@@ -46,7 +46,12 @@ def _run_scheduler(config: SchedulerConfig) -> None:
 
 
 def _run_worker_manager(config: WorkerManagerUnion) -> None:
-    setup_logger(config.logging_config.paths, config.logging_config.config_file, config.logging_config.level)
+    setup_logger(
+        config.logging_config.paths,
+        config.logging_config.config_file,
+        config.logging_config.level,
+        process_name=config._tag,
+    )
     register_event_loop(config.worker_config.event_loop)
     if isinstance(config, NativeWorkerManagerConfig):
         from scaler.worker_manager_adapter.baremetal.native import NativeWorkerManager

--- a/src/scaler/entry_points/worker_manager.py
+++ b/src/scaler/entry_points/worker_manager.py
@@ -90,7 +90,12 @@ def main() -> None:
         config_cls.parse_with_section("scaler_worker_manager", section_data, argv=remaining_argv),
     )
 
-    setup_logger(wm_config.logging_config.paths, wm_config.logging_config.config_file, wm_config.logging_config.level)
+    setup_logger(
+        wm_config.logging_config.paths,
+        wm_config.logging_config.config_file,
+        wm_config.logging_config.level,
+        process_name=wm_type,
+    )
     register_event_loop(wm_config.worker_config.event_loop)
 
     if isinstance(wm_config, NativeWorkerManagerConfig):

--- a/src/scaler/io/utility.py
+++ b/src/scaler/io/utility.py
@@ -8,6 +8,8 @@ from scaler.protocol.capnp import BaseMessage, Message
 from scaler.protocol.helpers import PROTOCOL
 from scaler.utility.exceptions import CapnpDeserializationError
 
+logger = logging.getLogger(__name__)
+
 try:
     from collections.abc import Buffer  # type: ignore[attr-defined]
 except ImportError:
@@ -24,7 +26,7 @@ def deserialize(data: Buffer) -> Optional[BaseMessage]:
     except (ValueError, RuntimeError) as e:
         raise CapnpDeserializationError(str(e)) from e
     if not hasattr(payload, payload.which()):
-        logging.error(f"unknown message type: {payload.which()}")
+        logger.error(f"unknown message type: {payload.which()}")
         return None
 
     return getattr(payload, payload.which())

--- a/src/scaler/io/ymq_async_binder.py
+++ b/src/scaler/io/ymq_async_binder.py
@@ -8,6 +8,8 @@ from scaler.io.utility import deserialize, serialize
 from scaler.io.ymq import BinderSocket, Bytes, ConnectorSocketClosedByRemoteEndError, IOContext
 from scaler.protocol.capnp import BaseMessage, BinderStatus
 
+logger = logging.getLogger(__name__)
+
 
 class YMQAsyncBinder(AsyncBinder):
     def __init__(self, context: IOContext, identity: bytes, callback: Callable[[bytes, BaseMessage], Awaitable[None]]):
@@ -53,7 +55,7 @@ class YMQAsyncBinder(AsyncBinder):
 
         message: Optional[BaseMessage] = deserialize(ymq_msg.payload.data)
         if message is None:
-            logging.error(f"received unknown message from {ymq_msg.address.data!r}: {ymq_msg.payload.data!r}")
+            logger.error(f"received unknown message from {ymq_msg.address.data!r}: {ymq_msg.payload.data!r}")
             return
 
         self.__count_received(message.__class__.__name__)

--- a/src/scaler/io/ymq_async_connector.py
+++ b/src/scaler/io/ymq_async_connector.py
@@ -7,6 +7,8 @@ from scaler.io.utility import deserialize, serialize
 from scaler.io.ymq import Bytes, ConnectorSocket, IOContext
 from scaler.protocol.capnp import BaseMessage
 
+logger = logging.getLogger(__name__)
+
 
 class YMQAsyncConnector(AsyncConnector):
     def __init__(self, context: IOContext, identity: bytes, callback: Callable[[BaseMessage], Awaitable[None]]):
@@ -73,7 +75,7 @@ class YMQAsyncConnector(AsyncConnector):
 
         result: Optional[BaseMessage] = deserialize(payload_data)
         if result is None:
-            logging.error(f"received unknown message: {payload_data!r}")
+            logger.error(f"received unknown message: {payload_data!r}")
             return None
 
         return result

--- a/src/scaler/io/ymq_async_object_storage_connector.py
+++ b/src/scaler/io/ymq_async_object_storage_connector.py
@@ -10,6 +10,8 @@ from scaler.protocol.helpers import from_capnp_object_id, to_capnp_object_id
 from scaler.utility.exceptions import ObjectStorageException
 from scaler.utility.identifiers import ObjectID
 
+logger = logging.getLogger(__name__)
+
 
 class YMQAsyncObjectStorageConnector(AsyncObjectStorageConnector):
     """An asyncio connector that uses YMQ to connect to a Scaler's object storage instance."""
@@ -76,7 +78,7 @@ class YMQAsyncObjectStorageConnector(AsyncObjectStorageConnector):
         pending_get_future = self._pending_get_requests.pop(from_capnp_object_id(header.objectID), None)
 
         if pending_get_future is None:
-            logging.warning(f"unknown get-ok response for unrequested object_id={repr(header.objectID)}.")
+            logger.warning(f"unknown get-ok response for unrequested object_id={repr(header.objectID)}.")
             return
 
         pending_get_future.set_result(payload)

--- a/src/scaler/io/zmq_async_binder.py
+++ b/src/scaler/io/zmq_async_binder.py
@@ -11,6 +11,8 @@ from scaler.io.mixins import AsyncBinder
 from scaler.io.utility import deserialize, serialize
 from scaler.protocol.capnp import BaseMessage, BinderStatus
 
+logger = logging.getLogger(__name__)
+
 
 class ZMQAsyncBinder(AsyncBinder):
     def __init__(
@@ -62,10 +64,10 @@ class ZMQAsyncBinder(AsyncBinder):
         try:
             message: Optional[BaseMessage] = deserialize(payload.bytes)
             if message is None:
-                logging.error(f"received unknown message from {source.bytes!r}: {payload!r}")
+                logger.error(f"received unknown message from {source.bytes!r}: {payload!r}")
                 return
         except Exception as e:
-            logging.error(f"{self.__get_prefix()} failed to deserialize message from {source.bytes!r}: {e}")
+            logger.error(f"{self.__get_prefix()} failed to deserialize message from {source.bytes!r}: {e}")
             return
 
         self.__count_received(message.__class__.__name__)
@@ -90,7 +92,7 @@ class ZMQAsyncBinder(AsyncBinder):
 
     def __is_valid_message(self, frames: List[Frame]) -> bool:
         if len(frames) != 2:
-            logging.error(f"{self.__get_prefix()} received unexpected frames {frames}")
+            logger.error(f"{self.__get_prefix()} received unexpected frames {frames}")
             return False
 
         return True

--- a/src/scaler/io/zmq_async_connector.py
+++ b/src/scaler/io/zmq_async_connector.py
@@ -9,6 +9,8 @@ from scaler.io.mixins import AsyncConnector, ConnectorRemoteType
 from scaler.io.utility import deserialize, serialize
 from scaler.protocol.capnp import BaseMessage
 
+logger = logging.getLogger(__name__)
+
 
 class ZMQAsyncConnector(AsyncConnector):
     def __init__(
@@ -83,7 +85,7 @@ class ZMQAsyncConnector(AsyncConnector):
         payload = await self._socket.recv(copy=False)
         result: Optional[BaseMessage] = deserialize(payload.bytes)
         if result is None:
-            logging.error(f"received unknown message: {payload.bytes!r}")
+            logger.error(f"received unknown message: {payload.bytes!r}")
             return None
 
         return result

--- a/src/scaler/io/zmq_sync_connector.py
+++ b/src/scaler/io/zmq_sync_connector.py
@@ -9,6 +9,8 @@ from scaler.io.mixins import ConnectorRemoteType, SyncConnector
 from scaler.io.utility import deserialize, serialize
 from scaler.protocol.capnp import BaseMessage
 
+logger = logging.getLogger(__name__)
+
 
 class ZMQSyncConnector(SyncConnector):
     def __init__(
@@ -59,7 +61,7 @@ class ZMQSyncConnector(SyncConnector):
     def __compose_message(self, payload: bytes) -> Optional[BaseMessage]:
         result: Optional[BaseMessage] = deserialize(payload)
         if result is None:
-            logging.error(f"{self.__get_prefix()}: received unknown message: {payload!r}")
+            logger.error(f"{self.__get_prefix()}: received unknown message: {payload!r}")
             return None
 
         return result

--- a/src/scaler/io/zmq_sync_subscriber.py
+++ b/src/scaler/io/zmq_sync_subscriber.py
@@ -10,6 +10,8 @@ from scaler.io.mixins import SyncSubscriber
 from scaler.io.utility import deserialize
 from scaler.protocol.capnp import BaseMessage
 
+logger = logging.getLogger(__name__)
+
 
 class ZMQSyncSubscriber(SyncSubscriber):
     def __init__(
@@ -72,7 +74,7 @@ class ZMQSyncSubscriber(SyncSubscriber):
     def __routine_receive(self, payload: bytes):
         result: Optional[BaseMessage] = deserialize(payload)
         if result is None:
-            logging.error(f"received unknown message: {payload!r}")
+            logger.error(f"received unknown message: {payload!r}")
             return None
 
         self._callback(result)

--- a/src/scaler/scheduler/controllers/balance_controller.py
+++ b/src/scaler/scheduler/controllers/balance_controller.py
@@ -8,6 +8,8 @@ from scaler.scheduler.controllers.mixins import PolicyController, TaskController
 from scaler.utility.identifiers import TaskID, WorkerID
 from scaler.utility.mixins import Looper
 
+logger = logging.getLogger(__name__)
+
 
 class VanillaBalanceController(Looper):
     def __init__(self, config_controller: VanillaConfigController, policy_controller: PolicyController):
@@ -35,7 +37,7 @@ class VanillaBalanceController(Looper):
             return
 
         worker_to_num_tasks = {worker: len(task_ids) for worker, task_ids in current_advice.items()}
-        logging.info(f"balancing task: {worker_to_num_tasks}")
+        logger.info(f"balancing task: {worker_to_num_tasks}")
         for worker, task_ids in current_advice.items():
             await self._binder_monitor.send(StateBalanceAdvice(workerId=worker, taskIds=task_ids))
 

--- a/src/scaler/scheduler/controllers/client_controller.py
+++ b/src/scaler/scheduler/controllers/client_controller.py
@@ -19,6 +19,8 @@ from scaler.utility.identifiers import ClientID, TaskID
 from scaler.utility.mixins import Looper, Reporter
 from scaler.utility.one_to_many_dict import OneToManyDict
 
+logger = logging.getLogger(__name__)
+
 
 class VanillaClientController(ClientController, Looper, Reporter):
     def __init__(self, config_controller: VanillaConfigController):
@@ -86,7 +88,7 @@ class VanillaClientController(ClientController, Looper, Reporter):
             ),
         )
         if client_id not in self._client_last_seen:
-            logging.info(f"{client_id!r} connected")
+            logger.info(f"{client_id!r} connected")
 
         self._client_last_seen[client_id] = (time.time(), info)
 
@@ -106,10 +108,10 @@ class VanillaClientController(ClientController, Looper, Reporter):
             return
 
         if self._config_controller.get_config("protected"):
-            logging.warning("cannot shutdown clusters as scheduler is running in protected mode")
+            logger.warning("cannot shutdown clusters as scheduler is running in protected mode")
             accepted = False
         else:
-            logging.info(f"shutdown scheduler and all clusters as received signal from {client_id!r}")
+            logger.info(f"shutdown scheduler and all clusters as received signal from {client_id!r}")
             accepted = True
 
         await self._binder.send(client_id, ClientShutdownResponse(accepted=accepted))
@@ -151,7 +153,7 @@ class VanillaClientController(ClientController, Looper, Reporter):
             await self.__on_client_disconnect(client)
 
     async def __on_client_disconnect(self, client_id: ClientID):
-        logging.info(f"{client_id!r} disconnected")
+        logger.info(f"{client_id!r} disconnected")
         if client_id in self._client_last_seen:
             self._client_last_seen.pop(client_id)
 

--- a/src/scaler/scheduler/controllers/config_controller.py
+++ b/src/scaler/scheduler/controllers/config_controller.py
@@ -4,6 +4,8 @@ from typing import Any, Dict
 from scaler.config.section.scheduler import SchedulerConfig
 from scaler.scheduler.controllers.mixins import ConfigController
 
+logger = logging.getLogger(__name__)
+
 
 class VanillaConfigController(ConfigController):
     def __init__(self, config: SchedulerConfig):
@@ -23,9 +25,9 @@ class VanillaConfigController(ConfigController):
 
         if path not in self._config:
             self._config[path] = value
-            logging.info(f"ConfigController: {path} = {value}")
+            logger.info(f"ConfigController: {path} = {value}")
             return
 
         old_value = self._config[path]
         self._config[path] = value
-        logging.info(f"ConfigController: updated `{path}` from `{old_value}` to `{value}`")
+        logger.info(f"ConfigController: updated `{path}` from `{old_value}` to `{value}`")

--- a/src/scaler/scheduler/controllers/object_controller.py
+++ b/src/scaler/scheduler/controllers/object_controller.py
@@ -11,6 +11,8 @@ from scaler.scheduler.object_usage.object_tracker import ObjectTracker, ObjectUs
 from scaler.utility.identifiers import ClientID, ObjectID
 from scaler.utility.mixins import Looper, Reporter
 
+logger = logging.getLogger(__name__)
+
 
 @dataclasses.dataclass
 class _ObjectCreation(ObjectUsage):
@@ -63,7 +65,7 @@ class VanillaObjectController(ObjectController, Looper, Reporter):
             self.on_del_objects(instruction.objectUser, set(instruction.objectMetadata.objectIds))
             return
 
-        logging.error(f"received unknown object instruction_type={instruction.instructionType} from {source=}")
+        logger.error(f"received unknown object instruction_type={instruction.instructionType} from {source=}")
 
     def on_add_object(
         self,
@@ -73,7 +75,7 @@ class VanillaObjectController(ObjectController, Looper, Reporter):
         object_name: bytes,
     ):
         creation = _ObjectCreation(object_id, client_id, object_type, object_name)
-        logging.debug(
+        logger.debug(
             f"add object cache "
             f"object_name={creation.object_name!r}, "
             f"object_type={creation.object_type}, "
@@ -130,7 +132,7 @@ class VanillaObjectController(ObjectController, Looper, Reporter):
 
     def __on_object_create(self, source: bytes, instruction: ObjectInstruction):
         if not self._client_manager.has_client_id(instruction.objectUser):
-            logging.error(f"received object creation from {source!r} for unknown client {instruction.objectUser!r}")
+            logger.error(f"received object creation from {source!r} for unknown client {instruction.objectUser!r}")
             return
 
         for object_id, object_type, object_name in zip(
@@ -141,5 +143,5 @@ class VanillaObjectController(ObjectController, Looper, Reporter):
             self.on_add_object(instruction.objectUser, object_id, object_type, object_name)
 
     def __finished_object_storage(self, creation: _ObjectCreation):
-        logging.debug(f"del object cache object_name={creation.object_name!r}, object_id={creation.object_id!r}")
+        logger.debug(f"del object cache object_name={creation.object_name!r}, object_id={creation.object_id!r}")
         self._queue_deleted_object_ids.put_nowait(creation.object_id)

--- a/src/scaler/scheduler/controllers/policies/simple_policy/allocation/capability_allocate_policy.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/allocation/capability_allocate_policy.py
@@ -11,6 +11,8 @@ from scaler.protocol.capnp import Task
 from scaler.scheduler.controllers.policies.simple_policy.allocation.mixins import TaskAllocatePolicy
 from scaler.utility.identifiers import TaskID, WorkerID
 
+logger = logging.getLogger(__name__)
+
 
 @dataclasses.dataclass(frozen=True)
 class _TaskHolder:
@@ -52,7 +54,7 @@ class CapabilityAllocatePolicy(TaskAllocatePolicy):
 
     def add_worker(self, worker: WorkerID, capabilities: Dict[str, int], queue_size: int) -> bool:
         if any(capability_value != -1 for capability_value in capabilities.values()):
-            logging.warning(f"allocate policy ignores non-infinite worker capabilities: {capabilities!r}.")
+            logger.warning(f"allocate policy ignores non-infinite worker capabilities: {capabilities!r}.")
 
         if worker in self._worker_id_to_worker:
             return False

--- a/src/scaler/scheduler/controllers/policies/simple_policy/allocation/even_load_allocate_policy.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/allocation/even_load_allocate_policy.py
@@ -8,6 +8,8 @@ from scaler.utility.identifiers import TaskID, WorkerID
 from scaler.utility.queues.async_priority_queue import AsyncPriorityQueue
 from scaler.utility.queues.indexed_queue import IndexedQueue
 
+logger = logging.getLogger(__name__)
+
 
 class EvenLoadAllocatePolicy(TaskAllocatePolicy):
     """This Allocator policy is trying to make all workers load as equal as possible"""
@@ -25,7 +27,7 @@ class EvenLoadAllocatePolicy(TaskAllocatePolicy):
             return False
 
         if len(capabilities) > 0:
-            logging.warning(f"allocate policy ignores worker capabilities: {capabilities!r}.")
+            logger.warning(f"allocate policy ignores worker capabilities: {capabilities!r}.")
 
         self._workers_to_task_ids[worker] = IndexedQueue()
         self._workers_to_queue_size[worker] = queue_size
@@ -112,7 +114,7 @@ class EvenLoadAllocatePolicy(TaskAllocatePolicy):
 
     def assign_task(self, task: Task) -> WorkerID:
         if len(task.capabilities) > 0:
-            logging.warning(f"allocate policy ignores task capabilities: {task.capabilities!r}.")
+            logger.warning(f"allocate policy ignores task capabilities: {task.capabilities!r}.")
 
         task_id = task.taskId
 

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -14,6 +14,8 @@ from scaler.scheduler.controllers.worker_manager_utilties import (
 from scaler.utility.identifiers import WorkerID
 from scaler.utility.snapshot import InformationSnapshot
 
+logger = logging.getLogger(__name__)
+
 
 class WaterfallScalingPolicy(ScalingPolicy):
     """
@@ -45,7 +47,7 @@ class WaterfallScalingPolicy(ScalingPolicy):
         rule = self._find_rule(manager_id)
 
         if rule is None:
-            logging.warning("Worker manager %r not found in waterfall rules, skipping scaling", manager_id)
+            logger.warning("Worker manager %r not found in waterfall rules, skipping scaling", manager_id)
             return []
 
         desired_per_capset = self._compute_desired_per_capset(

--- a/src/scaler/scheduler/controllers/task_controller.py
+++ b/src/scaler/scheduler/controllers/task_controller.py
@@ -30,6 +30,8 @@ from scaler.scheduler.task.task_state_manager import TaskStateManager
 from scaler.utility.identifiers import ClientID, TaskID, WorkerID
 from scaler.utility.mixins import Looper, Reporter
 
+logger = logging.getLogger(__name__)
+
 
 class VanillaTaskController(TaskController, Looper, Reporter):
     def __init__(self, config_controller: VanillaConfigController):
@@ -95,7 +97,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
     async def on_task_new(self, task: Task):
         task.capabilities = capabilities_to_dict(task.capabilities)
         if self._task_state_manager.get_state_machine(task.taskId) is not None:
-            logging.error(
+            logger.error(
                 f"{task.taskId!r}: state machine already exists: "
                 f"{self._task_state_manager.get_state_machine(task.taskId)}"
             )
@@ -107,7 +109,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
     async def on_task_cancel(self, client_id: ClientID, task_cancel: TaskCancel):
         state_machine = self._task_state_manager.get_state_machine(task_cancel.taskId)
         if state_machine is None:
-            logging.error(f"{task_cancel.taskId!r}: task not exists while received TaskCancel, send TaskCancelConfirm")
+            logger.error(f"{task_cancel.taskId!r}: task not exists while received TaskCancel, send TaskCancelConfirm")
 
             task_cancel_confirm = TaskCancelConfirm(
                 taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelNotFound
@@ -142,7 +144,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
 
         state_machine = self._task_state_manager.get_state_machine(task_cancel_confirm.taskId)
         if state_machine is None:
-            logging.error(
+            logger.error(
                 f"{task_cancel_confirm.taskId!r}: task not exists while received TaskCancelTaskCancelConfirm, ignore"
             )
             return
@@ -313,7 +315,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
         worker = await self._worker_controller.on_task_cancel(task_cancel)
         assert isinstance(worker, WorkerID)
         if not worker.is_valid():
-            logging.error(f"{task_cancel.taskId!r}: cannot find task in worker to cancel")
+            logger.error(f"{task_cancel.taskId!r}: cannot find task in worker to cancel")
             await self.__routing(
                 task_cancel.taskId,
                 TaskTransition.taskCancelConfirmNotFound,
@@ -387,13 +389,13 @@ class VanillaTaskController(TaskController, Looper, Reporter):
     async def __routing(self, task_id: TaskID, transition: TaskTransition, **kwargs):
         state_machine = self._task_state_manager.on_transition(task_id, transition)
         if state_machine is None:
-            logging.info(f"{task_id!r}: unknown transition: {transition}")
+            logger.info(f"{task_id!r}: unknown transition: {transition}")
             return
 
         try:
             await self._state_functions[state_machine.current_state()](task_id, state_machine, **kwargs)  # noqa
         except Exception as e:
-            logging.exception(
+            logger.exception(
                 f"{task_id!r}: exception happened, transition: {transition} path: {state_machine.get_path()}"
             )
             raise e

--- a/src/scaler/scheduler/controllers/worker_controller.py
+++ b/src/scaler/scheduler/controllers/worker_controller.py
@@ -25,6 +25,8 @@ from scaler.scheduler.controllers.mixins import PolicyController, TaskController
 from scaler.utility.identifiers import ClientID, TaskID, WorkerID
 from scaler.utility.mixins import Looper, Reporter
 
+logger = logging.getLogger(__name__)
+
 UINT8_MAX = 2**8 - 1
 
 
@@ -52,21 +54,21 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
     async def on_task_cancel(self, task_cancel: TaskCancel) -> WorkerID:
         worker = self._policy_controller.remove_task(task_cancel.taskId)
         if not worker.is_valid():
-            logging.error(f"cannot find task_id={task_cancel.taskId.hex()} in task workers")
+            logger.error(f"cannot find task_id={task_cancel.taskId.hex()} in task workers")
 
         return worker
 
     async def on_task_done(self, task_id: TaskID) -> WorkerID:
         worker = self._policy_controller.remove_task(task_id)
         if not worker.is_valid():
-            logging.error(f"Cannot find task in worker queue: task_id={task_id.hex()}")
+            logger.error(f"Cannot find task in worker queue: task_id={task_id.hex()}")
 
         return worker
 
     async def on_heartbeat(self, worker_id: WorkerID, info: WorkerHeartbeat):
         info.capabilities = capabilities_to_dict(info.capabilities)
         if self._policy_controller.add_worker(worker_id, info.capabilities, info.queueSize):
-            logging.info(f"worker {worker_id!r} connected")
+            logger.info(f"worker {worker_id!r} connected")
             await self._binder_monitor.send(
                 StateWorker(
                     workerId=worker_id,
@@ -177,7 +179,7 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
         if worker_id not in self._worker_alive_since:
             return
 
-        logging.info(f"{worker_id!r} disconnected")
+        logger.info(f"{worker_id!r} disconnected")
         await self._binder_monitor.send(
             StateWorker(workerId=worker_id, state=WorkerState.disconnected, capabilities=[])
         )
@@ -192,7 +194,7 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
         if not task_ids:
             return
 
-        logging.info(f"{len(task_ids)} task(s) failed due to worker {worker_id!r} disconnected")
+        logger.info(f"{len(task_ids)} task(s) failed due to worker {worker_id!r} disconnected")
         for task_id in task_ids:
             await self._task_controller.on_worker_disconnect(task_id, worker_id)
 

--- a/src/scaler/scheduler/controllers/worker_manager_controller.py
+++ b/src/scaler/scheduler/controllers/worker_manager_controller.py
@@ -19,6 +19,8 @@ from scaler.utility.identifiers import WorkerID
 from scaler.utility.mixins import Looper, Reporter
 from scaler.utility.snapshot import InformationSnapshot
 
+logger = logging.getLogger(__name__)
+
 
 class WorkerManagerController(Looper, Reporter):
     def __init__(self, config_controller: VanillaConfigController, policy_controller: PolicyController):
@@ -50,14 +52,14 @@ class WorkerManagerController(Looper, Reporter):
             manager_id = heartbeat.workerManagerID
             existing_source = self._manager_id_to_source.get(manager_id)
             if existing_source is not None and existing_source != source:
-                logging.warning(
+                logger.warning(
                     f"Duplicate worker_manager_id {manager_id!r}: source {source!r} rejected, "
                     f"already registered by source {existing_source!r}"
                 )
                 return
             self._manager_id_to_source[manager_id] = source
 
-            logging.info(f"WorkerManager {manager_id!r} connected")
+            logger.info(f"WorkerManager {manager_id!r} connected")
 
         self._manager_alive_since[source] = (time.time(), heartbeat)
 
@@ -159,7 +161,7 @@ class WorkerManagerController(Looper, Reporter):
         manager_id = heartbeat.workerManagerID
         self._manager_id_to_source.pop(manager_id, None)
 
-        logging.info(f"WorkerManager {source!r} disconnected")
+        logger.info(f"WorkerManager {source!r} disconnected")
         self._manager_alive_since.pop(source)
         self._last_desired_total.pop(source, None)
 

--- a/src/scaler/scheduler/scheduler.py
+++ b/src/scaler/scheduler/scheduler.py
@@ -38,6 +38,8 @@ from scaler.utility.event_loop import create_async_loop_routine
 from scaler.utility.exceptions import ClientShutdownException, ObjectStorageException
 from scaler.utility.identifiers import ClientID, WorkerID
 
+logger = logging.getLogger(__name__)
+
 
 class Scheduler:
     def __init__(self, config: SchedulerConfig):
@@ -126,20 +128,20 @@ class Scheduler:
         assert self._address is not None
         self._config_controller.update_config("bind_address", self._address)
 
-        logging.info(f"{self.__class__.__name__}: listen to scheduler address {self._address}")
+        logger.info(f"{self.__class__.__name__}: listen to scheduler address {self._address}")
 
         # Object storage
 
         await self._connector_storage.connect(self._config_controller.get_config("object_storage_address"))
         object_storage_address = self._connector_storage.address
 
-        logging.info(f"{self.__class__.__name__}: connected to object storage server {object_storage_address!r}")
+        logger.info(f"{self.__class__.__name__}: connected to object storage server {object_storage_address!r}")
 
         advertised_object_storage_address = (
             self._config_controller.get_config("advertised_object_storage_address") or object_storage_address
         )
 
-        logging.info(
+        logger.info(
             f"{self.__class__.__name__}: advertise object storage address {advertised_object_storage_address!r}"
         )
 
@@ -161,7 +163,7 @@ class Scheduler:
         assert monitor_address is not None
         self._config_controller.update_config("monitor_address", monitor_address)
 
-        logging.info(f"{self.__class__.__name__}: listen to scheduler monitor address {monitor_address!r}")
+        logger.info(f"{self.__class__.__name__}: listen to scheduler monitor address {monitor_address!r}")
 
     async def on_receive_message(self, source: bytes, message: BaseMessage):
         # Any inbound message from a tracked client refreshes its liveness
@@ -246,7 +248,7 @@ class Scheduler:
             await self._worker_manager_controller.on_heartbeat(source, message)
             return
 
-        logging.error(f"{self.__class__.__name__}: unknown message from {source=}: {message}")
+        logger.error(f"{self.__class__.__name__}: unknown message from {source=}: {message}")
 
     async def get_loops(self):
         await self.__initialize_network()
@@ -270,7 +272,7 @@ class Scheduler:
         except asyncio.CancelledError:
             pass
         except ClientShutdownException as e:
-            logging.info(f"{self.__class__.__name__}: {e}")
+            logger.info(f"{self.__class__.__name__}: {e}")
             pass
         except YMQException:
             pass

--- a/src/scaler/scheduler/task/task_state_manager.py
+++ b/src/scaler/scheduler/task/task_state_manager.py
@@ -5,6 +5,8 @@ from scaler.protocol.capnp import TaskState, TaskTransition
 from scaler.scheduler.task.task_state_machine import TaskStateMachine
 from scaler.utility.identifiers import TaskID
 
+logger = logging.getLogger(__name__)
+
 
 class TaskStateManager:
     TASK_STATES = (
@@ -51,7 +53,7 @@ class TaskStateManager:
 
         task_state_machine = self._task_id_to_state_machine.get(task_id, None)
         if task_state_machine is None:
-            logging.error(f"{task_id!r}: unknown {transition=} for non-existed state machine")
+            logger.error(f"{task_id!r}: unknown {transition=} for non-existed state machine")
             return None
 
         transit_success = task_state_machine.on_transition(transition)
@@ -59,7 +61,7 @@ class TaskStateManager:
             self._statistics[task_state_machine.previous_state()] -= 1
             self._statistics[task_state_machine.current_state()] += 1
         else:
-            logging.error(
+            logger.error(
                 f"{task_id!r}: cannot apply {transition} to current state" f" {task_state_machine.current_state()}"
             )
 

--- a/src/scaler/ui/webgui.py
+++ b/src/scaler/ui/webgui.py
@@ -8,7 +8,9 @@ from scaler.utility.logging.utility import setup_logger
 
 
 def start_webgui(config: WebGUIConfig) -> None:
-    setup_logger(config.logging_config.paths, config.logging_config.config_file, config.logging_config.level)
+    setup_logger(
+        config.logging_config.paths, config.logging_config.config_file, config.logging_config.level, process_name="gui"
+    )
 
     app = create_app(config)
     logging.info(f"Web GUI is now listening on: http://{config.gui_address}")

--- a/src/scaler/ui/webgui.py
+++ b/src/scaler/ui/webgui.py
@@ -6,6 +6,8 @@ from scaler.config.section.webgui import WebGUIConfig
 from scaler.ui.app import create_app
 from scaler.utility.logging.utility import setup_logger
 
+logger = logging.getLogger(__name__)
+
 
 def start_webgui(config: WebGUIConfig) -> None:
     setup_logger(
@@ -13,5 +15,5 @@ def start_webgui(config: WebGUIConfig) -> None:
     )
 
     app = create_app(config)
-    logging.info(f"Web GUI is now listening on: http://{config.gui_address}")
+    logger.info(f"Web GUI is now listening on: http://{config.gui_address}")
     uvicorn.run(app, host=config.gui_address.host, port=config.gui_address.port)

--- a/src/scaler/utility/event_loop.py
+++ b/src/scaler/utility/event_loop.py
@@ -3,6 +3,8 @@ import enum
 import logging
 from typing import Awaitable, Callable, Optional
 
+logger = logging.getLogger(__name__)
+
 
 class EventLoopType(enum.Enum):
     builtin = enum.auto()
@@ -28,7 +30,7 @@ def register_event_loop(event_loop_type: str):
 
     assert event_loop_type in EventLoopType.allowed_types()
 
-    logging.info(f"use event loop: {event_loop_type}")
+    logger.info(f"use event loop: {event_loop_type}")
 
 
 def create_async_loop_routine(routine: Callable[[], Awaitable], seconds: int):
@@ -40,10 +42,10 @@ def create_async_loop_routine(routine: Callable[[], Awaitable], seconds: int):
 
     async def loop():
         if seconds < 0:
-            logging.info(f"{routine.__self__.__class__.__name__}: disabled")  # type: ignore[attr-defined]
+            logger.info(f"{routine.__self__.__class__.__name__}: disabled")  # type: ignore[attr-defined]
             return
 
-        logging.info(f"{routine.__self__.__class__.__name__}: started")  # type: ignore[attr-defined]
+        logger.info(f"{routine.__self__.__class__.__name__}: started")  # type: ignore[attr-defined]
         try:
             while True:
                 await routine()
@@ -53,7 +55,7 @@ def create_async_loop_routine(routine: Callable[[], Awaitable], seconds: int):
         except KeyboardInterrupt:
             pass
 
-        logging.info(f"{routine.__self__.__class__.__name__}: exited")  # type: ignore[attr-defined]
+        logger.info(f"{routine.__self__.__class__.__name__}: exited")  # type: ignore[attr-defined]
 
     return loop()
 

--- a/src/scaler/utility/graph/topological_sorter.py
+++ b/src/scaler/utility/graph/topological_sorter.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+logger = logging.getLogger(__name__)
 # python-graphblas's native Matrix.__del__ has been observed to corrupt the heap on Windows
 # (STATUS_HEAP_CORRUPTION 0xC0000374) when finalized during a GC cycle that fires on a
 # non-main thread (e.g. asyncio.gather scheduling inside ScalerClientAgent). Until that is
@@ -11,7 +12,7 @@ else:
     try:
         from scaler.utility.graph.topological_sorter_graphblas import TopologicalSorter
 
-        logging.info("using GraphBLAS for calculate graph")
+        logger.info("using GraphBLAS for calculate graph")
     except ImportError as e:
         assert isinstance(e, Exception)
         from graphlib import TopologicalSorter  # type: ignore[assignment, no-redef]

--- a/src/scaler/utility/logging/scoped_logger.py
+++ b/src/scaler/utility/logging/scoped_logger.py
@@ -3,6 +3,8 @@ import logging
 import time
 from typing import Optional
 
+logger = logging.getLogger(__name__)
+
 
 class ScopedLogger:
     def __init__(self, message: str, logging_level=logging.INFO):
@@ -23,11 +25,11 @@ class TimedLogger:
 
     def begin(self):
         self.timer = time.perf_counter_ns()
-        logging.log(self.logging_level, f"beginning {self.message}")
+        logger.log(self.logging_level, f"beginning {self.message}")
 
     def end(self):
         elapsed = time.perf_counter_ns() - self.timer
         offset = datetime.timedelta(
             seconds=int(elapsed / 1e9), milliseconds=int(elapsed % 1e9 / 1e6), microseconds=int(elapsed % 1e6 / 1e3)
         )
-        logging.log(self.logging_level, f"completed {self.message} in {offset}")
+        logger.log(self.logging_level, f"completed {self.message} in {offset}")

--- a/src/scaler/utility/logging/utility.py
+++ b/src/scaler/utility/logging/utility.py
@@ -8,6 +8,8 @@ import typing
 
 from scaler.config.defaults import DEFAULT_LOGGING_PATHS
 
+logger = logging.getLogger(__name__)
+
 
 class LogType(enum.Enum):
     Screen = enum.auto()
@@ -48,7 +50,7 @@ def setup_logger(
 
     resolved_log_paths = [LogPath(log_type=__detect_log_types(file_name), path=file_name) for file_name in log_paths]
     __logging_config(log_paths=resolved_log_paths, logging_level=logging_level, process_name=process_name)
-    logging.info(f"logging to {log_paths}")
+    logger.info(f"logging to {log_paths}")
 
 
 def __detect_log_types(file_name: str) -> LogType:
@@ -71,7 +73,10 @@ def __generate_log_config(process_name: str) -> typing.Dict:
             "verbose": {"format": verbose_format, "datefmt": "%Y-%m-%d %H:%M:%S%z"},
         },
         "handlers": {},
-        "loggers": {"": {"handlers": [], "level": "DEBUG", "propagate": True}},
+        # Configure only the "scaler" logger so we do not mutate the host
+        # application's root logger (library-safety). propagate=False prevents
+        # our handlers from re-emitting through any root handler the host set up.
+        "loggers": {"scaler": {"handlers": [], "level": "DEBUG", "propagate": False}},
     }
 
 
@@ -86,17 +91,17 @@ def __logging_config(
 
     config = __generate_log_config(process_name)
     handlers = config["handlers"]
-    root_loggers = config["loggers"][""]["handlers"]
+    scaler_handlers = config["loggers"]["scaler"]["handlers"]
 
     for log_path in log_paths:
         if log_path.log_type == LogType.Screen:
             handlers["console"] = __create_stdout_handler(logging_level)
-            root_loggers.append("console")
+            scaler_handlers.append("console")
             continue
 
         elif log_path.log_type == LogType.File:
             handlers[log_path.path] = __create_time_rotating_file_handler(logging_level, log_path.path)
-            root_loggers.append(log_path.path)
+            scaler_handlers.append(log_path.path)
             continue
 
         raise TypeError(f"Unsupported LogPath: {log_path}")

--- a/src/scaler/utility/logging/utility.py
+++ b/src/scaler/utility/logging/utility.py
@@ -33,6 +33,7 @@ def setup_logger(
     log_paths: typing.Tuple[str, ...] = DEFAULT_LOGGING_PATHS,
     logging_config_file: typing.Optional[str] = None,
     logging_level: str = LoggingLevel.INFO.name,
+    process_name: str = "scaler",
 ):
     if not log_paths and not logging_config_file:
         return
@@ -46,7 +47,7 @@ def setup_logger(
         return
 
     resolved_log_paths = [LogPath(log_type=__detect_log_types(file_name), path=file_name) for file_name in log_paths]
-    __logging_config(log_paths=resolved_log_paths, logging_level=logging_level)
+    __logging_config(log_paths=resolved_log_paths, logging_level=logging_level, process_name=process_name)
     logging.info(f"logging to {log_paths}")
 
 
@@ -57,49 +58,33 @@ def __detect_log_types(file_name: str) -> LogType:
     return LogType.File
 
 
-def __format(name) -> str:
-    if not name:
-        return ""
-
-    return "%({name})s".format(name=name)
-
-
-def __generate_log_config() -> typing.Dict:
+def __generate_log_config(process_name: str) -> typing.Dict:
+    standard_format = f"%(asctime)s %(levelname)s {process_name}[%(process)d]: %(message)s"
+    verbose_format = (
+        f"%(asctime)s %(levelname)s {process_name}[%(process)d] " f"%(name)s:%(funcName)s:%(lineno)s: %(message)s"
+    )
     return {
         "version": 1,
         "disable_existing_loggers": False,  # this fixes the problem
         "formatters": {
-            "standard": {
-                "format": "[{levelname}]{asctime}: {message}".format(
-                    levelname=__format("levelname"), asctime=__format("asctime"), message=__format("message")
-                ),
-                "datefmt": "%Y-%m-%d %H:%M:%S%z",
-            },
-            "verbose": {
-                "format": "[{levelname}]{asctime}:{module}:{funcName}:{lineno}: {message}".format(
-                    levelname=__format("levelname"),
-                    asctime=__format("asctime"),
-                    module=__format("module"),
-                    funcName=__format("funcName"),
-                    lineno=__format("lineno"),
-                    message=__format("message"),
-                ),
-                "datefmt": "%Y-%m-%d %H:%M:%S%z",
-            },
+            "standard": {"format": standard_format, "datefmt": "%Y-%m-%d %H:%M:%S%z"},
+            "verbose": {"format": verbose_format, "datefmt": "%Y-%m-%d %H:%M:%S%z"},
         },
         "handlers": {},
         "loggers": {"": {"handlers": [], "level": "DEBUG", "propagate": True}},
     }
 
 
-def __logging_config(log_paths: typing.List[LogPath], logging_level: str = LoggingLevel.INFO.name):
+def __logging_config(
+    log_paths: typing.List[LogPath], logging_level: str = LoggingLevel.INFO.name, process_name: str = "scaler"
+):
     logging.addLevelName(logging.INFO, "INFO")
     logging.addLevelName(logging.WARNING, "WARN")
     logging.addLevelName(logging.ERROR, "EROR")
     logging.addLevelName(logging.DEBUG, "DEBG")
     logging.addLevelName(logging.CRITICAL, "CTIC")
 
-    config = __generate_log_config()
+    config = __generate_log_config(process_name)
     handlers = config["handlers"]
     root_loggers = config["loggers"][""]["handlers"]
 

--- a/src/scaler/worker/agent/processor/object_cache.py
+++ b/src/scaler/worker/agent/processor/object_cache.py
@@ -16,6 +16,8 @@ from scaler.config.defaults import CLEANUP_INTERVAL_SECONDS
 from scaler.utility.exceptions import DeserializeObjectError
 from scaler.utility.identifiers import ClientID, ObjectID
 
+logger = logging.getLogger(__name__)
+
 
 class ObjectCache(threading.Thread):
     def __init__(self, garbage_collect_interval_seconds: int, trim_memory_threshold_bytes: int):
@@ -67,7 +69,7 @@ class ObjectCache(threading.Thread):
             try:
                 deserialized: Any = self.deserialize(client, object_bytes)
             except Exception as exc:  # noqa: BLE001
-                logging.exception(f"failed to deserialize received {object_id!r}, length={len(object_bytes)}")
+                logger.exception(f"failed to deserialize received {object_id!r}, length={len(object_bytes)}")
                 deserialized = DeserializeObjectError(
                     f"failed to deserialize {object_id!r}: {type(exc).__name__}: {exc}"
                 )

--- a/src/scaler/worker/agent/processor/processor.py
+++ b/src/scaler/worker/agent/processor/processor.py
@@ -36,6 +36,8 @@ from scaler.worker.agent.processor.object_cache import ObjectCache
 from scaler.worker.agent.processor.streaming_buffer import StreamingBuffer
 from scaler.worker.preload import execute_preload
 
+logger = logging.getLogger(__name__)
+
 SUSPEND_SIGNAL = "SIGUSR1"  # use str instead of a signal.Signal to not trigger an import error on unsupported systems.
 
 _current_processor: ContextVar[Optional["Processor"]] = ContextVar("_current_processor", default=None)
@@ -120,7 +122,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
             identity=self._identity, connector_remote_type=ConnectorRemoteType.Binder, address=self._agent_address
         )
 
-        logging.info(f"Processor[{self.pid}] connecting to object storage at {self._object_storage_address}...")
+        logger.info(f"Processor[{self.pid}] connecting to object storage at {self._object_storage_address}...")
         self._connector_storage: SyncObjectStorageConnector = self._backend.create_sync_object_storage_connector(
             identity=self._identity, address=self._object_storage_address
         )
@@ -216,7 +218,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
             if self.__is_closed_zmq_socket_exception(e):
                 return
 
-            logging.exception(f"Processor[{self.pid}]: failed with unhandled exception:\n{e}")
+            logger.exception(f"Processor[{self.pid}]: failed with unhandled exception:\n{e}")
 
         finally:
             # Wake the suspend listener (if running on Windows) and let it exit before the connectors go away,
@@ -243,7 +245,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
             self.__on_received_task(message)
             return
 
-        logging.error(f"unknown {message=}")
+        logger.error(f"unknown {message=}")
 
     def __on_receive_object_instruction(self, instruction: ObjectInstruction):
         if instruction.instructionType == ObjectInstruction.ObjectInstructionType.delete:
@@ -251,7 +253,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
                 self._object_cache.del_object(object_id)
             return
 
-        logging.error(f"worker received unknown object instruction type {instruction=}")
+        logger.error(f"worker received unknown object instruction type {instruction=}")
 
     def __on_received_task(self, task: Task):
         self._current_task = task
@@ -305,7 +307,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
             task_result_type = TaskResultType.success
 
         except Exception as e:
-            logging.exception(f"exception when processing task_id={task.taskId.hex()}:")
+            logger.exception(f"exception when processing task_id={task.taskId.hex()}:")
             task_result_type = TaskResultType.failed
             result_bytes = serialize_failure(e)
 

--- a/src/scaler/worker/agent/processor/streaming_buffer.py
+++ b/src/scaler/worker/agent/processor/streaming_buffer.py
@@ -5,6 +5,8 @@ from scaler.io.mixins import SyncConnector
 from scaler.protocol.capnp import TaskLog
 from scaler.utility.identifiers import TaskID
 
+logger = logging.getLogger(__name__)
+
 
 class StreamingBuffer(io.TextIOBase):
     """A custom IO buffer that sends content as it's written."""
@@ -23,6 +25,6 @@ class StreamingBuffer(io.TextIOBase):
             try:
                 self._connector_agent.send(TaskLog(taskId=self._task_id, logType=self._log_type, content=content))
             except Exception as e:
-                logging.warning(f"Failed to send stream content: {e}")
+                logger.warning(f"Failed to send stream content: {e}")
 
         return 0

--- a/src/scaler/worker/agent/processor_holder.py
+++ b/src/scaler/worker/agent/processor_holder.py
@@ -13,6 +13,8 @@ from scaler.protocol.capnp import Task
 from scaler.utility.identifiers import ProcessorID
 from scaler.worker.agent.processor.processor import Processor
 
+logger = logging.getLogger(__name__)
+
 
 class ProcessorHolder:
     def __init__(
@@ -157,7 +159,7 @@ class ProcessorHolder:
             # TODO: some processors fail to interrupt because of a blocking 0mq call. Ideally we should interrupt
             # these blocking calls instead of sending a SIGKILL signal.
 
-            logging.warning(f"Processor[{self.pid()}] does not terminate in time, send SIGKILL.")
+            logger.warning(f"Processor[{self.pid()}] does not terminate in time, send SIGKILL.")
             try:
                 self._process.kill()
             except psutil.NoSuchProcess:

--- a/src/scaler/worker/agent/processor_manager.py
+++ b/src/scaler/worker/agent/processor_manager.py
@@ -22,6 +22,8 @@ from scaler.utility.serialization import serialize_failure
 from scaler.worker.agent.mixins import HeartbeatManager, ProcessorManager, ProfilingManager, TaskManager
 from scaler.worker.agent.processor_holder import ProcessorHolder
 
+logger = logging.getLogger(__name__)
+
 
 class VanillaProcessorManager(ProcessorManager):
     def __init__(
@@ -204,7 +206,7 @@ class VanillaProcessorManager(ProcessorManager):
         holder.suspend()
         self._suspended_holders_by_task_id[task_id] = holder
 
-        logging.info(f"{self._identity!r}: suspend Processor[{holder.pid()}]")
+        logger.info(f"{self._identity!r}: suspend Processor[{holder.pid()}]")
 
         self.__start_new_processor()
 
@@ -227,7 +229,7 @@ class VanillaProcessorManager(ProcessorManager):
         self._current_holder = suspended_holder
         suspended_holder.resume()
 
-        logging.info(f"{self._identity!r}: resume Processor[{self._current_holder.pid()}]")
+        logger.info(f"{self._identity!r}: resume Processor[{self._current_holder.pid()}]")
 
         return True
 
@@ -333,7 +335,7 @@ class VanillaProcessorManager(ProcessorManager):
 
         self._profiling_manager.on_process_start(processor_pid)
 
-        logging.info(f"{self._identity!r}: start Processor[{processor_pid}]")
+        logger.info(f"{self._identity!r}: start Processor[{processor_pid}]")
 
     def __kill_processor(self, reason: str, holder: ProcessorHolder):
         processor_pid = holder.pid()
@@ -345,7 +347,7 @@ class VanillaProcessorManager(ProcessorManager):
 
         holder.kill()
 
-        logging.info(f"{self._identity!r}: stop Processor[{processor_pid}], reason: {reason}")
+        logger.info(f"{self._identity!r}: stop Processor[{processor_pid}], reason: {reason}")
 
     def __restart_current_processor(self, reason: str):
         assert self._current_holder is not None

--- a/src/scaler/worker/agent/profiling_manager.py
+++ b/src/scaler/worker/agent/profiling_manager.py
@@ -10,6 +10,8 @@ from scaler.utility.metadata.profile_result import ProfileResult
 from scaler.utility.mixins import Looper
 from scaler.worker.agent.mixins import ProfilingManager
 
+logger = logging.getLogger(__name__)
+
 
 @dataclasses.dataclass
 class _ProcessProfiler:
@@ -76,7 +78,7 @@ class VanillaProfilingManager(ProfilingManager, Looper):
         except (psutil.ZombieProcess, psutil.NoSuchProcess):
             # Linux reports dead-but-not-yet-reaped processes as zombies; Windows raises NoSuchProcess
             # immediately because there is no zombie state.
-            logging.warning(f"profiling missing process: {pid=}")
+            logger.warning(f"profiling missing process: {pid=}")
             cpu_time_delta = 0
 
         memory_delta = process_profiler.peak_memory_rss - process_profiler.init_memory_rss
@@ -95,7 +97,7 @@ class VanillaProfilingManager(ProfilingManager, Looper):
                         process_profiler.peak_memory_rss, self.__process_memory_rss(process_profiler.process)
                     )
                 except (psutil.ZombieProcess, psutil.NoSuchProcess):
-                    logging.warning(f"profiling missing process: pid={process_profiler.process.pid}")
+                    logger.warning(f"profiling missing process: pid={process_profiler.process.pid}")
 
     @staticmethod
     def __process_time():

--- a/src/scaler/worker/preload.py
+++ b/src/scaler/worker/preload.py
@@ -5,6 +5,8 @@ import os
 import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
+logger = logging.getLogger(__name__)
+
 
 class PreloadSpecError(Exception):
     pass
@@ -17,7 +19,7 @@ def execute_preload(spec: str) -> None:
     Example: 'foo.bar:preload_function("a", 2)'
     """
     module_path, func_name, args, kwargs = _parse_preload_spec(spec)
-    logging.info("preloading: %s:%s with args=%s kwargs=%s", module_path, func_name, args, kwargs)
+    logger.info("preloading: %s:%s with args=%s kwargs=%s", module_path, func_name, args, kwargs)
 
     try:
         module = importlib.import_module(module_path)
@@ -31,7 +33,7 @@ def execute_preload(spec: str) -> None:
     try:
         target = getattr(module, func_name)
     except AttributeError:
-        logging.exception(f"Failed to find attribute {func_name!r} in {module_path!r}.")
+        logger.exception(f"Failed to find attribute {func_name!r} in {module_path!r}.")
         raise PreloadSpecError(f"Failed to find attribute {func_name!r} in {module_path!r}.")
 
     if not callable(target):

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -40,6 +40,8 @@ from scaler.worker.agent.profiling_manager import VanillaProfilingManager
 from scaler.worker.agent.task_manager import VanillaTaskManager
 from scaler.worker.agent.timeout_manager import VanillaTimeoutManager
 
+logger = logging.getLogger(__name__)
+
 
 class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
     def __init__(
@@ -204,11 +206,11 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
         if isinstance(message, ClientDisconnect):
             if message.disconnectType == ClientDisconnect.DisconnectType.shutdown:
                 raise ClientShutdownException("received client shutdown, quitting")
-            logging.error(f"Worker received invalid ClientDisconnect type, ignoring {message=}")
+            logger.error(f"Worker received invalid ClientDisconnect type, ignoring {message=}")
             return
 
         if isinstance(message, DisconnectResponse):
-            logging.error("Worker initiated DisconnectRequest got replied")
+            logger.error("Worker initiated DisconnectRequest got replied")
             self._task.cancel()
             return
 
@@ -269,11 +271,11 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
             if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
                 pass
             else:
-                logging.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+                logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
         except (ClientShutdownException, TimeoutError) as e:
-            logging.info(f"{self.identity!r}: {str(e)}")
+            logger.info(f"{self.identity!r}: {str(e)}")
         except Exception as e:
-            logging.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+            logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
 
         if isinstance(self._backend, ZMQNetworkBackend):
             await self.__graceful_shutdown()
@@ -289,7 +291,7 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
             # Windows named pipes have no filesystem entry to remove; only unlink Unix-domain-socket paths.
             pathlib.Path(self._address_internal.host).unlink(missing_ok=True)
 
-        logging.info(f"{self.identity!r}: quit")
+        logger.info(f"{self.identity!r}: quit")
 
     def __register_signal(self):
         if isinstance(self._backend, ZMQNetworkBackend):

--- a/src/scaler/worker_manager_adapter/aws_hpc/callback.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/callback.py
@@ -10,6 +10,8 @@ import logging
 import threading
 from typing import Any, Dict, List, Optional
 
+logger = logging.getLogger(__name__)
+
 
 class BatchJobCallback:
     """
@@ -36,12 +38,12 @@ class BatchJobCallback:
         with self._callback_lock:
             task_id = self._batch_job_id_to_task_id.get(batch_job_id)
             if task_id is None:
-                logging.warning(f"Received result for unknown batch job: {batch_job_id}")
+                logger.warning(f"Received result for unknown batch job: {batch_job_id}")
                 return
 
             future = self._task_id_to_future.pop(task_id, None)
             if future is None:
-                logging.warning(f"No future found for task: {task_id}")
+                logger.warning(f"No future found for task: {task_id}")
                 return
 
             self._cleanup_job_mapping(task_id, batch_job_id)
@@ -60,12 +62,12 @@ class BatchJobCallback:
         with self._callback_lock:
             task_id = self._batch_job_id_to_task_id.get(batch_job_id)
             if task_id is None:
-                logging.warning(f"Received failure for unknown batch job: {batch_job_id}")
+                logger.warning(f"Received failure for unknown batch job: {batch_job_id}")
                 return
 
             future = self._task_id_to_future.pop(task_id, None)
             if future is None:
-                logging.warning(f"No future found for task: {task_id}")
+                logger.warning(f"No future found for task: {task_id}")
                 return
 
             self._cleanup_job_mapping(task_id, batch_job_id)

--- a/src/scaler/worker_manager_adapter/aws_hpc/task_manager.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/task_manager.py
@@ -17,6 +17,8 @@ from scaler.protocol.capnp import Task, TaskCancel
 from scaler.utility.identifiers import TaskID
 from scaler.worker_manager_adapter.mixins import ExecutionBackend, TaskDeserializer, TaskInputLoader
 
+logger = logging.getLogger(__name__)
+
 ARRAY_JOB_BATCH_WINDOW_SECONDS: float = 0.5
 ARRAY_JOB_MIN_BATCH_SIZE: int = 2
 ARRAY_JOB_MAX_BATCH_SIZE: int = 10000
@@ -64,7 +66,7 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
         session = boto3.Session(region_name=self._aws_region)
         self._batch_client = session.client("batch")
         self._s3_client = session.client("s3")
-        logging.info(f"AWS HPC task manager initialized: region={self._aws_region}, queue={self._job_queue}")
+        logger.info(f"AWS HPC task manager initialized: region={self._aws_region}, queue={self._job_queue}")
 
     async def routine(self) -> None:
         """Flush pending batch when the collection window has expired."""
@@ -119,10 +121,10 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
                 single_future = futures_map[single_task.taskId]
                 batch_job_id = await self._submit_single_batch_job(single_task, single_func, single_args)
                 self._task_id_to_batch_job_id[single_task.taskId] = batch_job_id
-                logging.info(f"Task {single_task.taskId.hex()[:8]} submitted as Batch job {batch_job_id}")
+                logger.info(f"Task {single_task.taskId.hex()[:8]} submitted as Batch job {batch_job_id}")
                 asyncio.create_task(self._monitor_batch_job(batch_job_id, single_future, single_task.taskId))
         except Exception as e:
-            logging.exception(f"Failed to submit batch of {len(batch)} tasks: {e}")
+            logger.exception(f"Failed to submit batch of {len(batch)} tasks: {e}")
             for f in futures_map.values():
                 if not f.done():
                     f.set_exception(e)
@@ -188,14 +190,14 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
             response = await self._run_in_executor(self._batch_client.submit_job, **submit_kwargs)
         except ClientError as e:
             if "ExpiredToken" in str(e) or "expired" in str(e).lower():
-                logging.warning("AWS credentials expired, refreshing...")
+                logger.warning("AWS credentials expired, refreshing...")
                 self._initialize_aws_clients()
                 response = await self._run_in_executor(self._batch_client.submit_job, **submit_kwargs)
             else:
                 raise
 
         parent_job_id = response["jobId"]
-        logging.info(
+        logger.info(
             f"Submitted array job {parent_job_id} with {array_size} tasks "
             f"(s3://{self._s3_bucket}/{s3_prefix_array}/)"
         )
@@ -236,7 +238,7 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
                         status = job["status"]
                         task_id = index_to_task_id[index]
                         future = futures_map.get(task_id)
-                        logging.debug(f"Array child {child_id}: status={status}, index={index}")
+                        logger.debug(f"Array child {child_id}: status={status}, index={index}")
 
                         if future is None or future.done():
                             resolved.add(index)
@@ -285,7 +287,7 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
                             resolved.add(index)
 
             except Exception as e:
-                logging.exception(f"Error monitoring array job {parent_job_id}: {e}")
+                logger.exception(f"Error monitoring array job {parent_job_id}: {e}")
 
         try:
             for index in index_to_task_id:
@@ -293,7 +295,7 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
                     self._s3_client.delete_object, Bucket=self._s3_bucket, Key=f"{s3_prefix_array}/{index}.pkl"
                 )
         except Exception as e:
-            logging.warning(f"Failed to cleanup array payloads: {e}")
+            logger.warning(f"Failed to cleanup array payloads: {e}")
 
     async def _submit_single_batch_job(self, task: Task, function: Any, arguments: List[Any]) -> str:
         import base64
@@ -349,7 +351,7 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
             response = await self._run_in_executor(self._batch_client.submit_job, **submit_kwargs)
         except ClientError as e:
             if "ExpiredToken" in str(e) or "expired" in str(e).lower():
-                logging.warning("AWS credentials expired, refreshing...")
+                logger.warning("AWS credentials expired, refreshing...")
                 self._initialize_aws_clients()
                 response = await self._run_in_executor(self._batch_client.submit_job, **submit_kwargs)
             else:
@@ -413,17 +415,17 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
                 elif status in ("SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"):
                     continue
                 else:
-                    logging.warning(f"Unknown job status: {status}")
+                    logger.warning(f"Unknown job status: {status}")
 
             except Exception as e:
-                logging.exception(f"Error monitoring job {job_id}: {e}")
+                logger.exception(f"Error monitoring job {job_id}: {e}")
 
     async def _cancel_batch_job(self, job_id: str) -> None:
         try:
             await self._run_in_executor(self._batch_client.terminate_job, jobId=job_id, reason="Canceled by Scaler")
-            logging.info(f"Canceled Batch job {job_id}")
+            logger.info(f"Canceled Batch job {job_id}")
         except Exception as e:
-            logging.warning(f"Failed to cancel Batch job {job_id}: {e}")
+            logger.warning(f"Failed to cancel Batch job {job_id}: {e}")
 
     async def _fetch_job_logs(self, job_id: str) -> str:
         try:
@@ -473,5 +475,5 @@ class AWSBatchExecutionBackend(TaskInputLoader, ExecutionBackend):
                 return "Job debug info:\n" + "\n".join(debug_info) + f"\n\n(Log stream not found: {log_stream})"
 
         except Exception as e:
-            logging.warning(f"Failed to fetch logs for job {job_id}: {e}")
+            logger.warning(f"Failed to fetch logs for job {job_id}: {e}")
             return f"(Failed to fetch logs: {e})"

--- a/src/scaler/worker_manager_adapter/aws_hpc/utility/batch_job_runner.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/utility/batch_job_runner.py
@@ -21,13 +21,15 @@ import traceback
 import boto3
 import cloudpickle
 
+logger = logging.getLogger(__name__)
+
 COMPRESSION_THRESHOLD_BYTES: int = 4096
 
 
 def signal_handler(signum, frame):
     """Handle signals to log before crash."""
     sig_name = signal.Signals(signum).name
-    logging.error(f"Received signal {sig_name} ({signum})")
+    logger.error(f"Received signal {sig_name} ({signum})")
     sys.stdout.flush()
     sys.exit(128 + signum)
 
@@ -89,7 +91,7 @@ def get_payload(args: dict) -> bytes:
     array_index = os.environ.get("AWS_BATCH_JOB_ARRAY_INDEX")
     if s3_key and "ARRAY_INDEX" in s3_key and array_index is not None:
         s3_key = s3_key.replace("ARRAY_INDEX", array_index)
-        logging.info(f"Array job index {array_index}, resolved S3 key: {s3_key}")
+        logger.info(f"Array job index {array_index}, resolved S3 key: {s3_key}")
 
     # Try inline payload from job parameters
     if payload_b64:
@@ -113,7 +115,7 @@ def get_payload(args: dict) -> bytes:
     try:
         s3_client.delete_object(Bucket=s3_bucket, Key=s3_key)
     except Exception as e:
-        logging.warning(f"Failed to cleanup S3 input: {e}")
+        logger.warning(f"Failed to cleanup S3 input: {e}")
 
     return payload
 
@@ -133,7 +135,7 @@ def store_result(result: bytes, s3_bucket: str, s3_prefix: str, job_id: str):
     s3_client = boto3.client("s3")
     s3_client.put_object(Bucket=s3_bucket, Key=result_key, Body=result)
 
-    logging.info(f"Result stored to s3://{s3_bucket}/{result_key}")
+    logger.info(f"Result stored to s3://{s3_bucket}/{result_key}")
     return result_key
 
 
@@ -146,15 +148,15 @@ def main():
     s3_prefix = args.get("s3_prefix", "scaler-tasks")
     job_id = os.environ.get("AWS_BATCH_JOB_ID", task_id)
 
-    logging.info(f"Starting task {task_id[:8]}...")
-    logging.info(f"Args: task_id={task_id[:8]}, s3_bucket={s3_bucket}, s3_prefix={s3_prefix}")
+    logger.info(f"Starting task {task_id[:8]}...")
+    logger.info(f"Args: task_id={task_id[:8]}, s3_bucket={s3_bucket}, s3_prefix={s3_prefix}")
 
     try:
         # Get payload
         payload_bytes = get_payload(args)
         task_data = cloudpickle.loads(payload_bytes)
 
-        logging.info(f"Task data loaded, keys: {list(task_data.keys())}")
+        logger.info(f"Task data loaded, keys: {list(task_data.keys())}")
 
         # task_data contains:
         # - task_id: hex string
@@ -172,31 +174,31 @@ def main():
             func = task_data["function"]
             arguments = task_data["arguments"]
 
-            logging.info(f"Executing function with {len(arguments)} arguments")
+            logger.info(f"Executing function with {len(arguments)} arguments")
             sys.stdout.flush()
 
-            logging.info(f"Function type: {type(func)}, name: {getattr(func, '__name__', 'unknown')}")
-            logging.info(f"Arguments: {arguments}")
+            logger.info(f"Function type: {type(func)}, name: {getattr(func, '__name__', 'unknown')}")
+            logger.info(f"Arguments: {arguments}")
 
             # Log memory before execution
             try:
                 import resource  # type: ignore[import-not-found]
 
                 mem_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss  # type: ignore[attr-defined]
-                logging.info(f"Memory before execution: {mem_before} KB")
+                logger.info(f"Memory before execution: {mem_before} KB")
             except Exception:
                 pass
             sys.stdout.flush()
 
             try:
-                logging.info("Calling function now...")
+                logger.info("Calling function now...")
                 sys.stdout.flush()
                 result = func(*arguments)
                 sys.stdout.flush()
-                logging.info(f"Function completed, result type: {type(result).__name__}, value: {result}")
+                logger.info(f"Function completed, result type: {type(result).__name__}, value: {result}")
                 sys.stdout.flush()
             except Exception as func_error:
-                logging.error(f"Function execution failed: {func_error}")
+                logger.error(f"Function execution failed: {func_error}")
                 traceback.print_exc()
                 sys.stdout.flush()
                 raise
@@ -206,17 +208,17 @@ def main():
             raise ValueError("Task data missing 'function' and 'arguments' - reference mode not yet supported")
 
         # Serialize and store result
-        logging.info("Serializing result...")
+        logger.info("Serializing result...")
         result_bytes = cloudpickle.dumps(result)
-        logging.info(f"Result serialized, size: {len(result_bytes)} bytes")
+        logger.info(f"Result serialized, size: {len(result_bytes)} bytes")
 
-        logging.info("Storing result to S3...")
+        logger.info("Storing result to S3...")
         store_result(result_bytes, s3_bucket, s3_prefix, job_id)
 
-        logging.info(f"Task {task_id[:8]} completed successfully")
+        logger.info(f"Task {task_id[:8]} completed successfully")
 
     except Exception as e:
-        logging.error(f"Task {task_id[:8]} failed: {e}")
+        logger.error(f"Task {task_id[:8]} failed: {e}")
         traceback.print_exc()
 
         # Store error result
@@ -224,7 +226,7 @@ def main():
             error_result = {"error": str(e), "traceback": traceback.format_exc()}
             store_result(cloudpickle.dumps(error_result), s3_bucket, s3_prefix, job_id)
         except Exception as store_error:
-            logging.error(f"Failed to store error result: {store_error}")
+            logger.error(f"Failed to store error result: {store_error}")
 
         sys.exit(1)
 

--- a/src/scaler/worker_manager_adapter/aws_hpc/utility/provisioner.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/utility/provisioner.py
@@ -13,6 +13,8 @@ from typing import Dict, List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_PREFIX = "scaler-batch"
 DEFAULT_CONFIG_FILE = ".scaler_aws_batch_config.json"
 
@@ -94,7 +96,7 @@ class AWSBatchProvisioner:
         Returns:
             dict with resource names/ARNs
         """
-        logging.info(f"Provisioning AWS Batch (EC2) resources with prefix '{self._prefix}'...")
+        logger.info(f"Provisioning AWS Batch (EC2) resources with prefix '{self._prefix}'...")
 
         if instance_types is None:
             instance_types = ["default_x86_64"]
@@ -143,7 +145,7 @@ class AWSBatchProvisioner:
             "instance_types": instance_types,
         }
 
-        logging.info("Provisioning complete!")
+        logger.info("Provisioning complete!")
         return result
 
     @staticmethod
@@ -153,7 +155,7 @@ class AWSBatchProvisioner:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
             json.dump(config, f, indent=2)
-        logging.info(f"Config saved to {path.absolute()}")
+        logger.info(f"Config saved to {path.absolute()}")
 
     @staticmethod
     def load_config(config_file: str = DEFAULT_CONFIG_FILE) -> Dict[str, object]:
@@ -182,8 +184,8 @@ class AWSBatchProvisioner:
             f.write(f"export SCALER_S3_BUCKET=\"{config['s3_bucket']}\"\n")
             f.write(f"export SCALER_JOB_QUEUE=\"{config['job_queue_name']}\"\n")
             f.write(f"export SCALER_JOB_DEFINITION=\"{config['job_definition_name']}\"\n")
-        logging.info(f"Env file saved: {path.absolute()}")
-        logging.info(f"Run: source {env_file}")
+        logger.info(f"Env file saved: {path.absolute()}")
+        logger.info(f"Run: source {env_file}")
 
     def provision_s3_bucket(self) -> str:
         """Create S3 bucket for task data."""
@@ -196,10 +198,10 @@ class AWSBatchProvisioner:
                 self._s3.create_bucket(
                     Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": self._region}
                 )
-            logging.info(f"Created S3 bucket: {bucket_name}")
+            logger.info(f"Created S3 bucket: {bucket_name}")
         except ClientError as e:
             if e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
-                logging.info(f"S3 bucket already exists: {bucket_name}")
+                logger.info(f"S3 bucket already exists: {bucket_name}")
             else:
                 raise
 
@@ -249,18 +251,18 @@ class AWSBatchProvisioner:
                 Description="IAM role for Scaler AWS Batch jobs",
             )
             role_arn = response["Role"]["Arn"]
-            logging.info(f"Created IAM role: {role_name}")
+            logger.info(f"Created IAM role: {role_name}")
         except ClientError as e:
             if e.response["Error"]["Code"] == "EntityAlreadyExists":
                 role_arn = f"arn:aws:iam::{self._account_id}:role/{role_name}"
-                logging.info(f"IAM role already exists: {role_name}")
+                logger.info(f"IAM role already exists: {role_name}")
             else:
                 raise
 
         # Attach AWS managed policy for ECS task execution (covers CloudWatch Logs, ECR)
         try:
             self._iam.attach_role_policy(RoleName=role_name, PolicyArn=IAM_POLICY_ECS_TASK_EXECUTION)
-            logging.info(f"Attached AmazonECSTaskExecutionRolePolicy to {role_name}")
+            logger.info(f"Attached AmazonECSTaskExecutionRolePolicy to {role_name}")
         except ClientError:
             pass  # May already be attached
 
@@ -295,7 +297,7 @@ class AWSBatchProvisioner:
                 },
             )
             env_arn = response["computeEnvironmentArn"]
-            logging.info(f"Created EC2 compute environment: {env_name} (instance_types={instance_types})")
+            logger.info(f"Created EC2 compute environment: {env_name} (instance_types={instance_types})")
 
             # Wait for compute environment to be valid
             self._wait_for_compute_environment(env_name)
@@ -303,7 +305,7 @@ class AWSBatchProvisioner:
         except ClientError as e:
             if "already exists" in str(e):
                 env_arn = f"arn:aws:batch:{self._region}:{self._account_id}:compute-environment/{env_name}"
-                logging.info(f"Compute environment already exists: {env_name}")
+                logger.info(f"Compute environment already exists: {env_name}")
             else:
                 raise
 
@@ -329,7 +331,7 @@ class AWSBatchProvisioner:
                 AssumeRolePolicyDocument=json.dumps(trust_policy),
                 Description="IAM role for Scaler AWS Batch EC2 instances",
             )
-            logging.info(f"Created instance role: {role_name}")
+            logger.info(f"Created instance role: {role_name}")
         except ClientError as e:
             if e.response["Error"]["Code"] != "EntityAlreadyExists":
                 raise
@@ -345,7 +347,7 @@ class AWSBatchProvisioner:
         # Create instance profile if it doesn't exist
         try:
             self._iam.create_instance_profile(InstanceProfileName=profile_name)
-            logging.info(f"Created instance profile: {profile_name}")
+            logger.info(f"Created instance profile: {profile_name}")
         except ClientError as e:
             if e.response["Error"]["Code"] != "EntityAlreadyExists":
                 raise
@@ -371,11 +373,11 @@ class AWSBatchProvisioner:
                 computeEnvironmentOrder=[{"order": 1, "computeEnvironment": compute_env_arn}],
             )
             queue_arn = response["jobQueueArn"]
-            logging.info(f"Created job queue: {queue_name}")
+            logger.info(f"Created job queue: {queue_name}")
         except ClientError as e:
             if "already exists" in str(e):
                 queue_arn = f"arn:aws:batch:{self._region}:{self._account_id}:job-queue/{queue_name}"
-                logging.info(f"Job queue already exists: {queue_name}")
+                logger.info(f"Job queue already exists: {queue_name}")
             else:
                 raise
 
@@ -392,7 +394,7 @@ class AWSBatchProvisioner:
         total_memory = memory_multiple * MEMORY_BASE_MB
         effective_memory = int(total_memory * MEMORY_UTILIZATION_FACTOR)
 
-        logging.info(
+        logger.info(
             f"Memory config: requested={memory_mb}MB, "
             f"multiple={memory_multiple}x{MEMORY_BASE_MB}={total_memory}MB, "
             f"effective({int(MEMORY_UTILIZATION_FACTOR * 100)}%)={effective_memory}MB"
@@ -437,7 +439,7 @@ class AWSBatchProvisioner:
         )
 
         job_def_arn = response["jobDefinitionArn"]
-        logging.info(f"Registered job definition: {job_def_name} (vcpus={int(vcpus)}, memory={effective_memory}MB)")
+        logger.info(f"Registered job definition: {job_def_name} (vcpus={int(vcpus)}, memory={effective_memory}MB)")
 
         # Cleanup old job definition revisions, keep only latest N
         self._cleanup_old_job_definitions(job_def_name, keep_latest=JOB_DEFINITION_REVISIONS_TO_KEEP)
@@ -462,12 +464,12 @@ class AWSBatchProvisioner:
             for job_def in job_defs[keep_latest:]:
                 try:
                     self._batch.deregister_job_definition(jobDefinition=job_def["jobDefinitionArn"])
-                    logging.info(f"Deregistered old job definition: {job_def['jobDefinitionArn']}")
+                    logger.info(f"Deregistered old job definition: {job_def['jobDefinitionArn']}")
                 except ClientError as e:
-                    logging.warning(f"Failed to deregister {job_def['jobDefinitionArn']}: {e}")
+                    logger.warning(f"Failed to deregister {job_def['jobDefinitionArn']}: {e}")
 
         except ClientError as e:
-            logging.warning(f"Failed to cleanup old job definitions: {e}")
+            logger.warning(f"Failed to cleanup old job definitions: {e}")
 
     def _setup_cloudwatch_logs_retention(self, retention_days: int = CLOUDWATCH_RETENTION_DAYS) -> None:
         """Set CloudWatch Logs retention policy for AWS Batch logs."""
@@ -478,16 +480,16 @@ class AWSBatchProvisioner:
             # Create log group if it doesn't exist
             try:
                 logs_client.create_log_group(logGroupName=log_group_name)
-                logging.info(f"Created CloudWatch log group: {log_group_name}")
+                logger.info(f"Created CloudWatch log group: {log_group_name}")
             except ClientError as e:
                 if e.response["Error"]["Code"] != "ResourceAlreadyExistsException":
                     raise
 
             # Set retention policy
             logs_client.put_retention_policy(logGroupName=log_group_name, retentionInDays=retention_days)
-            logging.info(f"Set CloudWatch Logs retention: {retention_days} days for {log_group_name}")
+            logger.info(f"Set CloudWatch Logs retention: {retention_days} days for {log_group_name}")
         except ClientError as e:
-            logging.warning(f"Failed to set CloudWatch Logs retention: {e}")
+            logger.warning(f"Failed to set CloudWatch Logs retention: {e}")
 
     def _get_default_subnets(self) -> List[str]:
         """Get default VPC subnets."""
@@ -506,17 +508,17 @@ class AWSBatchProvisioner:
         import time
 
         start = time.time()
-        logging.info(f"Waiting for compute environment {env_name} to become VALID (timeout: {timeout}s)...")
+        logger.info(f"Waiting for compute environment {env_name} to become VALID (timeout: {timeout}s)...")
         while time.time() - start < timeout:
             response = self._batch.describe_compute_environments(computeEnvironments=[env_name])
             if not response["computeEnvironments"]:
-                logging.warning(f"Compute environment {env_name} not found, waiting...")
+                logger.warning(f"Compute environment {env_name} not found, waiting...")
                 time.sleep(5)
                 continue
             status = response["computeEnvironments"][0]["status"]
-            logging.info(f"Compute environment status: {status}")
+            logger.info(f"Compute environment status: {status}")
             if status == "VALID":
-                logging.info(f"Compute environment {env_name} is VALID")
+                logger.info(f"Compute environment {env_name} is VALID")
                 return
             if status == "INVALID":
                 status_reason = response["computeEnvironments"][0].get("statusReason", "Unknown")
@@ -539,11 +541,11 @@ class AWSBatchProvisioner:
         # Create ECR repository if it doesn't exist
         try:
             ecr.create_repository(repositoryName=repo_name)
-            logging.info(f"Created ECR repository: {repo_name}")
+            logger.info(f"Created ECR repository: {repo_name}")
         except ClientError as e:
             if e.response["Error"]["Code"] != "RepositoryAlreadyExistsException":
                 raise
-            logging.info(f"ECR repository already exists: {repo_name}")
+            logger.info(f"ECR repository already exists: {repo_name}")
 
         # Set lifecycle policy to keep only ECR_IMAGES_TO_KEEP latest images
         lifecycle_policy = {
@@ -562,9 +564,9 @@ class AWSBatchProvisioner:
         }
         try:
             ecr.put_lifecycle_policy(repositoryName=repo_name, lifecyclePolicyText=json.dumps(lifecycle_policy))
-            logging.info(f"Set ECR lifecycle policy: keep {ECR_IMAGES_TO_KEEP} latest images")
+            logger.info(f"Set ECR lifecycle policy: keep {ECR_IMAGES_TO_KEEP} latest images")
         except ClientError as e:
-            logging.warning(f"Failed to set lifecycle policy: {e}")
+            logger.warning(f"Failed to set lifecycle policy: {e}")
 
         # Get ECR login credentials
         auth = ecr.get_authorization_token()
@@ -577,7 +579,7 @@ class AWSBatchProvisioner:
         # Docker login
         login_cmd = f"echo {password} | docker login --username {username} --password-stdin {registry}"
         subprocess.run(login_cmd, shell=True, check=True, capture_output=True)
-        logging.info("Logged in to ECR")
+        logger.info("Logged in to ECR")
 
         # Build image
         image_uri = f"{self._account_id}.dkr.ecr.{self._region}.amazonaws.com/{repo_name}:latest"
@@ -600,22 +602,22 @@ class AWSBatchProvisioner:
             image_uri,
             str(repo_root),  # Use repo root, not src/
         ]
-        logging.info(f"Building image for linux/amd64: {image_uri}")
+        logger.info(f"Building image for linux/amd64: {image_uri}")
         subprocess.run(build_cmd, check=True)
 
         # Push image
-        logging.info("Pushing image to ECR...")
+        logger.info("Pushing image to ECR...")
         push_cmd = ["docker", "push", image_uri]
         subprocess.run(push_cmd, check=True)
 
-        logging.info(f"Image pushed: {image_uri}")
+        logger.info(f"Image pushed: {image_uri}")
         return image_uri
 
     def cleanup(self) -> None:
         """Delete all provisioned resources."""
         import time
 
-        logging.info("Cleaning up AWS resources...")
+        logger.info("Cleaning up AWS resources...")
 
         queue_name = f"{self._prefix}-queue"
         env_name = f"{self._prefix}-compute"
@@ -627,7 +629,7 @@ class AWSBatchProvisioner:
 
         # Disable and delete job queue
         try:
-            logging.info(f"Disabling job queue: {queue_name}")
+            logger.info(f"Disabling job queue: {queue_name}")
             self._batch.update_job_queue(jobQueue=queue_name, state="DISABLED")
 
             # Wait for queue to be disabled
@@ -645,7 +647,7 @@ class AWSBatchProvisioner:
                 time.sleep(2)
 
             self._batch.delete_job_queue(jobQueue=queue_name)
-            logging.info(f"Deleted job queue: {queue_name}")
+            logger.info(f"Deleted job queue: {queue_name}")
 
             # Wait for queue deletion
             for _ in range(30):
@@ -655,11 +657,11 @@ class AWSBatchProvisioner:
                 time.sleep(2)
 
         except ClientError as e:
-            logging.warning(f"Failed to delete job queue: {e}")
+            logger.warning(f"Failed to delete job queue: {e}")
 
         # Disable and delete compute environment
         try:
-            logging.info(f"Disabling compute environment: {env_name}")
+            logger.info(f"Disabling compute environment: {env_name}")
             self._batch.update_compute_environment(computeEnvironment=env_name, state="DISABLED")
 
             # Wait for compute env to be disabled
@@ -677,7 +679,7 @@ class AWSBatchProvisioner:
                 time.sleep(5)
 
             self._batch.delete_compute_environment(computeEnvironment=env_name)
-            logging.info(f"Deleted compute environment: {env_name}")
+            logger.info(f"Deleted compute environment: {env_name}")
 
             # Wait for compute env deletion
             for _ in range(60):
@@ -687,16 +689,16 @@ class AWSBatchProvisioner:
                 time.sleep(5)
 
         except ClientError as e:
-            logging.warning(f"Failed to delete compute environment: {e}")
+            logger.warning(f"Failed to delete compute environment: {e}")
 
         # Deregister job definitions
         try:
             response = self._batch.describe_job_definitions(jobDefinitionName=job_def_name, status="ACTIVE")
             for job_def in response.get("jobDefinitions", []):
                 self._batch.deregister_job_definition(jobDefinition=job_def["jobDefinitionArn"])
-            logging.info(f"Deregistered job definitions: {job_def_name}")
+            logger.info(f"Deregistered job definitions: {job_def_name}")
         except ClientError as e:
-            logging.warning(f"Failed to deregister job definitions: {e}")
+            logger.warning(f"Failed to deregister job definitions: {e}")
 
         # Delete job IAM role
         try:
@@ -709,9 +711,9 @@ class AWSBatchProvisioner:
             pass
         try:
             self._iam.delete_role(RoleName=role_name)
-            logging.info(f"Deleted IAM role: {role_name}")
+            logger.info(f"Deleted IAM role: {role_name}")
         except ClientError as e:
-            logging.warning(f"Failed to delete IAM role: {e}")
+            logger.warning(f"Failed to delete IAM role: {e}")
 
         # Delete instance profile and role
         try:
@@ -722,9 +724,9 @@ class AWSBatchProvisioner:
             pass
         try:
             self._iam.delete_instance_profile(InstanceProfileName=instance_profile_name)
-            logging.info(f"Deleted instance profile: {instance_profile_name}")
+            logger.info(f"Deleted instance profile: {instance_profile_name}")
         except ClientError as e:
-            logging.warning(f"Failed to delete instance profile: {e}")
+            logger.warning(f"Failed to delete instance profile: {e}")
 
         try:
             self._iam.detach_role_policy(RoleName=instance_role_name, PolicyArn=IAM_POLICY_EC2_CONTAINER_SERVICE)
@@ -732,9 +734,9 @@ class AWSBatchProvisioner:
             pass
         try:
             self._iam.delete_role(RoleName=instance_role_name)
-            logging.info(f"Deleted instance role: {instance_role_name}")
+            logger.info(f"Deleted instance role: {instance_role_name}")
         except ClientError as e:
-            logging.warning(f"Failed to delete instance role: {e}")
+            logger.warning(f"Failed to delete instance role: {e}")
 
         # Delete S3 bucket (must be empty)
         try:
@@ -743,20 +745,20 @@ class AWSBatchProvisioner:
                 for obj in page.get("Contents", []):
                     self._s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
             self._s3.delete_bucket(Bucket=bucket_name)
-            logging.info(f"Deleted S3 bucket: {bucket_name}")
+            logger.info(f"Deleted S3 bucket: {bucket_name}")
         except ClientError as e:
-            logging.warning(f"Failed to delete S3 bucket: {e}")
+            logger.warning(f"Failed to delete S3 bucket: {e}")
 
         # Delete ECR repository
         ecr_repo_name = f"{self._prefix}-worker"
         try:
             ecr = self._session.client("ecr")
             ecr.delete_repository(repositoryName=ecr_repo_name, force=True)
-            logging.info(f"Deleted ECR repository: {ecr_repo_name}")
+            logger.info(f"Deleted ECR repository: {ecr_repo_name}")
         except ClientError as e:
-            logging.warning(f"Failed to delete ECR repository: {e}")
+            logger.warning(f"Failed to delete ECR repository: {e}")
 
-        logging.info("Cleanup complete!")
+        logger.info("Cleanup complete!")
 
 
 def main() -> None:
@@ -812,7 +814,7 @@ def main() -> None:
     if args.action == "provision":
         # If no image specified, build and push to ECR
         if args.image is None:
-            logging.info("No --image specified, building and pushing to ECR...")
+            logger.info("No --image specified, building and pushing to ECR...")
             container_image = provisioner.build_and_push_image()
         else:
             container_image = args.image

--- a/src/scaler/worker_manager_adapter/aws_hpc/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/worker_manager.py
@@ -84,13 +84,16 @@ class BatchWorkerProvisioner(DeclarativeWorkerProvisioner):
         self._units.clear()
 
 
+logger = logging.getLogger(__name__)
+
+
 class AWSHPCWorkerManager:
     def __init__(self, config: AWSBatchWorkerManagerConfig) -> None:
         self._config = config
 
     def run(self) -> None:
         config = self._config
-        logging.info(f"Starting AWS HPC Worker Manager (backend: {config.backend.name})")
+        logger.info(f"Starting AWS HPC Worker Manager (backend: {config.backend.name})")
         if config.backend != AWSHPCBackend.batch:
             raise NotImplementedError(f"backend {config.backend.name!r} is not yet implemented")
 

--- a/src/scaler/worker_manager_adapter/aws_raw/ecs.py
+++ b/src/scaler/worker_manager_adapter/aws_raw/ecs.py
@@ -16,6 +16,10 @@ from scaler.worker_manager_adapter.worker_manager_runner import WorkerManagerRun
 if TYPE_CHECKING:
     from scaler.protocol.capnp import WorkerManagerCommand
 
+logger = logging.getLogger(__name__)
+
+_WorkerGroupID = bytes
+
 
 class ECSWorkerProvisioner(DeclarativeWorkerProvisioner):
     def __init__(self, config: ECSWorkerManagerConfig) -> None:
@@ -64,13 +68,13 @@ class ECSWorkerProvisioner(DeclarativeWorkerProvisioner):
         resp = self._ecs_client.describe_clusters(clusters=[self._ecs_cluster])
         clusters = resp.get("clusters") or []
         if not clusters or clusters[0]["status"] != "ACTIVE":
-            logging.info(f"ECS cluster '{self._ecs_cluster}' missing, creating it.")
+            logger.info(f"ECS cluster '{self._ecs_cluster}' missing, creating it.")
             self._ecs_client.create_cluster(clusterName=self._ecs_cluster)
 
         try:
             resp = self._ecs_client.describe_task_definition(taskDefinition=self._ecs_task_definition)
         except self._ecs_client.exceptions.ClientException:
-            logging.info(f"ECS task definition '{self._ecs_task_definition}' missing, creating it.")
+            logger.info(f"ECS task definition '{self._ecs_task_definition}' missing, creating it.")
             iam_client = aws_session.client("iam")
             try:
                 resp = iam_client.get_role(RoleName="ecsTaskExecutionRole")
@@ -192,10 +196,10 @@ class ECSWorkerProvisioner(DeclarativeWorkerProvisioner):
             )
             failures = resp.get("failures") or []
             if failures:
-                logging.error(f"ECS stop task {task_arn!r} failed: {failures}")
+                logger.error(f"ECS stop task {task_arn!r} failed: {failures}")
             else:
                 self._units.remove(task_arn)
-                logging.info(f"Stopped ECS task {task_arn!r}")
+                logger.info(f"Stopped ECS task {task_arn!r}")
 
     async def terminate(self) -> None:
         self._capacity_coordinator.cancel()

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -20,6 +20,8 @@ from scaler.worker_manager_adapter.worker_manager_runner import WorkerManagerRun
 if TYPE_CHECKING:
     from scaler.protocol.capnp import WorkerManagerCommand
 
+logger = logging.getLogger(__name__)
+
 
 class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
     def __init__(self, config: NativeWorkerManagerConfig) -> None:
@@ -88,7 +90,7 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
             fixed_workers[worker.identity] = worker
 
         def _on_signal(sig: int, frame: object) -> None:
-            logging.info("NativeWorkerProvisioner (FIXED): received signal %d, terminating workers", sig)
+            logger.info("NativeWorkerProvisioner (FIXED): received signal %d, terminating workers", sig)
             for worker in fixed_workers.values():
                 if worker.is_alive():
                     worker.terminate()
@@ -113,12 +115,12 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
             worker = self._create_worker()
             worker.start()
             self._workers.append(worker)
-            logging.info(f"Started native worker {worker.identity!r}")
+            logger.info(f"Started native worker {worker.identity!r}")
 
     async def stop_units(self, count: int) -> None:
         to_stop = self._workers[:count]
         if len(to_stop) < count:
-            logging.warning(f"Requested to stop {count} worker(s) but only {len(to_stop)} available.")
+            logger.warning(f"Requested to stop {count} worker(s) but only {len(to_stop)} available.")
         for worker in to_stop:
             if sys.platform == "win32":
                 # Windows os.kill with SIGINT only works for processes attached to the same console.
@@ -128,7 +130,7 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
             else:
                 os.kill(worker.pid, signal.SIGINT)
             self._workers.pop(0)
-            logging.info(f"Stopped native worker {worker.identity!r}")
+            logger.info(f"Stopped native worker {worker.identity!r}")
 
     async def terminate(self) -> None:
         self._capacity_coordinator.cancel()

--- a/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
@@ -24,6 +24,8 @@ from scaler.worker_manager_adapter.common import extract_desired_count, format_c
 from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner
 from scaler.worker_manager_adapter.worker_manager_runner import WorkerManagerRunner
 
+logger = logging.getLogger(__name__)
+
 ORB_AWS_EC2_POLLING_INTERVAL_SECONDS = 5
 ORB_AWS_EC2_MAX_POLLING_ATTEMPTS = 60
 
@@ -63,14 +65,14 @@ class ORBWorkerProvisioner(DeclarativeWorkerProvisioner):
         )
 
     async def start_units(self, count: int) -> None:
-        logging.info(f"Submitting ORB batch machine request for template {self._template_id} (count={count})...")
+        logger.info(f"Submitting ORB batch machine request for template {self._template_id} (count={count})...")
         create_response = await self._sdk.create_request(template_id=self._template_id, count=count)
 
         request_id = create_response.get("created_request_id") if isinstance(create_response, dict) else None
         if not request_id:
             raise RuntimeError(f"ORB create_request returned no request ID. Response: {create_response}")
 
-        logging.info(f"ORB request {request_id} submitted, polling for {count} instance ID(s)...")
+        logger.info(f"ORB request {request_id} submitted, polling for {count} instance ID(s)...")
         timeout_seconds = ORB_AWS_EC2_MAX_POLLING_ATTEMPTS * ORB_AWS_EC2_POLLING_INTERVAL_SECONDS
         elapsed = 0
 
@@ -90,7 +92,7 @@ class ORBWorkerProvisioner(DeclarativeWorkerProvisioner):
 
             if len(machine_ids) >= count:
                 for instance_id in machine_ids:
-                    logging.info(f"ORB request {request_id}: instance {instance_id} ready")
+                    logger.info(f"ORB request {request_id}: instance {instance_id} ready")
                 self._units.extend(machine_ids)
                 return
 
@@ -107,24 +109,24 @@ class ORBWorkerProvisioner(DeclarativeWorkerProvisioner):
     async def stop_units(self, count: int) -> None:
         unit_ids = self._units[:count]
         if len(unit_ids) < count:
-            logging.warning(f"Requested to stop {count} unit(s) but only {len(unit_ids)} available.")
+            logger.warning(f"Requested to stop {count} unit(s) but only {len(unit_ids)} available.")
         if not unit_ids:
             return
-        logging.info(f"Stopping {len(unit_ids)} unit(s): instances {unit_ids}")
+        logger.info(f"Stopping {len(unit_ids)} unit(s): instances {unit_ids}")
         await self._sdk.create_return_request(machine_ids=unit_ids)
         del self._units[:count]
-        logging.info(f"Successfully stopped {count} unit(s): instances {unit_ids}")
+        logger.info(f"Successfully stopped {count} unit(s): instances {unit_ids}")
 
     async def terminate(self) -> None:
         self._capacity_coordinator.cancel()
         if not self._units:
             return
-        logging.info(f"Terminating {len(self._units)} unit(s)...")
+        logger.info(f"Terminating {len(self._units)} unit(s)...")
         try:
             await self._sdk.create_return_request(machine_ids=self._units)
-            logging.info(f"Successfully requested termination of instances: {self._units}")
+            logger.info(f"Successfully requested termination of instances: {self._units}")
         except Exception as e:
-            logging.warning(f"Failed to terminate instances during cleanup: {e}")
+            logger.warning(f"Failed to terminate instances during cleanup: {e}")
         self._units.clear()
 
 
@@ -180,7 +182,7 @@ class ORBAWSEC2WorkerManager:
         workers_per_instance = self._discover_vcpu_count(self._config.instance_type)
         mtc = self._config.worker_manager_config.max_task_concurrency
         max_instances = math.ceil(mtc / workers_per_instance) if mtc != -1 else -1
-        logging.info(
+        logger.info(
             f"ORB instance type {self._config.instance_type!r}: {workers_per_instance} vCPUs/instance, "
             f"max_task_concurrency={mtc} -> max_instances={max_instances}"
         )
@@ -238,10 +240,10 @@ class ORBAWSEC2WorkerManager:
             self._dump_debug_state(template_id, template_kwargs)
 
         create_result = await sdk.create_template(**template_kwargs)
-        logging.info(f"create_template result: {create_result}")
+        logger.info(f"create_template result: {create_result}")
 
         validate_result = await sdk.validate_template(template_id=template_id)
-        logging.info(f"validate_template result: {validate_result}")
+        logger.info(f"validate_template result: {validate_result}")
 
     def run(self) -> None:
         self._loop = asyncio.new_event_loop()
@@ -275,23 +277,23 @@ class ORBAWSEC2WorkerManager:
         if self._runner is not None:
             self._runner.cleanup()
 
-        logging.info("Starting cleanup of AWS resources...")
+        logger.info("Starting cleanup of AWS resources...")
 
         if self._created_security_group_id is not None:
             try:
-                logging.info(f"Deleting AWS security group: {self._created_security_group_id}")
+                logger.info(f"Deleting AWS security group: {self._created_security_group_id}")
                 self._ec2.delete_security_group(GroupId=self._created_security_group_id)
             except Exception as e:
-                logging.warning(f"Failed to delete security group {self._created_security_group_id}: {e}")
+                logger.warning(f"Failed to delete security group {self._created_security_group_id}: {e}")
 
         if self._created_key_name is not None:
             try:
-                logging.info(f"Deleting AWS key pair: {self._created_key_name}")
+                logger.info(f"Deleting AWS key pair: {self._created_key_name}")
                 self._ec2.delete_key_pair(KeyName=self._created_key_name)
             except Exception as e:
-                logging.warning(f"Failed to delete key pair {self._created_key_name}: {e}")
+                logger.warning(f"Failed to delete key pair {self._created_key_name}: {e}")
 
-        logging.info("Cleanup completed.")
+        logger.info("Cleanup completed.")
 
     def __del__(self) -> None:
         self._cleanup()
@@ -304,7 +306,7 @@ class ORBAWSEC2WorkerManager:
             json.dump(dataclasses.asdict(self._config), f, indent=2, default=str)
         with open(template_path, "w") as f:
             json.dump(template_kwargs, f, indent=2, default=str)
-        logging.info(f"[DEBUG] Dumped config to {config_path} and template to {template_path}")
+        logger.info(f"[DEBUG] Dumped config to {config_path} and template to {template_path}")
 
     def _create_user_data(self) -> str:
         worker_config = self._config.worker_config
@@ -386,7 +388,7 @@ set +e
             raise RuntimeError("No AL2023 AMI found in the current region.")
         images.sort(key=lambda img: img["CreationDate"], reverse=True)
         ami_id = images[0]["ImageId"]
-        logging.info(f"Auto-discovered latest AL2023 AMI: {ami_id}")
+        logger.info(f"Auto-discovered latest AL2023 AMI: {ami_id}")
         return ami_id
 
     def _discover_default_subnet(self) -> str:
@@ -400,7 +402,7 @@ set +e
             raise RuntimeError(f"No subnets found in default VPC {default_vpc_id}.")
 
         subnet_id = subnets["Subnets"][0]["SubnetId"]
-        logging.info(f"Auto-discovered subnet_id: {subnet_id}")
+        logger.info(f"Auto-discovered subnet_id: {subnet_id}")
         return subnet_id
 
     def _create_security_group(self, template_id: str) -> None:
@@ -414,13 +416,13 @@ set +e
             VpcId=vpc_id,
         )
         self._created_security_group_id = sg_response["GroupId"]
-        logging.info(f"Created security group with ID: {self._created_security_group_id}")
+        logger.info(f"Created security group with ID: {self._created_security_group_id}")
 
     def _create_key_pair(self, template_id: str) -> None:
         key_name = f"opengris-orb-key-{template_id}"
         self._ec2.create_key_pair(KeyName=key_name)
         self._created_key_name = key_name
-        logging.info(f"Created key pair: {key_name}")
+        logger.info(f"Created key pair: {key_name}")
 
     @staticmethod
     def _validate_requirements(requirements_content: str) -> None:

--- a/src/scaler/worker_manager_adapter/symphony/task_manager.py
+++ b/src/scaler/worker_manager_adapter/symphony/task_manager.py
@@ -11,6 +11,8 @@ from scaler.worker_manager_adapter.mixins import ExecutionBackend, TaskDeseriali
 from scaler.worker_manager_adapter.symphony.callback import SessionCallback
 from scaler.worker_manager_adapter.symphony.message import SoamMessage
 
+logger = logging.getLogger(__name__)
+
 try:
     import soamapi
 except ImportError:
@@ -30,7 +32,7 @@ class SymphonyExecutionBackend(TaskInputLoader, ExecutionBackend):
         self._ibm_soam_connection = soamapi.connect(
             self._service_name, soamapi.DefaultSecurityCallback("Guest", "Guest")
         )
-        logging.info(f"established IBM Spectrum Symphony connection {self._ibm_soam_connection.get_id()}")
+        logger.info(f"established IBM Spectrum Symphony connection {self._ibm_soam_connection.get_id()}")
 
         ibm_soam_session_attr = soamapi.SessionCreationAttributes()
         ibm_soam_session_attr.set_session_type("RecoverableAllHistoricalData")
@@ -38,7 +40,7 @@ class SymphonyExecutionBackend(TaskInputLoader, ExecutionBackend):
         ibm_soam_session_attr.set_session_flags(soamapi.SessionFlags.PARTIAL_ASYNC)
         ibm_soam_session_attr.set_session_callback(self._session_callback)
         self._ibm_soam_session = self._ibm_soam_connection.create_session(ibm_soam_session_attr)
-        logging.info(f"established IBM Spectrum Symphony session {self._ibm_soam_session.get_id()}")
+        logger.info(f"established IBM Spectrum Symphony session {self._ibm_soam_session.get_id()}")
 
     def register(self, load_task_inputs: TaskDeserializer) -> None:
         self._loader = load_task_inputs

--- a/src/scaler/worker_manager_adapter/symphony/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/symphony/worker_manager.py
@@ -15,6 +15,7 @@ from scaler.worker_manager_adapter.worker_process import WorkerProcess
 
 if TYPE_CHECKING:
     from scaler.protocol.capnp import WorkerManagerCommand
+logger = logging.getLogger(__name__)
 
 
 class SymphonyWorkerProvisioner(DeclarativeWorkerProvisioner):
@@ -64,7 +65,7 @@ class SymphonyWorkerProvisioner(DeclarativeWorkerProvisioner):
         )
         worker.start()
         self._workers.append(worker)
-        logging.info(f"Started Symphony worker {worker.identity!r}")
+        logger.info(f"Started Symphony worker {worker.identity!r}")
 
     async def start_units(self, count: int) -> None:
         for _ in range(count):
@@ -73,11 +74,11 @@ class SymphonyWorkerProvisioner(DeclarativeWorkerProvisioner):
     async def stop_units(self, count: int) -> None:
         to_stop = self._workers[:count]
         if len(to_stop) < count:
-            logging.warning(f"Requested to stop {count} worker(s) but only {len(to_stop)} available.")
+            logger.warning(f"Requested to stop {count} worker(s) but only {len(to_stop)} available.")
         for worker in to_stop:
             os.kill(worker.pid, signal.SIGINT)
             self._workers.pop(0)
-            logging.info(f"Stopped Symphony worker {worker.identity!r}")
+            logger.info(f"Stopped Symphony worker {worker.identity!r}")
 
     async def terminate(self) -> None:
         self._capacity_coordinator.cancel()

--- a/tests/cpp/logging/test_logging.cpp
+++ b/tests/cpp/logging/test_logging.cpp
@@ -130,18 +130,14 @@ TEST_F(LoggingUnitTest, TestLogsProcessToken)
 TEST_F(LoggingUnitTest, TestLogsNameToken)
 {
     scaler::ymq::Logger logger(
-        "%(name)s: %(message)s",
-        {curr_log_filename},
-        scaler::ymq::Logger::LoggingLevel::info,
-        "scheduler");
+        "%(name)s: %(message)s", {curr_log_filename}, scaler::ymq::Logger::LoggingLevel::info, "scheduler");
     logger.log(scaler::ymq::Logger::LoggingLevel::info, "hello");
     EXPECT_EQ(readLogFile(curr_log_filename), "scheduler: hello");
 }
 
 TEST_F(LoggingUnitTest, TestLogsUnknownTokenPreservesSpecifier)
 {
-    scaler::ymq::Logger logger(
-        "Count %(unknown)d here", {curr_log_filename}, scaler::ymq::Logger::LoggingLevel::info);
+    scaler::ymq::Logger logger("Count %(unknown)d here", {curr_log_filename}, scaler::ymq::Logger::LoggingLevel::info);
     logger.log(scaler::ymq::Logger::LoggingLevel::info);
     EXPECT_EQ(readLogFile(curr_log_filename), "Count %(unknown)d here");
 }

--- a/tests/cpp/logging/test_logging.cpp
+++ b/tests/cpp/logging/test_logging.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <cstdio>
 #include <fstream>
@@ -115,6 +116,34 @@ TEST_F(LoggingUnitTest, TestLogsMismatchedArguments)
         "[%(levelname)s] No message token here", {curr_log_filename}, scaler::ymq::Logger::LoggingLevel::info);
     logger.log(scaler::ymq::Logger::LoggingLevel::info, "this part is ignored", 123);
     EXPECT_EQ(readLogFile(curr_log_filename), "[INFO] No message token here");
+}
+
+TEST_F(LoggingUnitTest, TestLogsProcessToken)
+{
+    scaler::ymq::Logger logger(
+        "pid=%(process)d msg=%(message)s", {curr_log_filename}, scaler::ymq::Logger::LoggingLevel::info);
+    logger.log(scaler::ymq::Logger::LoggingLevel::info, "hello");
+    std::string expected = "pid=" + std::to_string(::getpid()) + " msg=hello";
+    EXPECT_EQ(readLogFile(curr_log_filename), expected);
+}
+
+TEST_F(LoggingUnitTest, TestLogsNameToken)
+{
+    scaler::ymq::Logger logger(
+        "%(name)s: %(message)s",
+        {curr_log_filename},
+        scaler::ymq::Logger::LoggingLevel::info,
+        "scheduler");
+    logger.log(scaler::ymq::Logger::LoggingLevel::info, "hello");
+    EXPECT_EQ(readLogFile(curr_log_filename), "scheduler: hello");
+}
+
+TEST_F(LoggingUnitTest, TestLogsUnknownTokenPreservesSpecifier)
+{
+    scaler::ymq::Logger logger(
+        "Count %(unknown)d here", {curr_log_filename}, scaler::ymq::Logger::LoggingLevel::info);
+    logger.log(scaler::ymq::Logger::LoggingLevel::info);
+    EXPECT_EQ(readLogFile(curr_log_filename), "Count %(unknown)d here");
 }
 
 // New test case to verify logging to multiple files

--- a/tests/entry_points/test_all.py
+++ b/tests/entry_points/test_all.py
@@ -374,7 +374,9 @@ class TestRunWorkerManager(unittest.TestCase):
             mock_nm.return_value.run.return_value = None
             _run_worker_manager(config)
 
-        mock_log.assert_called_once_with(config.logging_config.paths, config.logging_config.config_file, "WARNING")
+        mock_log.assert_called_once_with(
+            config.logging_config.paths, config.logging_config.config_file, "WARNING", process_name=config._tag
+        )
 
     def _make_orb_aws_ec2_config(self, event_loop="builtin", logging_level="INFO"):
         from scaler.config.common.logging import LoggingConfig


### PR DESCRIPTION
# READY FOR REVIEW.

- Unify log format to `<time> <level> <process_name>[<pid>]: <msg>` across Python and C++ (#691) — makes it easy to tell which subprocess emitted which line under `scaler_all`.
- Migrate scaler off the root logger onto a named `scaler` logger with `propagate=False` + `NullHandler` (#653) — third-party code (e.g. ORB) can no longer suppress scaler output.

## LOGGING MIGRATION GUIDE FOR PRIVATE WORKER MANAGERS (FOR HUMAN):
- Log format has been changed, no action is required if your worker managers running through worker manager entry point.
- Global `logging` is no longer being used, please use a named logger instead. Consult orb worker manager for the usage.
- **If your adapter lives outside this repo**, name your logger under the scaler tree so it inherits scaler's handlers:
    `logger = logging.getLogger(f"scaler.external.{__name__}")` — otherwise your logs  will silently go nowhere.

# HUMAN SHOULD STOP READING HERE
## LOGGING MIGRATION GUIDE FOR PRIVATE WORKER MANAGERS (FOR AI):

## Context

Two recent changes in `opengris-scaler` (PRs #691 and #653) affect every
worker-manager adapter that logs output. Internal / out-of-repo adapters
must be updated to match, or their log output will either (a) not appear,
or (b) drift from the unified scaler format.

## What changed upstream

1. **Unified log format (#691)** — all scaler processes emit:
       `<timestamp> <level> <process_name>[<pid>]: <message>`
   The `<process_name>` is set by `setup_logger(..., process_name=...)`,
   called once in `scaler.entry_points.scaler._run_worker_manager` before
   your adapter's `run()` executes. You do NOT call `setup_logger` yourself.

2. **Named loggers, off the root logger (#653)** — scaler no longer
   configures the root logger. It configures the named logger `"scaler"`
   with `propagate=False`. Any logger whose dotted name starts with
   `scaler.` inherits scaler's handlers and format; anything outside that
   tree does not.

3. **ORB workaround removed.** Calls like:
       setup_logger(self._logging_paths, self._logging_config_file, self._logging_level)
   inside `__aenter__` (or anywhere inside an adapter) are now dead. The
   reason the workaround existed — third-party SDKs mutating root after
   scaler configured it — is no longer relevant because scaler no longer
   uses root.

## Required changes for an internal worker-manager adapter

### Step 1 — Add a module-level named logger

At the top of every `.py` file in the adapter that currently uses
`logging.<method>(...)` module-level calls, add:

```python
import logging

logger = logging.getLogger(f"scaler.external.{__name__}")
```

The `scaler.external.` prefix places the logger under the `scaler` tree
so it inherits scaler's handlers, format, and level automatically. If
your adapter is already under the `scaler.` namespace (unlikely for
out-of-repo code), use `logging.getLogger(__name__)` directly.

### Step 2 — Replace module-level logging calls

Mechanical substitution across every `.py` in the adapter:

    logging.info(...)       → logger.info(...)
    logging.warning(...)    → logger.warning(...)
    logging.error(...)      → logger.error(...)
    logging.exception(...)  → logger.exception(...)
    logging.debug(...)      → logger.debug(...)

Leave `import logging` — it's still needed for the `logging.getLogger`
call and any `logging.INFO`-level constants.

### Step 3 — Remove dead logging-setup code

Delete the following patterns wherever they appear in the adapter:

```python
# In __init__ — remove these lines:
self._logging_paths       = config.logging_config.paths
self._logging_level       = config.logging_config.level
self._logging_config_file = config.logging_config.config_file
```

```python
# In __aenter__ / run() / similar — remove:
setup_logger(self._logging_paths, self._logging_config_file, self._logging_level)
```

```python
# Remove the import if now unused:
from scaler.utility.logging.utility import setup_logger
```

### Step 4 — Do not call `setup_logger` from the adapter

`_run_worker_manager` in `scaler.entry_points.scaler` calls
`setup_logger(..., process_name=config._tag)` as the first statement of
the subprocess. Adapters MUST NOT call it again — doing so resets the
format with the wrong `process_name`.

### Step 5 — Verify

Run the adapter and confirm:

1. Log lines appear in the unified format
   `<time> <level> <process_name>[<pid>]: <message>`
   with `<process_name>` equal to `config._tag`.
2. No warnings about "no handler attached to logger …".
3. A third-party library calling `logging.basicConfig(...)` from within
   the subprocess does NOT change scaler's log output.

## Verification checklist

- [ ] Every `.py` in the adapter has `logger = logging.getLogger("scaler.external." + __name__)` (or equivalent scaler-prefixed name).
- [ ] `grep -rn 'logging\.\(info\|warning\|error\|exception\|debug\)(' <adapter>` returns zero matches.
- [ ] No `setup_logger` call remains in adapter code.
- [ ] No `self._logging_paths` / `_logging_level` / `_logging_config_file` field storage in adapter classes.
- [ ] Running the adapter under `scaler_all` produces log lines whose process-name prefix matches the configured `_tag`.

## What NOT to change

- Do NOT change `logging.INFO`, `logging.WARNING`, etc. constants — only the method calls.
- Do NOT rename the `logger` variable — stick to this convention for grep-ability.
- Do NOT attach handlers to your adapter's logger manually. The `scaler`
  logger already has them; propagation handles the rest.
- Do NOT set `logger.propagate = False` on the adapter's logger. You want
  it to propagate up to the `scaler` parent logger.

