### PR TITLE
Scheduler stops support `startWorker`/`shutdownWorker`

### DIFF
--- a/docs/source/tutorials/scaling/simple.rst
+++ b/docs/source/tutorials/scaling/simple.rst
@@ -127,6 +127,5 @@ The ``scaling`` option controls how worker capacity grows or shrinks.
 Notes:
 
 * ``policy_content`` must contain exactly ``allocate`` and ``scaling`` keys.
-* Scale-up is capped by each manager heartbeat's ``max_task_concurrency``.
-* Pending (booting) workers count toward the cap: if ``connected_workers + pending_workers >= max_task_concurrency``, no additional ``StartWorkers`` request is issued, preventing duplicate launches during the boot window.
+* The desired worker count emitted in ``setDesiredTaskConcurrency`` is capped by each manager heartbeat's ``max_task_concurrency``.
 * Threshold values are currently fixed in code.

--- a/docs/source/tutorials/worker_managers/aws_raw_ecs.rst
+++ b/docs/source/tutorials/worker_managers/aws_raw_ecs.rst
@@ -274,11 +274,10 @@ How It Works
 ------------
 
 1. The AWS Raw ECS worker manager connects to the Scaler scheduler and sends periodic heartbeats.
-2. When the scheduler's scaling policy requests more workers, it sends a ``StartWorkerGroup`` command.
-3. The worker manager calls ``ecs:RunTask`` to launch a Fargate task running the Scaler worker container.
+2. On each heartbeat, the scheduler responds with a ``setDesiredTaskConcurrency`` command declaring the target worker count per capability set.
+3. The worker manager converges by calling ``ecs:RunTask`` to launch Fargate tasks running the Scaler worker container when the target exceeds the current count, or by stopping Fargate tasks when the target is below it.
 4. Each Fargate task runs ``scaler_cluster`` inside the container, spawning one or more worker processes (controlled by ``--ecs-task-cpu``).
 5. Workers connect back to the scheduler and process tasks like local workers.
-6. When the scheduler wants to scale down, it sends a ``ShutdownWorkerGroup`` command and the worker manager stops the Fargate task.
 
 Configuration Reference
 ------------------------
@@ -320,7 +319,7 @@ Architecture
                                                                   runs inside each
                                                                   Fargate task)
 
-1. The scheduler sends scaling commands (``StartWorkerGroup`` / ``ShutdownWorkerGroup``) to the ECS worker manager.
+1. The scheduler sends a ``setDesiredTaskConcurrency`` command to the ECS worker manager on each heartbeat, declaring the desired worker count per capability set.
 2. The worker manager calls ``ecs:RunTask`` to launch Fargate tasks running ``scaler_cluster``.
 3. Workers inside each Fargate task connect back to the scheduler and process tasks like local workers.
 4. The worker manager auto-creates the ECS cluster and task definition on first run if they don't exist.

--- a/docs/source/tutorials/worker_managers/baremetal_native.rst
+++ b/docs/source/tutorials/worker_managers/baremetal_native.rst
@@ -186,7 +186,7 @@ Or use a TOML configuration file:
 How It Works
 ------------
 
-**Dynamic mode:** The worker manager connects to the scheduler and waits for scaling commands. When the scheduler's scaling policy determines that more workers are needed, it sends a ``StartWorkerGroup`` command. The worker manager spawns a new worker subprocess. When the scheduler wants to scale down, it sends a ``ShutdownWorkerGroup`` command and the worker manager terminates the worker. Each worker group contains exactly one worker process.
+**Dynamic mode:** The worker manager connects to the scheduler and waits for scaling commands. On every heartbeat the scheduler sends a ``setDesiredTaskConcurrency`` command that declares the desired worker count per capability set. The worker manager spawns or terminates worker subprocesses to converge toward that target. Each worker group contains exactly one worker process.
 
 **Fixed mode** (``scaler_worker_manager baremetal_native --mode fixed``): A fixed number of worker subprocesses are spawned immediately at startup and connect to the scheduler. Workers are not dynamically scaled. If a worker terminates, it is **not** automatically restarted.
 

--- a/src/cpp/scaler/protocol/pymod/schema_registry.cpp
+++ b/src/cpp/scaler/protocol/pymod/schema_registry.cpp
@@ -55,9 +55,7 @@ bool SchemaRegistry::init()
     registerCompiledSchema<scaler::protocol::WorkerHeartbeatEcho>("message", "WorkerHeartbeatEcho");
     registerCompiledSchema<scaler::protocol::WorkerManagerHeartbeat>("message", "WorkerManagerHeartbeat");
     registerCompiledSchema<scaler::protocol::WorkerManagerHeartbeatEcho>("message", "WorkerManagerHeartbeatEcho");
-    registerCompiledSchema<scaler::protocol::WorkerManagerCommandType>("message", "WorkerManagerCommandType");
     registerCompiledSchema<scaler::protocol::WorkerManagerCommand>("message", "WorkerManagerCommand");
-    registerCompiledSchema<scaler::protocol::WorkerManagerCommandResponse>("message", "WorkerManagerCommandResponse");
     registerCompiledSchema<scaler::protocol::ObjectInstruction>("message", "ObjectInstruction");
     registerCompiledSchema<scaler::protocol::DisconnectRequest>("message", "DisconnectRequest");
     registerCompiledSchema<scaler::protocol::DisconnectResponse>("message", "DisconnectResponse");

--- a/src/cpp/scaler/ymq/internal/accept_server.cpp
+++ b/src/cpp/scaler/ymq/internal/accept_server.cpp
@@ -109,7 +109,7 @@ void AcceptServer::disconnect() noexcept
 
     std::optional<std::string> pipeName {};
     if (auto* pipeServer = std::get_if<scaler::wrapper::uv::PipeServer>(&_state->_server.value())) {
-        *pipeName = UV_EXIT_ON_ERROR(pipeServer->getSockName());
+        pipeName = UV_EXIT_ON_ERROR(pipeServer->getSockName());
     }
 
     _state->_server = std::nullopt;

--- a/src/protocol/message.capnp
+++ b/src/protocol/message.capnp
@@ -98,39 +98,13 @@ struct WorkerManagerHeartbeat {
 struct WorkerManagerHeartbeatEcho {
 }
 
-enum WorkerManagerCommandType {
-    # During the transition to the declarative scaling protocol, the scheduler emits both
-    # startWorkers/shutdownWorkers (old imperative) and setDesiredTaskConcurrency (new
-    # declarative). A worker manager may handle either the old or the new variants - it is
-    # expected to ignore the ones it does not implement.
-    startWorkers @0;
-    shutdownWorkers @1;
-    setDesiredTaskConcurrency @2;
-}
-
 struct WorkerManagerCommand {
     struct DesiredTaskConcurrencyRequest {
         taskConcurrency @0 :UInt32;
         capabilities @1 :List(CommonType.TaskCapability);
     }
 
-    workerIDs @0 :List(Data);
-    command @1 :WorkerManagerCommandType;
-    capabilities @2 :List(CommonType.TaskCapability);
-    setDesiredTaskConcurrencyRequests @3 :List(DesiredTaskConcurrencyRequest);
-}
-
-struct WorkerManagerCommandResponse {
-    workerIDs @0 :List(Data);
-    command @1 :WorkerManagerCommandType;
-    status @2 :Status;
-    capabilities @3 :List(CommonType.TaskCapability);
-    enum Status {
-        tooManyWorkers @0;
-        unknownAction @1;
-        workerNotFound @2;
-        success @3;
-    }
+    setDesiredTaskConcurrencyRequests @0 :List(DesiredTaskConcurrencyRequest);
 }
 
 struct ObjectInstruction {
@@ -266,6 +240,5 @@ struct Message {
         workerManagerHeartbeat @25 :WorkerManagerHeartbeat;
         workerManagerHeartbeatEcho @26 :WorkerManagerHeartbeatEcho;
         workerManagerCommand @27 :WorkerManagerCommand;
-        workerManagerCommandResponse @28 :WorkerManagerCommandResponse;
     }
 }

--- a/src/protocol/status.capnp
+++ b/src/protocol/status.capnp
@@ -71,6 +71,8 @@ struct ScalingManagerStatus {
         lastSeenS @2 :UInt8;
         maxTaskConcurrency @3 :UInt32;
         capabilities @4 :Text;
+        # Workers the scheduler has requested but that have not yet connected.
+        # Computed each tick as max(0, total_requested - connected_count).
         pendingWorkers @5 :UInt32;
     }
 }

--- a/src/scaler/protocol/capnp.pyi
+++ b/src/scaler/protocol/capnp.pyi
@@ -236,32 +236,12 @@ class WorkerManagerHeartbeat(BaseMessage):
 
 class WorkerManagerHeartbeatEcho(BaseMessage): ...
 
-class WorkerManagerCommandType(IntEnum):
-    startWorkers = 0
-    shutdownWorkers = 1
-    setDesiredTaskConcurrency = 2
-
 class WorkerManagerCommand(BaseMessage):
-    workerIDs: Any
-    command: WorkerManagerCommandType
-    capabilities: Any
     setDesiredTaskConcurrencyRequests: Any
 
     class DesiredTaskConcurrencyRequest(CapnpStruct):
         taskConcurrency: int
         capabilities: Any
-
-class WorkerManagerCommandResponse(BaseMessage):
-    command: WorkerManagerCommandType
-    status: "WorkerManagerCommandResponse.Status"
-    workerIDs: Any
-    capabilities: Any
-
-    class Status(IntEnum):
-        tooManyWorkers = 0
-        unknownAction = 1
-        workerNotFound = 2
-        success = 3
 
 class ObjectInstruction(BaseMessage):
     instructionType: "ObjectInstruction.ObjectInstructionType"
@@ -366,7 +346,6 @@ class Message(CapnpUnionStruct):
     workerManagerHeartbeat: WorkerManagerHeartbeat
     workerManagerHeartbeatEcho: WorkerManagerHeartbeatEcho
     workerManagerCommand: WorkerManagerCommand
-    workerManagerCommandResponse: WorkerManagerCommandResponse
 
 class ObjectRequestHeader(CapnpStruct):
     MESSAGE_LENGTH: ClassVar[int]

--- a/src/scaler/protocol/helpers.py
+++ b/src/scaler/protocol/helpers.py
@@ -64,7 +64,6 @@ PROTOCOL: bidict.bidict[str, type] = bidict.bidict(
         "workerManagerHeartbeat": capnp.WorkerManagerHeartbeat,
         "workerManagerHeartbeatEcho": capnp.WorkerManagerHeartbeatEcho,
         "workerManagerCommand": capnp.WorkerManagerCommand,
-        "workerManagerCommandResponse": capnp.WorkerManagerCommandResponse,
         "disconnectRequest": capnp.DisconnectRequest,
         "disconnectResponse": capnp.DisconnectResponse,
         "stateClient": capnp.StateClient,

--- a/src/scaler/scheduler/controllers/mixins.py
+++ b/src/scaler/scheduler/controllers/mixins.py
@@ -259,10 +259,9 @@ class PolicyController(metaclass=abc.ABCMeta):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
-        """Pure function: state in, commands out. Commands are either all start or all shutdown, never mixed."""
+        """Pure function: state in, commands out (a single declarative setDesiredTaskConcurrency)."""
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/src/scaler/scheduler/controllers/policies/mixins.py
+++ b/src/scaler/scheduler/controllers/policies/mixins.py
@@ -50,7 +50,6 @@ class ScalerPolicy(metaclass=abc.ABCMeta):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
         raise NotImplementedError()

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
@@ -1,18 +1,15 @@
-import logging
 from collections import defaultdict
 from math import ceil
-from typing import Dict, FrozenSet, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Tuple
 
-from scaler.protocol.capnp import (
-    ScalingManagerStatus,
-    WorkerManagerCommand,
-    WorkerManagerCommandType,
-    WorkerManagerHeartbeat,
-)
-from scaler.protocol.helpers import dict_to_capabilities
+from scaler.protocol.capnp import ScalingManagerStatus, WorkerManagerCommand, WorkerManagerHeartbeat
 from scaler.scheduler.controllers.policies.simple_policy.scaling.mixins import ScalingPolicy
 from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
-from scaler.scheduler.controllers.worker_manager_utilties import build_scaling_manager_status, build_set_desired_command
+from scaler.scheduler.controllers.worker_manager_utilties import (
+    build_scaling_manager_status,
+    build_set_desired_command,
+    effective_desired_for_manager,
+)
 from scaler.utility.identifiers import WorkerID
 from scaler.utility.snapshot import InformationSnapshot
 
@@ -21,16 +18,12 @@ class CapabilityScalingPolicy(ScalingPolicy):
     """
     A stateless scaling policy that scales workers based on task-required capabilities.
 
-    When tasks require specific capabilities (e.g., {"gpu": 1}), this policy will
-    request workers that provide those capabilities from the worker manager.
-    It uses the same task-to-worker ratio logic as VanillaScalingPolicy but applies
-    it per capability set.
-
-    All state (managed_worker_ids, managed_worker_capabilities) is passed in as parameters.
+    For each distinct capability set observed in pending tasks, it computes a desired worker
+    count using a task-to-worker ratio threshold. The desired counts are sent declaratively
+    via setDesiredTaskConcurrency; the worker manager is responsible for making it so.
     """
 
     def __init__(self):
-        self._lower_task_ratio = 0.5
         self._upper_task_ratio = 5
 
     def get_scaling_commands(
@@ -38,37 +31,14 @@ class CapabilityScalingPolicy(ScalingPolicy):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
-        # Group tasks by their required capabilities
         tasks_by_capability = self._group_tasks_by_capability(information_snapshot)
-
-        # Group workers by their provided capabilities
-        workers_by_capability = self._group_workers_by_capability(information_snapshot)
-
-        snapshot = worker_manager_snapshots.get(worker_manager_heartbeat.workerManagerID)
-        pending = snapshot.pending_worker_count if snapshot else 0
-
-        # Try to get start commands first - if any, return early
-        start_commands = self._get_start_commands(
-            tasks_by_capability,
-            workers_by_capability,
-            managed_worker_ids,
-            managed_worker_capabilities,
-            worker_manager_heartbeat,
-            pending,
-        )
-        if start_commands:
-            imperative = start_commands
-        else:
-            imperative = self._get_shutdown_commands(
-                information_snapshot, tasks_by_capability, workers_by_capability, managed_worker_ids
-            )
-
         desired_per_capset = self._compute_desired_per_capset(tasks_by_capability, worker_manager_heartbeat)
-        declarative = build_set_desired_command(desired_per_capset)
-        return [declarative] + imperative
+        effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
+        if effective == len(managed_worker_ids):
+            return []
+        return [build_set_desired_command(desired_per_capset)]
 
     def get_status(self, managed_workers: Dict[bytes, List[WorkerID]]) -> ScalingManagerStatus:
         return build_scaling_manager_status(managed_workers)
@@ -84,167 +54,6 @@ class CapabilityScalingPolicy(ScalingPolicy):
             tasks_by_capability[capability_keys].append(task.capabilities)
 
         return tasks_by_capability
-
-    def _group_workers_by_capability(
-        self, information_snapshot: InformationSnapshot
-    ) -> Dict[FrozenSet[str], List[Tuple[WorkerID, int]]]:
-        """
-        Group workers by their provided capability keys.
-        Returns a dict mapping capability set to list of (worker_id, queued_tasks).
-        """
-        workers_by_capability: Dict[FrozenSet[str], List[Tuple[WorkerID, int]]] = defaultdict(list)
-
-        for worker_id, worker_heartbeat in information_snapshot.workers.items():
-            capability_keys = frozenset(worker_heartbeat.capabilities.keys())
-            workers_by_capability[capability_keys].append((worker_id, worker_heartbeat.queuedTasks))
-
-        return workers_by_capability
-
-    def _find_capable_workers(
-        self,
-        required_capabilities: FrozenSet[str],
-        workers_by_capability: Dict[FrozenSet[str], List[Tuple[WorkerID, int]]],
-    ) -> List[Tuple[WorkerID, int]]:
-        """
-        Find all workers that can handle tasks with the given required capabilities.
-        A worker can handle a task if the task's capability keys are a subset of the worker's.
-        """
-        capable_workers: List[Tuple[WorkerID, int]] = []
-
-        for worker_capability_keys, workers in workers_by_capability.items():
-            if required_capabilities <= worker_capability_keys:
-                capable_workers.extend(workers)
-
-        return capable_workers
-
-    def _get_start_commands(
-        self,
-        tasks_by_capability: Dict[FrozenSet[str], List[Dict[str, int]]],
-        workers_by_capability: Dict[FrozenSet[str], List[Tuple[WorkerID, int]]],
-        managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        pending_worker_count: int = 0,
-    ) -> List[WorkerManagerCommand]:
-        """Collect all start commands for capability sets that need scaling up."""
-        commands: List[WorkerManagerCommand] = []
-
-        for capability_keys, tasks in tasks_by_capability.items():
-            if not tasks:
-                continue
-
-            capable_workers = self._find_capable_workers(capability_keys, workers_by_capability)
-            capability_dict = tasks[0]
-            worker_count = len(capable_workers)
-            task_count = len(tasks)
-
-            if worker_count == 0 and task_count > 0:
-                if not self._has_capable_managed_workers(
-                    capability_keys, managed_worker_ids, managed_worker_capabilities
-                ):
-                    command = self._create_start_command(
-                        capability_dict, managed_worker_ids, worker_manager_heartbeat, pending_worker_count
-                    )
-                    if command is not None:
-                        commands.append(command)
-            elif worker_count > 0:
-                task_ratio = task_count / worker_count
-                if task_ratio > self._upper_task_ratio:
-                    command = self._create_start_command(
-                        capability_dict, managed_worker_ids, worker_manager_heartbeat, pending_worker_count
-                    )
-                    if command is not None:
-                        commands.append(command)
-
-        return commands
-
-    def _get_shutdown_commands(
-        self,
-        information_snapshot: InformationSnapshot,
-        tasks_by_capability: Dict[FrozenSet[str], List[Dict[str, int]]],
-        workers_by_capability: Dict[FrozenSet[str], List[Tuple[WorkerID, int]]],
-        managed_worker_ids: List[WorkerID],
-    ) -> List[WorkerManagerCommand]:
-        """Collect all shutdown commands for idle workers greedily."""
-        # Complexity: O(C^2 * (T + W)) where C is the number of distinct capability sets,
-        # T is the total number of tasks, and W is the total number of workers.
-        # For each tracked capability set, we iterate over all task capability sets to count
-        # matching tasks, and call _find_capable_workers which iterates over worker capability sets.
-        # This could be optimized if it becomes a performance bottleneck.
-
-        managed_set = set(managed_worker_ids)
-        shutdown_ids: List[bytes] = []
-
-        for capability_keys in list(workers_by_capability.keys()):
-            capable_workers = self._find_capable_workers(capability_keys, workers_by_capability)
-            worker_count = len(capable_workers)
-            if worker_count == 0:
-                continue
-
-            task_count = 0
-            for task_capability_keys, tasks in tasks_by_capability.items():
-                if task_capability_keys <= capability_keys:
-                    task_count += len(tasks)
-
-            if task_count / worker_count < self._lower_task_ratio:
-                managed_capable = [(wid, queued) for wid, queued in capable_workers if wid in managed_set]
-                managed_capable.sort(key=lambda x: x[1])
-
-                if task_count == 0:
-                    min_keep = 0
-                else:
-                    min_keep = max(1, ceil(task_count / self._upper_task_ratio))
-
-                # Only shut down managed workers; non-managed workers count toward min_keep
-                non_managed_count = worker_count - len(managed_capable)
-                managed_to_keep = max(0, min_keep - non_managed_count)
-                to_shutdown = len(managed_capable) - managed_to_keep
-
-                for wid, _ in managed_capable[:to_shutdown]:
-                    shutdown_ids.append(bytes(wid))
-
-        if not shutdown_ids:
-            return []
-
-        return [
-            WorkerManagerCommand(
-                workerIDs=shutdown_ids, command=WorkerManagerCommandType.shutdownWorkers, capabilities=[]
-            )
-        ]
-
-    def _has_capable_managed_workers(
-        self,
-        required_capabilities: FrozenSet[str],
-        managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
-    ) -> bool:
-        """
-        Check if we already have managed workers that can handle tasks
-        with the given required capabilities.
-        """
-        if not managed_worker_ids:
-            return False
-        manager_capability_keys = frozenset(managed_worker_capabilities.keys())
-        return required_capabilities <= manager_capability_keys
-
-    def _create_start_command(
-        self,
-        capability_dict: Dict[str, int],
-        managed_worker_ids: List[WorkerID],
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        pending_worker_count: int = 0,
-    ) -> Optional[WorkerManagerCommand]:
-        """Create a start workers command if capacity allows."""
-        max_concurrency = worker_manager_heartbeat.maxTaskConcurrency
-        if max_concurrency != -1 and len(managed_worker_ids) + pending_worker_count >= max_concurrency:
-            return None
-
-        logging.info(f"Requesting worker with capabilities: {capability_dict!r}")
-        return WorkerManagerCommand(
-            workerIDs=[],
-            command=WorkerManagerCommandType.startWorkers,
-            capabilities=dict_to_capabilities(capability_dict),
-        )
 
     def _compute_desired_per_capset(
         self,

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/mixins.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/mixins.py
@@ -11,8 +11,8 @@ class ScalingPolicy:
     """
     Stateless scaling policy interface.
 
-    All state (managed workers, capabilities) is owned by WorkerManagerController and passed in as parameters.
-    Policies return commands rather than mutating internal state.
+    All state (managed workers) is owned by WorkerManagerController and passed in as parameters.
+    Policies return a single declarative setDesiredTaskConcurrency command.
     """
 
     @abc.abstractmethod
@@ -21,14 +21,9 @@ class ScalingPolicy:
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
-        """
-        Pure function: state in, commands out.
-
-        Returns a list of WorkerManagerCommands. Commands are either all start or all shutdown, never mixed.
-        """
+        """Pure function: state in, declarative scaling command out."""
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/no.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/no.py
@@ -17,7 +17,6 @@ class NoScalingPolicy(ScalingPolicy):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
         return []

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/types.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/types.py
@@ -12,7 +12,6 @@ class WorkerManagerSnapshot:
     worker_count: int
     last_seen_s: float  # time.time() epoch seconds of last heartbeat
     capabilities: Dict[str, int] = dataclasses.field(default_factory=dict)
-    pending_worker_count: int = 0
 
 
 class ScalingPolicyStrategy(enum.Enum):

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
@@ -1,15 +1,14 @@
 from math import ceil
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
-from scaler.protocol.capnp import (
-    ScalingManagerStatus,
-    WorkerManagerCommand,
-    WorkerManagerCommandType,
-    WorkerManagerHeartbeat,
-)
+from scaler.protocol.capnp import ScalingManagerStatus, WorkerManagerCommand, WorkerManagerHeartbeat
 from scaler.scheduler.controllers.policies.simple_policy.scaling.mixins import ScalingPolicy
 from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
-from scaler.scheduler.controllers.worker_manager_utilties import build_scaling_manager_status, build_set_desired_command
+from scaler.scheduler.controllers.worker_manager_utilties import (
+    build_scaling_manager_status,
+    build_set_desired_command,
+    effective_desired_for_manager,
+)
 from scaler.utility.identifiers import WorkerID
 from scaler.utility.snapshot import InformationSnapshot
 
@@ -28,87 +27,41 @@ class VanillaScalingPolicy(ScalingPolicy):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
-        snapshot = worker_manager_snapshots.get(worker_manager_heartbeat.workerManagerID)
-        pending = snapshot.pending_worker_count if snapshot else 0
-
-        if not information_snapshot.workers:
-            if information_snapshot.tasks:
-                imperative = self._create_start_commands(managed_worker_ids, worker_manager_heartbeat, pending)
-            else:
-                imperative = []
-        else:
-            task_ratio = len(information_snapshot.tasks) / len(information_snapshot.workers)
-            if task_ratio > self._upper_task_ratio:
-                imperative = self._create_start_commands(managed_worker_ids, worker_manager_heartbeat, pending)
-            elif task_ratio < self._lower_task_ratio:
-                imperative = self._create_shutdown_commands(information_snapshot, managed_worker_ids)
-            else:
-                imperative = []
-
-        desired = self._compute_desired_worker_count(managed_worker_ids, pending, imperative)
-        declarative = build_set_desired_command([({}, desired)])
-        return [declarative] + imperative
+        desired = self._compute_desired_worker_count(information_snapshot, worker_manager_heartbeat, managed_worker_ids)
+        desired_per_capset: List[Tuple[Dict[str, int], int]] = [({}, desired)]
+        effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
+        if effective == len(managed_worker_ids):
+            return []
+        return [build_set_desired_command(desired_per_capset)]
 
     def get_status(self, managed_workers: Dict[bytes, List[WorkerID]]) -> ScalingManagerStatus:
         return build_scaling_manager_status(managed_workers)
 
-    def _create_start_commands(
-        self,
-        managed_worker_ids: List[WorkerID],
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        pending_worker_count: int = 0,
-    ) -> List[WorkerManagerCommand]:
-        max_concurrency = worker_manager_heartbeat.maxTaskConcurrency
-        if max_concurrency != -1 and len(managed_worker_ids) + pending_worker_count >= max_concurrency:
-            return []
-        return [WorkerManagerCommand(workerIDs=[], command=WorkerManagerCommandType.startWorkers, capabilities=[])]
-
-    def _create_shutdown_commands(
-        self, information_snapshot: InformationSnapshot, managed_worker_ids: List[WorkerID]
-    ) -> List[WorkerManagerCommand]:
-        if not managed_worker_ids:
-            return []
-
-        workers_with_load = []
-        for wid in managed_worker_ids:
-            if wid in information_snapshot.workers:
-                workers_with_load.append((wid, information_snapshot.workers[wid].queuedTasks))
-        workers_with_load.sort(key=lambda x: x[1])
-
-        if not workers_with_load:
-            return []
-
-        task_count = len(information_snapshot.tasks)
-        if task_count == 0:
-            min_keep = 0
-        else:
-            min_keep = max(1, ceil(task_count / self._upper_task_ratio))
-
-        to_shutdown = len(workers_with_load) - min_keep
-        if to_shutdown <= 0:
-            return []
-
-        shutdown_ids = [bytes(wid) for wid, _ in workers_with_load[:to_shutdown]]
-        return [
-            WorkerManagerCommand(
-                workerIDs=shutdown_ids, command=WorkerManagerCommandType.shutdownWorkers, capabilities=[]
-            )
-        ]
-
     def _compute_desired_worker_count(
         self,
+        information_snapshot: InformationSnapshot,
+        worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        pending_worker_count: int,
-        imperative_commands: List[WorkerManagerCommand],
     ) -> int:
-        """Desired count equals current + pending adjusted by this tick's imperative deltas."""
-        desired = len(managed_worker_ids) + pending_worker_count
-        for command in imperative_commands:
-            if command.command == WorkerManagerCommandType.startWorkers:
-                desired += 1
-            elif command.command == WorkerManagerCommandType.shutdownWorkers:
-                desired -= len(command.workerIDs)
+        """Compute the target worker count for this manager from current task and worker observations."""
+        current = len(managed_worker_ids)
+        task_count = len(information_snapshot.tasks)
+        worker_count = len(information_snapshot.workers)
+
+        if worker_count == 0:
+            desired = current + 1 if task_count > 0 else current
+        else:
+            task_ratio = task_count / worker_count
+            if task_ratio > self._upper_task_ratio:
+                desired = current + 1
+            elif task_ratio < self._lower_task_ratio:
+                desired = 0 if task_count == 0 else max(1, ceil(task_count / self._upper_task_ratio))
+            else:
+                desired = current
+
+        max_concurrency = worker_manager_heartbeat.maxTaskConcurrency
+        if max_concurrency != -1:
+            desired = min(desired, max_concurrency)
         return max(0, desired)

--- a/src/scaler/scheduler/controllers/policies/simple_policy/simple_policy.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/simple_policy.py
@@ -62,15 +62,10 @@ class SimplePolicy(ScalerPolicy):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
         return self._scaling_policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            managed_worker_ids,
-            managed_worker_capabilities,
-            worker_manager_snapshots,
+            information_snapshot, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
         )
 
     def get_scaling_status(self, managed_workers: Dict[bytes, List[WorkerID]]) -> ScalingManagerStatus:

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -110,6 +110,15 @@ class WaterfallScalingPolicy(ScalingPolicy):
         """Allocate this manager's share of the cluster-wide generic worker target."""
         task_count = len(information_snapshot.tasks)
         if task_count == 0:
+            # Drain lower-priority managers first: if any lower-priority manager still has
+            # connected workers, this manager holds its current count rather than draining.
+            for rule in self._rules:
+                if rule.priority <= current_rule.priority:
+                    continue
+                snap = snapshots.get(rule.worker_manager_id)
+                if snap is not None and snap.worker_count > 0:
+                    own_snap = snapshots.get(current_rule.worker_manager_id)
+                    return own_snap.worker_count if own_snap is not None else 0
             return 0
         total_desired = max(1, ceil(task_count / self._upper_task_ratio))
 

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -2,39 +2,35 @@ import logging
 from math import ceil
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
-from scaler.protocol.capnp import (
-    ScalingManagerStatus,
-    WorkerManagerCommand,
-    WorkerManagerCommandType,
-    WorkerManagerHeartbeat,
-)
-from scaler.protocol.helpers import dict_to_capabilities
+from scaler.protocol.capnp import ScalingManagerStatus, WorkerManagerCommand, WorkerManagerHeartbeat
 from scaler.scheduler.controllers.policies.simple_policy.scaling.mixins import ScalingPolicy
 from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
 from scaler.scheduler.controllers.policies.waterfall_v1.scaling.types import WaterfallRule
-from scaler.scheduler.controllers.worker_manager_utilties import build_scaling_manager_status, build_set_desired_command
+from scaler.scheduler.controllers.worker_manager_utilties import (
+    build_scaling_manager_status,
+    build_set_desired_command,
+    effective_desired_for_manager,
+)
 from scaler.utility.identifiers import WorkerID
 from scaler.utility.snapshot import InformationSnapshot
 
 
 class WaterfallScalingPolicy(ScalingPolicy):
     """
-    Stateless scaling policy that cascades worker scaling across prioritized worker managers.
+    Stateless declarative scaling policy that cascades worker allocation across prioritized
+    worker managers.
 
-    Priority-1 managers fill first; overflow goes to priority-2, then priority-3, etc.
-    Shutdown is reversed: highest priority number (least preferred) drains first.
+    For each capability set (including the generic empty set) the total target worker count
+    is computed from observed task volume, then assigned to managers in priority order.
+    Higher-priority managers absorb capacity first; overflow spills to the next priority.
 
-    Rules reference exact worker manager IDs. Each rule maps to one specific worker manager.
-
-    All configuration (rules, thresholds) is immutable after construction.
-    All mutable state is passed as function parameters.
+    Capability-aware allocation: only managers whose advertised capabilities are a superset
+    of a task capset participate in that capset's allocation chain.
     """
 
     def __init__(self, rules: List[WaterfallRule]):
         self._rules = sorted(rules, key=lambda r: r.priority)
         self._rule_by_manager_id: Dict[bytes, WaterfallRule] = {r.worker_manager_id: r for r in self._rules}
-        # Scale down when tasks/workers < 1 (more workers than tasks, underutilized)
-        self._lower_task_ratio = 1
         # Scale up when tasks/workers > 10 (tasks significantly outnumber workers, overloaded)
         self._upper_task_ratio = 10
 
@@ -43,7 +39,6 @@ class WaterfallScalingPolicy(ScalingPolicy):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
         manager_id = worker_manager_heartbeat.workerManagerID
@@ -53,226 +48,16 @@ class WaterfallScalingPolicy(ScalingPolicy):
             logging.warning("Worker manager %r not found in waterfall rules, skipping scaling", manager_id)
             return []
 
-        imperative = self._build_imperative(
-            rule, information_snapshot, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
-        )
         desired_per_capset = self._compute_desired_per_capset(
-            rule, information_snapshot, worker_manager_heartbeat, managed_worker_ids, imperative
+            rule, information_snapshot, worker_manager_heartbeat, worker_manager_snapshots
         )
-        declarative = build_set_desired_command(desired_per_capset)
-        return [declarative] + imperative
+        effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
+        if effective == len(managed_worker_ids):
+            return []
+        return [build_set_desired_command(desired_per_capset)]
 
     def get_status(self, managed_workers: Dict[bytes, List[WorkerID]]) -> ScalingManagerStatus:
         return build_scaling_manager_status(managed_workers)
-
-    def _build_imperative(
-        self,
-        rule: WaterfallRule,
-        information_snapshot: InformationSnapshot,
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        managed_worker_ids: List[WorkerID],
-        worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
-    ) -> List[WorkerManagerCommand]:
-        # Check for tasks with capabilities that no existing worker can handle
-        capability_commands = self._create_capability_start_commands(
-            rule, information_snapshot, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
-        )
-        if capability_commands:
-            return capability_commands
-
-        if not information_snapshot.workers:
-            if information_snapshot.tasks:
-                return self._create_start_commands(
-                    rule, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
-                )
-            return []
-
-        task_ratio = len(information_snapshot.tasks) / len(information_snapshot.workers)
-
-        if task_ratio > self._upper_task_ratio:
-            return self._create_start_commands(
-                rule, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
-            )
-        elif task_ratio < self._lower_task_ratio:
-            return self._create_shutdown_commands(
-                rule, information_snapshot, managed_worker_ids, worker_manager_snapshots
-            )
-
-        return []
-
-    def _create_capability_start_commands(
-        self,
-        current_rule: WaterfallRule,
-        information_snapshot: InformationSnapshot,
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        managed_worker_ids: List[WorkerID],
-        worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
-    ) -> List[WorkerManagerCommand]:
-        """Create start commands for tasks whose capabilities are not met by any existing worker."""
-        unmet = self._find_unmet_capabilities(information_snapshot)
-        if not unmet:
-            return []
-
-        commands: List[WorkerManagerCommand] = []
-
-        for required_keys, capability_dict in unmet.items():
-            command = self._resolve_capability_start(
-                current_rule,
-                required_keys,
-                capability_dict,
-                managed_worker_ids,
-                worker_manager_heartbeat,
-                worker_manager_snapshots,
-            )
-            if command is not None:
-                commands.append(command)
-
-        return commands
-
-    def _find_unmet_capabilities(
-        self, information_snapshot: InformationSnapshot
-    ) -> Dict[FrozenSet[str], Dict[str, int]]:
-        """Return capability sets required by tasks that no existing worker can handle.
-
-        Only considers tasks with non-empty capability requirements. Returns a dict mapping
-        each unmet capability key-set to a representative capability dict from one such task.
-        """
-        worker_capability_sets: List[FrozenSet[str]] = [
-            frozenset(worker_hb.capabilities.keys()) for worker_hb in information_snapshot.workers.values()
-        ]
-
-        unmet: Dict[FrozenSet[str], Dict[str, int]] = {}
-        for task in information_snapshot.tasks.values():
-            if not task.capabilities:
-                continue
-            required_keys = frozenset(task.capabilities.keys())
-            if required_keys in unmet:
-                continue
-            if not any(required_keys <= wc for wc in worker_capability_sets):
-                unmet[required_keys] = dict(task.capabilities)
-
-        return unmet
-
-    def _resolve_capability_start(
-        self,
-        current_rule: WaterfallRule,
-        required_keys: FrozenSet[str],
-        capability_dict: Dict[str, int],
-        managed_worker_ids: List[WorkerID],
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
-    ) -> Optional[WorkerManagerCommand]:
-        """Walk the waterfall priority chain and return a start command if this manager should handle it."""
-        for rule in self._rules:
-            snapshot = self._find_matching_snapshot(rule, worker_manager_snapshots)
-            if snapshot is None:
-                continue
-
-            if not required_keys <= frozenset(snapshot.capabilities.keys()):
-                continue
-
-            effective_capacity = min(rule.max_task_concurrency, snapshot.max_task_concurrency)
-            if snapshot.worker_count >= effective_capacity:
-                continue
-
-            # This is the highest-priority capable manager with capacity
-            if rule.worker_manager_id == current_rule.worker_manager_id:
-                local_capacity = min(current_rule.max_task_concurrency, worker_manager_heartbeat.maxTaskConcurrency)
-                if len(managed_worker_ids) >= local_capacity:
-                    return None
-                return WorkerManagerCommand(
-                    workerIDs=[],
-                    command=WorkerManagerCommandType.startWorkers,
-                    capabilities=dict_to_capabilities(capability_dict),
-                )
-            else:
-                # A higher-priority capable manager should handle it
-                return None
-
-        return None
-
-    def _create_start_commands(
-        self,
-        current_rule: WaterfallRule,
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        managed_worker_ids: List[WorkerID],
-        worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
-    ) -> List[WorkerManagerCommand]:
-        # Check if higher-priority managers (lower priority number) still have capacity
-        for rule in self._rules:
-            if rule.priority >= current_rule.priority:
-                continue
-
-            snapshot = self._find_matching_snapshot(rule, worker_manager_snapshots)
-            if snapshot is None:
-                continue  # manager offline or never seen
-
-            effective_capacity = min(rule.max_task_concurrency, snapshot.max_task_concurrency)
-            if snapshot.worker_count < effective_capacity:
-                # Higher-priority manager still has room, let it fill first
-                return []
-
-        # Check this manager's effective capacity
-        effective_capacity = min(current_rule.max_task_concurrency, worker_manager_heartbeat.maxTaskConcurrency)
-        if len(managed_worker_ids) >= effective_capacity:
-            return []
-
-        return [WorkerManagerCommand(workerIDs=[], command=WorkerManagerCommandType.startWorkers, capabilities=[])]
-
-    def _create_shutdown_commands(
-        self,
-        current_rule: WaterfallRule,
-        information_snapshot: InformationSnapshot,
-        managed_worker_ids: List[WorkerID],
-        worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
-    ) -> List[WorkerManagerCommand]:
-        if not managed_worker_ids:
-            return []
-
-        # Check if lower-priority managers (higher priority number) still have workers to drain first
-        for rule in self._rules:
-            if rule.priority <= current_rule.priority:
-                continue
-
-            snapshot = self._find_matching_snapshot(rule, worker_manager_snapshots)
-            if snapshot is not None and snapshot.worker_count > 0:
-                # Lower-priority manager still has workers, let it drain first
-                return []
-
-        # Partition managed workers: prefer shutting down workers without capabilities first
-        no_cap_candidates: List[Tuple[WorkerID, int]] = []
-        has_cap_candidates: List[Tuple[WorkerID, int]] = []
-        for wid in managed_worker_ids:
-            if wid in information_snapshot.workers:
-                worker_hb = information_snapshot.workers[wid]
-                if worker_hb.capabilities:
-                    has_cap_candidates.append((wid, worker_hb.queuedTasks))
-                else:
-                    no_cap_candidates.append((wid, worker_hb.queuedTasks))
-
-        no_cap_candidates.sort(key=lambda x: x[1])
-        has_cap_candidates.sort(key=lambda x: x[1])
-        workers_with_load = no_cap_candidates + has_cap_candidates
-
-        if not workers_with_load:
-            return []
-
-        task_count = len(information_snapshot.tasks)
-        if task_count == 0:
-            min_keep = 0
-        else:
-            min_keep = max(1, ceil(task_count / self._upper_task_ratio))
-
-        to_shutdown = len(workers_with_load) - min_keep
-        if to_shutdown <= 0:
-            return []
-
-        shutdown_ids = [bytes(wid) for wid, _ in workers_with_load[:to_shutdown]]
-        return [
-            WorkerManagerCommand(
-                workerIDs=shutdown_ids, command=WorkerManagerCommandType.shutdownWorkers, capabilities=[]
-            )
-        ]
 
     def _find_rule(self, manager_id: bytes) -> Optional[WaterfallRule]:
         """Find the rule whose worker manager ID matches *manager_id*."""
@@ -286,43 +71,116 @@ class WaterfallScalingPolicy(ScalingPolicy):
 
     def _compute_desired_per_capset(
         self,
-        rule: WaterfallRule,
+        current_rule: WaterfallRule,
         information_snapshot: InformationSnapshot,
-        worker_manager_heartbeat: WorkerManagerHeartbeat,
-        managed_worker_ids: List[WorkerID],
-        imperative_commands: List[WorkerManagerCommand],
+        current_heartbeat: WorkerManagerHeartbeat,
+        snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[Tuple[Dict[str, int], int]]:
-        """Compute desired per capability set using current + imperative delta.
+        """Compute desired worker count per capability set for this manager only.
 
-        A single request with empty capabilities covers the generic (non-capability)
-        demand for this manager. Capability-specific requests mirror imperative
-        startWorkers commands carrying non-empty capabilities (i.e. capsets this
-        manager has been asked to scale up for this heartbeat).
+        Generic (empty-cap) tasks fill higher-priority managers first; this manager's share is
+        whatever overflows from higher priorities, clamped by its effective capacity.
+
+        Capability-specific requests are emitted only for capsets this manager owns: the
+        highest-priority manager whose advertised capabilities are a superset of the capset.
         """
-        current = len(managed_worker_ids)
+        result: List[Tuple[Dict[str, int], int]] = []
 
-        start_delta = sum(1 for c in imperative_commands if c.command == WorkerManagerCommandType.startWorkers)
-        shutdown_delta = sum(
-            len(c.workerIDs) for c in imperative_commands if c.command == WorkerManagerCommandType.shutdownWorkers
+        generic_desired = self._allocate_generic_desired(
+            current_rule, information_snapshot, current_heartbeat, snapshots
         )
-        desired_generic = max(0, current + start_delta - shutdown_delta)
-        effective_capacity = min(rule.max_task_concurrency, worker_manager_heartbeat.maxTaskConcurrency)
-        if effective_capacity >= 0:
-            desired_generic = min(desired_generic, effective_capacity)
+        result.append(({}, generic_desired))
 
-        result: List[Tuple[Dict[str, int], int]] = [({}, desired_generic)]
+        for required_keys, capability_dict in self._tasks_by_capability(information_snapshot).items():
+            cap_desired = self._allocate_capset_desired(
+                current_rule, required_keys, information_snapshot, current_heartbeat, snapshots
+            )
+            if cap_desired > 0:
+                result.append((capability_dict, cap_desired))
 
-        for command in imperative_commands:
-            if command.command != WorkerManagerCommandType.startWorkers:
+        return result
+
+    def _allocate_generic_desired(
+        self,
+        current_rule: WaterfallRule,
+        information_snapshot: InformationSnapshot,
+        current_heartbeat: WorkerManagerHeartbeat,
+        snapshots: Dict[bytes, WorkerManagerSnapshot],
+    ) -> int:
+        """Allocate this manager's share of the cluster-wide generic worker target."""
+        task_count = len(information_snapshot.tasks)
+        if task_count == 0:
+            return 0
+        total_desired = max(1, ceil(task_count / self._upper_task_ratio))
+
+        remaining = total_desired
+        for rule in self._rules:
+            cap = self._effective_capacity(rule, current_rule, current_heartbeat, snapshots)
+            if cap is None:
                 continue
-            caps = command.capabilities
-            caps_dict = dict(caps) if isinstance(caps, dict) else {c.name: c.value for c in caps}
-            if not caps_dict:
-                continue
-            # Capability-specific capset: +1 worker requested this tick.
-            cap_desired = 1
-            if effective_capacity >= 0:
-                cap_desired = min(cap_desired, effective_capacity)
-            result.append((caps_dict, cap_desired))
+            if rule.worker_manager_id == current_rule.worker_manager_id:
+                return min(remaining, cap)
+            remaining = max(0, remaining - cap)
+        return 0
 
+    def _allocate_capset_desired(
+        self,
+        current_rule: WaterfallRule,
+        required_keys: FrozenSet[str],
+        information_snapshot: InformationSnapshot,
+        current_heartbeat: WorkerManagerHeartbeat,
+        snapshots: Dict[bytes, WorkerManagerSnapshot],
+    ) -> int:
+        """Allocate this manager's share of the target for one capability set."""
+        task_count = sum(
+            1 for task in information_snapshot.tasks.values() if frozenset(task.capabilities.keys()) == required_keys
+        )
+        if task_count == 0:
+            return 0
+        total_desired = max(1, ceil(task_count / self._upper_task_ratio))
+
+        remaining = total_desired
+        for rule in self._rules:
+            snap = self._find_matching_snapshot(rule, snapshots)
+            if rule.worker_manager_id == current_rule.worker_manager_id:
+                manager_capabilities = frozenset(current_heartbeat.capabilities.keys())
+            elif snap is not None:
+                manager_capabilities = frozenset(snap.capabilities.keys())
+            else:
+                continue
+            if not required_keys <= manager_capabilities:
+                continue
+
+            cap = self._effective_capacity(rule, current_rule, current_heartbeat, snapshots)
+            if cap is None:
+                continue
+            if rule.worker_manager_id == current_rule.worker_manager_id:
+                return min(remaining, cap)
+            remaining = max(0, remaining - cap)
+        return 0
+
+    def _effective_capacity(
+        self,
+        rule: WaterfallRule,
+        current_rule: WaterfallRule,
+        current_heartbeat: WorkerManagerHeartbeat,
+        snapshots: Dict[bytes, WorkerManagerSnapshot],
+    ) -> Optional[int]:
+        """Return min(rule cap, manager-reported max). Returns None if the manager is offline."""
+        if rule.worker_manager_id == current_rule.worker_manager_id:
+            return min(rule.max_task_concurrency, current_heartbeat.maxTaskConcurrency)
+        snap = self._find_matching_snapshot(rule, snapshots)
+        if snap is None:
+            return None
+        return min(rule.max_task_concurrency, snap.max_task_concurrency)
+
+    def _tasks_by_capability(self, information_snapshot: InformationSnapshot) -> Dict[FrozenSet[str], Dict[str, int]]:
+        """Group tasks with non-empty capabilities, mapping capset keys to a representative dict."""
+        result: Dict[FrozenSet[str], Dict[str, int]] = {}
+        for task in information_snapshot.tasks.values():
+            if not task.capabilities:
+                continue
+            required_keys = frozenset(task.capabilities.keys())
+            if required_keys not in result:
+                result[required_keys] = dict(task.capabilities)
         return result

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/waterfall_v1_policy.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/waterfall_v1_policy.py
@@ -59,15 +59,10 @@ class WaterfallV1Policy(ScalerPolicy):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
         return self._scaling_policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            managed_worker_ids,
-            managed_worker_capabilities,
-            worker_manager_snapshots,
+            information_snapshot, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
         )
 
     def get_scaling_status(self, managed_workers: Dict[bytes, List[WorkerID]]) -> ScalingManagerStatus:

--- a/src/scaler/scheduler/controllers/vanilla_policy_controller.py
+++ b/src/scaler/scheduler/controllers/vanilla_policy_controller.py
@@ -44,15 +44,10 @@ class VanillaPolicyController(PolicyController):
         information_snapshot: InformationSnapshot,
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
-        managed_worker_capabilities: Dict[str, int],
         worker_manager_snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> List[WorkerManagerCommand]:
         return self._policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            managed_worker_ids,
-            managed_worker_capabilities,
-            worker_manager_snapshots,
+            information_snapshot, worker_manager_heartbeat, managed_worker_ids, worker_manager_snapshots
         )
 
     def get_scaling_status(self, managed_workers: Dict[bytes, List[WorkerID]]) -> ScalingManagerStatus:

--- a/src/scaler/scheduler/controllers/worker_manager_controller.py
+++ b/src/scaler/scheduler/controllers/worker_manager_controller.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
 from scaler.config.defaults import DEFAULT_WORKER_MANAGER_TIMEOUT_SECONDS
@@ -8,8 +7,6 @@ from scaler.io.mixins import AsyncBinder
 from scaler.protocol.capnp import (
     ScalingManagerStatus,
     WorkerManagerCommand,
-    WorkerManagerCommandResponse,
-    WorkerManagerCommandType,
     WorkerManagerHeartbeat,
     WorkerManagerHeartbeatEcho,
 )
@@ -35,19 +32,12 @@ class WorkerManagerController(Looper, Reporter):
         # Track worker manager heartbeats: source -> (last_seen_time, heartbeat)
         self._manager_alive_since: Dict[bytes, Tuple[float, WorkerManagerHeartbeat]] = {}
 
-        # Track last command sent to each source
-        self._pending_commands: Dict[bytes, WorkerManagerCommand] = {}
-
-        # Track capabilities per manager: source -> capabilities dict
-        self._manager_capabilities: Dict[bytes, Dict[str, int]] = defaultdict(dict)
-
         # Reverse map: worker_manager_id -> source (for duplicate detection)
         self._manager_id_to_source: Dict[bytes, bytes] = {}
 
-        # Pending worker tracking: workers launched (StartWorkers success) but not yet connected.
-        # _pending_worker_count[source] is decremented as workers appear in the worker controller.
-        self._pending_worker_count: Dict[bytes, int] = {}
-        self._last_worker_count: Dict[bytes, int] = {}
+        # Per-manager total desired worker count from the latest setDesiredTaskConcurrency command.
+        # Used to report pendingWorkers = max(0, last_desired - connected_count) to the monitor.
+        self._last_desired_total: Dict[bytes, int] = {}
 
     def register(self, binder: AsyncBinder, task_controller: TaskController, worker_controller: WorkerController):
         self._binder = binder
@@ -74,55 +64,17 @@ class WorkerManagerController(Looper, Reporter):
         await self._binder.send(source, WorkerManagerHeartbeatEcho())
 
         information_snapshot = self._build_snapshot()
-
-        # Get managed worker IDs from worker controller (heartbeat-based live truth)
         managed_worker_ids = self._worker_controller.get_workers_by_manager_id(heartbeat.workerManagerID)
-
-        # Update pending worker count: decrement for each worker that newly connected.
-        worker_count = len(managed_worker_ids)
-        prev_count = self._last_worker_count.get(source, 0)
-        newly_connected = max(0, worker_count - prev_count)
-        if newly_connected > 0:
-            self._pending_worker_count[source] = max(0, self._pending_worker_count.get(source, 0) - newly_connected)
-        self._last_worker_count[source] = worker_count
-
-        managed_worker_capabilities = self._manager_capabilities[source]
-
-        # Build cross-manager snapshots from all known managers
         worker_manager_snapshots = self._build_manager_snapshots()
 
-        # Wait for the previous command to complete before sending another.
-        # Worker managers can take a long time to fulfill commands (e.g. ORB polls for instance IDs),
-        # so sending a new command before the response arrives causes duplicate work and errors.
-        if source in self._pending_commands:
-            return
-
         commands = self._policy_controller.get_scaling_commands(
-            information_snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, worker_manager_snapshots
+            information_snapshot, heartbeat, managed_worker_ids, worker_manager_snapshots
         )
 
         for command in commands:
             await self._send_command(source, command)
 
-    async def on_command_response(self, source: bytes, response: WorkerManagerCommandResponse):
-        """Called by scheduler event loop when WorkerManagerCommandResponse is received."""
-        response_capabilities = capabilities_to_dict(getattr(response, "capabilities", {}))
-        pending = self._pending_commands.pop(source, None)
-        if pending is None:
-            logging.warning(f"Received response from {source!r} but no pending command found")
-
-        if response.command == WorkerManagerCommandType.startWorkers:
-            if response.status == WorkerManagerCommandResponse.Status.success:
-                if response_capabilities:
-                    self._manager_capabilities[source] = response_capabilities
-                new_workers = len(response.workerIDs)
-                self._pending_worker_count[source] = self._pending_worker_count.get(source, 0) + new_workers
-            else:
-                logging.warning(f"StartWorkers failed: {response.status.name}")
-
-        elif response.command == WorkerManagerCommandType.shutdownWorkers:
-            if response.status != WorkerManagerCommandResponse.Status.success:
-                logging.warning(f"ShutdownWorkers failed: {response.status.name}")
+        self._last_desired_total[source] = _sum_desired_for_manager(commands, heartbeat.capabilities)
 
     async def routine(self):
         await self._clean_managers()
@@ -135,6 +87,8 @@ class WorkerManagerController(Looper, Reporter):
         for source, (last_seen, heartbeat) in self._manager_alive_since.items():
             caps = heartbeat.capabilities
             caps_str = " ".join(sorted(capabilities_to_dict(caps).keys())) if caps else ""
+            connected = len(self._worker_controller.get_workers_by_manager_id(heartbeat.workerManagerID))
+            pending = max(0, self._last_desired_total.get(source, 0) - connected)
             details.append(
                 {
                     "worker_manager_id": heartbeat.workerManagerID,
@@ -142,7 +96,7 @@ class WorkerManagerController(Looper, Reporter):
                     "last_seen_s": min(int(now - last_seen), 255),
                     "max_task_concurrency": heartbeat.maxTaskConcurrency,
                     "capabilities": caps_str,
-                    "pending_workers": self._pending_worker_count.get(source, 0),
+                    "pending_workers": pending,
                 }
             )
 
@@ -157,11 +111,6 @@ class WorkerManagerController(Looper, Reporter):
         return result
 
     async def _send_command(self, source: bytes, command: WorkerManagerCommand):
-        # setDesiredTaskConcurrency is declarative and worker managers may silently ignore it
-        # during the transition. No response is guaranteed, so it must bypass the single-
-        # in-flight gate; otherwise the gate would wedge and block all subsequent scaling.
-        if command.command != WorkerManagerCommandType.setDesiredTaskConcurrency:
-            self._pending_commands[source] = command
         await self._binder.send(source, command)
 
     def _build_manager_snapshots(self) -> Dict[bytes, WorkerManagerSnapshot]:
@@ -174,7 +123,6 @@ class WorkerManagerController(Looper, Reporter):
                 worker_manager_id=manager_id,
                 max_task_concurrency=heartbeat.maxTaskConcurrency,
                 worker_count=worker_count,
-                pending_worker_count=self._pending_worker_count.get(source, 0),
                 last_seen_s=last_seen,
                 capabilities=heartbeat.capabilities,
             )
@@ -213,7 +161,20 @@ class WorkerManagerController(Looper, Reporter):
 
         logging.info(f"WorkerManager {source!r} disconnected")
         self._manager_alive_since.pop(source)
-        self._pending_commands.pop(source, None)
-        self._manager_capabilities.pop(source, None)
-        self._pending_worker_count.pop(source, None)
-        self._last_worker_count.pop(source, None)
+        self._last_desired_total.pop(source, None)
+
+
+def _sum_desired_for_manager(commands: List[WorkerManagerCommand], manager_capabilities: Dict[str, int]) -> int:
+    """Sum taskConcurrency across requests whose capability set is a subset of the manager's capabilities.
+
+    Mirrors the rule the worker manager itself applies to translate the declarative command into a
+    concrete worker count. An empty capability set on a request acts as a wildcard.
+    """
+    manager_items = manager_capabilities.items()
+    total = 0
+    for command in commands:
+        for request in getattr(command, "setDesiredTaskConcurrencyRequests", ()):
+            req_caps = capabilities_to_dict(request.capabilities)
+            if req_caps.items() <= manager_items:
+                total += request.taskConcurrency
+    return total

--- a/src/scaler/scheduler/controllers/worker_manager_utilties.py
+++ b/src/scaler/scheduler/controllers/worker_manager_utilties.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, Tuple
 
 from scaler.protocol import capnp
-from scaler.protocol.capnp import ScalingManagerStatus, TaskCapability, WorkerManagerCommand, WorkerManagerCommandType
+from scaler.protocol.capnp import ScalingManagerStatus, TaskCapability, WorkerManagerCommand
 
 
 def build_scaling_manager_status(
@@ -43,9 +43,21 @@ def build_set_desired_command(desired_per_capset: List[Tuple[Dict[str, int], int
         )
         for caps, count in desired_per_capset
     ]
-    return WorkerManagerCommand(
-        workerIDs=[],
-        command=WorkerManagerCommandType.setDesiredTaskConcurrency,
-        capabilities=[],
-        setDesiredTaskConcurrencyRequests=requests,
-    )
+    return WorkerManagerCommand(setDesiredTaskConcurrencyRequests=requests)
+
+
+def effective_desired_for_manager(
+    desired_per_capset: List[Tuple[Dict[str, int], int]], manager_capabilities: Dict[str, int]
+) -> int:
+    """Sum taskConcurrency across capsets the manager can serve.
+
+    Capability subsumption is by name only: a request capset whose keys are a subset of
+    the manager's advertised capability names is considered serviceable, regardless of
+    the numeric values attached to either side (matches waterfall's allocation rule).
+    """
+    manager_keys = set(manager_capabilities.keys())
+    total = 0
+    for caps, count in desired_per_capset:
+        if set(caps.keys()) <= manager_keys:
+            total += count
+    return total

--- a/src/scaler/scheduler/scheduler.py
+++ b/src/scaler/scheduler/scheduler.py
@@ -22,7 +22,6 @@ from scaler.protocol.capnp import (
     TaskLog,
     TaskResult,
     WorkerHeartbeat,
-    WorkerManagerCommandResponse,
     WorkerManagerHeartbeat,
 )
 from scaler.scheduler.controllers.balance_controller import VanillaBalanceController
@@ -235,10 +234,6 @@ class Scheduler:
         # worker manager controller
         if isinstance(message, WorkerManagerHeartbeat):
             await self._worker_manager_controller.on_heartbeat(source, message)
-            return
-
-        if isinstance(message, WorkerManagerCommandResponse):
-            await self._worker_manager_controller.on_command_response(source, message)
             return
 
         logging.error(f"{self.__class__.__name__}: unknown message from {source=}: {message}")

--- a/src/scaler/worker_manager_adapter/mixins.py
+++ b/src/scaler/worker_manager_adapter/mixins.py
@@ -4,14 +4,12 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Tuple
 
-from scaler.protocol.capnp import ProcessorStatus, Task, TaskCancel, WorkerManagerCommandResponse
-from scaler.utility.identifiers import TaskID, WorkerID
+from scaler.protocol.capnp import ProcessorStatus, Task, TaskCancel
+from scaler.utility.identifiers import TaskID
 
 if TYPE_CHECKING:
     from scaler.protocol.capnp import WorkerManagerCommand
     from scaler.worker_manager_adapter.task_manager import TaskManager
-
-Status = WorkerManagerCommandResponse.Status
 
 
 class ProcessorStatusProvider(ABC):
@@ -45,14 +43,6 @@ class ExecutionBackend(ABC):
 
     @abstractmethod
     def register(self, load_task_inputs: Callable[[Task], Awaitable[Tuple[Any, List[Any]]]]) -> None: ...
-
-
-class ImperativeWorkerProvisioner(ABC):
-    @abstractmethod
-    async def start_worker(self) -> Tuple[List[WorkerID], Status]: ...
-
-    @abstractmethod
-    async def shutdown_workers(self, worker_ids: List[WorkerID]) -> Tuple[List[WorkerID], Status]: ...
 
 
 class DeclarativeWorkerProvisioner(ABC):

--- a/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
@@ -16,15 +16,13 @@ except ModuleNotFoundError as exc:
     raise ModuleNotFoundError('execute "pip install opengris-scaler[orb]" to use ORB AWS EC2 worker Manager') from exc
 
 from scaler.config.section.orb_aws_ec2_worker_adapter import ORBAWSEC2WorkerAdapterConfig
-from scaler.protocol.capnp import WorkerManagerCommand, WorkerManagerCommandResponse
+from scaler.protocol.capnp import WorkerManagerCommand
 from scaler.utility.event_loop import register_event_loop, run_task_forever
 from scaler.utility.logging.utility import setup_logger
 from scaler.worker_manager_adapter.capacity_coordinator import CapacityCoordinator
 from scaler.worker_manager_adapter.common import extract_desired_count, format_capabilities
 from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner
 from scaler.worker_manager_adapter.worker_manager_runner import WorkerManagerRunner
-
-Status = WorkerManagerCommandResponse.Status
 
 ORB_AWS_EC2_POLLING_INTERVAL_SECONDS = 5
 ORB_AWS_EC2_MAX_POLLING_ATTEMPTS = 60

--- a/src/scaler/worker_manager_adapter/worker_manager_runner.py
+++ b/src/scaler/worker_manager_adapter/worker_manager_runner.py
@@ -1,27 +1,17 @@
 import asyncio
 import logging
 import signal
-from typing import Dict, List, Optional, Union
+from typing import Dict, Optional
 
 from scaler.config.types.address import AddressConfig
 from scaler.io import ymq
 from scaler.io.mixins import AsyncConnector, ConnectorRemoteType, NetworkBackend
 from scaler.io.network_backends import get_network_backend_from_env
 from scaler.io.utility import generate_identity_from_name
-from scaler.protocol.capnp import (
-    BaseMessage,
-    WorkerManagerCommand,
-    WorkerManagerCommandResponse,
-    WorkerManagerCommandType,
-    WorkerManagerHeartbeat,
-    WorkerManagerHeartbeatEcho,
-)
+from scaler.protocol.capnp import BaseMessage, WorkerManagerCommand, WorkerManagerHeartbeat, WorkerManagerHeartbeatEcho
 from scaler.protocol.helpers import dict_to_capabilities
 from scaler.utility.event_loop import create_async_loop_routine, run_task_forever
-from scaler.utility.identifiers import WorkerID
-from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner, ImperativeWorkerProvisioner
-
-Status = WorkerManagerCommandResponse.Status
+from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner
 
 
 class WorkerManagerRunner:
@@ -33,7 +23,7 @@ class WorkerManagerRunner:
         capabilities: Dict[str, int],
         max_provisioner_units: int,
         worker_manager_id: bytes,
-        worker_provisioner: Union[ImperativeWorkerProvisioner, DeclarativeWorkerProvisioner],
+        worker_provisioner: DeclarativeWorkerProvisioner,
         io_threads: int = 1,
         workers_per_provisioner_unit: int = 1,
     ) -> None:
@@ -115,8 +105,7 @@ class WorkerManagerRunner:
         except Exception:
             logging.exception(f"{self._ident!r}: failed with unhandled exception")
 
-        if isinstance(self._worker_provisioner, DeclarativeWorkerProvisioner):
-            await self._worker_provisioner.terminate()
+        await self._worker_provisioner.terminate()
 
     async def _on_receive_external(self, message: BaseMessage) -> None:
         try:
@@ -125,49 +114,13 @@ class WorkerManagerRunner:
             elif isinstance(message, WorkerManagerHeartbeatEcho):
                 pass
             else:
-                logging.warning(f"Received unknown message type: {type(message)}")
+                logging.warning(f"Unknown action: received unrecognized message type {type(message).__name__!r}")
         except Exception:
             logging.exception(f"Unhandled exception while processing message {type(message).__name__}")
 
     async def _handle_command(self, command: WorkerManagerCommand) -> None:
-        cmd_type = command.command
-        response_status: Status = Status.success
-        worker_ids: List[WorkerID] = []
-        capabilities: Dict[str, int] = {}
-
-        if cmd_type == WorkerManagerCommandType.startWorkers:
-            if isinstance(self._worker_provisioner, ImperativeWorkerProvisioner):
-                worker_ids, response_status = await self._worker_provisioner.start_worker()
-                if response_status == Status.success:
-                    capabilities = self._capabilities
-            else:
-                # declarative provisioners send a no-op success so the scheduler's
-                # single-in-flight gate is not blocked waiting for a response that never comes
-                logging.debug(f"Ignoring unimplemented WorkerManagerCommand: {cmd_type!r}")
-        elif cmd_type == WorkerManagerCommandType.shutdownWorkers:
-            if isinstance(self._worker_provisioner, ImperativeWorkerProvisioner):
-                worker_ids, response_status = await self._worker_provisioner.shutdown_workers(
-                    [WorkerID(wid) for wid in command.workerIDs]
-                )
-            else:
-                logging.debug(f"Ignoring unimplemented WorkerManagerCommand: {cmd_type!r}")
-        elif cmd_type == WorkerManagerCommandType.setDesiredTaskConcurrency:
-            if isinstance(self._worker_provisioner, DeclarativeWorkerProvisioner):
-                await self._worker_provisioner.set_desired_task_concurrency(
-                    list(command.setDesiredTaskConcurrencyRequests)
-                )
-            else:
-                logging.debug(f"Ignoring unimplemented WorkerManagerCommand: {cmd_type!r}")
+        requests = getattr(command, "setDesiredTaskConcurrencyRequests", None)
+        if requests is None:
+            logging.warning("Unknown action: received WorkerManagerCommand with no recognized payload")
             return
-        else:
-            logging.debug(f"Ignoring unimplemented WorkerManagerCommand: {cmd_type!r}")
-            return
-
-        await self._connector_external.send(
-            WorkerManagerCommandResponse(
-                command=cmd_type,
-                status=response_status,
-                workerIDs=worker_ids,
-                capabilities=dict_to_capabilities(capabilities),
-            )
-        )
+        await self._worker_provisioner.set_desired_task_concurrency(list(requests))

--- a/tests/scheduler/test_scaling.py
+++ b/tests/scheduler/test_scaling.py
@@ -3,7 +3,7 @@ import signal
 import time
 import unittest
 from multiprocessing import Process
-from unittest.mock import AsyncMock, MagicMock
+from typing import Dict, Optional
 
 from scaler import Client
 from scaler.cluster.object_storage_server import ObjectStorageServerProcess
@@ -30,24 +30,14 @@ from scaler.config.section.native_worker_manager import NativeWorkerManagerConfi
 from scaler.config.section.scheduler import PolicyConfig
 from scaler.config.types.address import AddressConfig
 from scaler.config.types.worker import WorkerCapabilities
-from scaler.protocol.capnp import (
-    Resource,
-    Task,
-    WorkerHeartbeat,
-    WorkerManagerCommandResponse,
-    WorkerManagerCommandType,
-    WorkerManagerHeartbeat,
-)
+from scaler.protocol.capnp import Resource, Task, WorkerHeartbeat, WorkerManagerHeartbeat
 from scaler.protocol.helpers import capabilities_to_dict
 from scaler.scheduler.controllers.policies.simple_policy.scaling.capability_scaling import CapabilityScalingPolicy
-from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
 from scaler.scheduler.controllers.policies.simple_policy.scaling.vanilla import VanillaScalingPolicy
-from scaler.scheduler.controllers.worker_manager_controller import WorkerManagerController
 from scaler.utility.identifiers import ClientID, ObjectID, TaskID, WorkerID
 from scaler.utility.logging.utility import setup_logger
 from scaler.utility.network_util import get_available_tcp_port
 from scaler.utility.snapshot import InformationSnapshot
-from scaler.worker_manager_adapter.baremetal.native import NativeWorkerManager
 from tests.utility.utility import logging_test_name
 
 
@@ -156,512 +146,53 @@ class TestScaling(unittest.TestCase):
         manager_process.join()
 
 
-class TestCapabilityScalingPolicy(unittest.TestCase):
-    """Unit tests for CapabilityScalingPolicy with stateless interface."""
-
-    def setUp(self):
-        setup_logger()
-        self.policy = CapabilityScalingPolicy()
-        # Empty initial state
-        self.managed_worker_ids = []
-        self.managed_worker_capabilities = {}
-
-    def test_starts_worker_when_no_capable_workers(self):
-        """Test that a worker is started when tasks require capabilities no worker provides."""
-        task_id = TaskID.generate_task_id()
-        task = _create_mock_task(task_id, {"gpu": 1})
-
-        information_snapshot = InformationSnapshot(tasks={task_id: task}, workers={})
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        imperative = _imperative(commands)
-        self.assertEqual(len(imperative), 1)
-        self.assertEqual(imperative[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertEqual(capabilities_to_dict(imperative[0].capabilities), {"gpu": 1})
-
-    def test_no_scale_when_capable_workers_exist(self):
-        """Test that no worker is started when workers with matching capabilities exist."""
-        task_id = TaskID.generate_task_id()
-        task = _create_mock_task(task_id, {"gpu": 1})
-        worker_id = WorkerID(b"worker-1")
-        worker_heartbeat = _create_mock_worker_heartbeat({"gpu": -1}, queued_tasks=0)
-
-        information_snapshot = InformationSnapshot(tasks={task_id: task}, workers={worker_id: worker_heartbeat})
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        # Should not return any start commands
-        start_commands = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_commands), 0)
-
-    def test_scales_when_task_ratio_exceeds_threshold(self):
-        """Test that scaling occurs when task-to-worker ratio exceeds upper threshold."""
-        # Create 15 tasks with gpu capability (ratio will be 15/1 = 15 > 10)
-        tasks = {}
-        for _ in range(15):
-            task_id = TaskID.generate_task_id()
-            tasks[task_id] = _create_mock_task(task_id, {"gpu": 1})
-
-        worker_id = WorkerID(b"worker-1")
-        worker_heartbeat = _create_mock_worker_heartbeat({"gpu": -1}, queued_tasks=5)
-
-        information_snapshot = InformationSnapshot(tasks=tasks, workers={worker_id: worker_heartbeat})
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        imperative = _imperative(commands)
-        self.assertEqual(len(imperative), 1)
-        self.assertEqual(imperative[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertEqual(capabilities_to_dict(imperative[0].capabilities), {"gpu": 1})
-
-    def test_different_capability_sets_handled_separately(self):
-        """Test that tasks with different capabilities trigger separate scaling suggestions."""
-        gpu_task_id = TaskID.generate_task_id()
-        gpu_task = _create_mock_task(gpu_task_id, {"gpu": 1})
-
-        tpu_task_id = TaskID.generate_task_id()
-        tpu_task = _create_mock_task(tpu_task_id, {"tpu": 1})
-
-        information_snapshot = InformationSnapshot(tasks={gpu_task_id: gpu_task, tpu_task_id: tpu_task}, workers={})
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        # Should return 2 start commands (one for each capability set)
-        commands = self.policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        start_commands = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_commands), 2)
-
-        capabilities_requested = {frozenset(capabilities_to_dict(c.capabilities).keys()) for c in start_commands}
-        self.assertIn(frozenset({"gpu"}), capabilities_requested)
-        self.assertIn(frozenset({"tpu"}), capabilities_requested)
-
-    def test_worker_with_superset_capabilities_matches_task(self):
-        """Test that a worker with superset capabilities can handle tasks requiring a subset."""
-        task_id = TaskID.generate_task_id()
-        task = _create_mock_task(task_id, {"gpu": 1})  # Task requires only GPU
-
-        worker_id = WorkerID(b"worker-1")
-        # Worker has both GPU and CPU capabilities
-        worker_heartbeat = _create_mock_worker_heartbeat({"gpu": -1, "cpu": -1}, queued_tasks=0)
-
-        information_snapshot = InformationSnapshot(tasks={task_id: task}, workers={worker_id: worker_heartbeat})
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        # No StartWorkers command should be returned
-        start_commands = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_commands), 0)
-
-    def test_tasks_without_capabilities_handled(self):
-        """Test that tasks without capability requirements are handled correctly."""
-        task_id = TaskID.generate_task_id()
-        task = _create_mock_task(task_id, {})  # No capabilities required
-
-        information_snapshot = InformationSnapshot(tasks={task_id: task}, workers={})  # No workers
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(
-            information_snapshot,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        # Should start a worker with empty capabilities
-        imperative = _imperative(commands)
-        self.assertEqual(len(imperative), 1)
-        self.assertEqual(imperative[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertEqual(capabilities_to_dict(imperative[0].capabilities), {})
-
-    def test_get_status_returns_scaling_manager_status(self):
-        """Test that get_status returns a ScalingManagerStatus object."""
-        managed_workers = {b"mgr-1": [WorkerID(b"worker-1"), WorkerID(b"worker-2")]}
-
-        status = self.policy.get_status(managed_workers)
-
-        from scaler.protocol.capnp import ScalingManagerStatus
-
-        self.assertIsInstance(status, ScalingManagerStatus)
-
-    def test_no_duplicate_worker_for_pending_workers(self):
-        """Test that no new worker is started if capable workers are already pending."""
-        # First snapshot: task with mqa:1, no workers -> should start a worker
-        task1_id = TaskID.generate_task_id()
-        task1 = _create_mock_task(task1_id, {"mqa": 1})
-        information_snapshot1 = InformationSnapshot(tasks={task1_id: task1}, workers={})
-        worker_manager_heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands1 = self.policy.get_scaling_commands(
-            information_snapshot1,
-            worker_manager_heartbeat,
-            self.managed_worker_ids,
-            self.managed_worker_capabilities,
-            {},
-        )
-
-        imperative1 = _imperative(commands1)
-        self.assertEqual(len(imperative1), 1)
-        self.assertEqual(imperative1[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertEqual(capabilities_to_dict(imperative1[0].capabilities), {"mqa": 1})
-
-        # Simulate state update as if manager responded successfully
-        updated_worker_ids = [WorkerID(b"w-mqa")]
-        updated_capabilities = {"mqa": -1}
-
-        # Second snapshot: task with mqa:-1, no workers connected yet
-        # Should NOT start another worker since capable worker already pending
-        task2_id = TaskID.generate_task_id()
-        task2 = _create_mock_task(task2_id, {"mqa": -1})
-        information_snapshot2 = InformationSnapshot(tasks={task2_id: task2}, workers={})
-
-        commands2 = self.policy.get_scaling_commands(
-            information_snapshot2, worker_manager_heartbeat, updated_worker_ids, updated_capabilities, {}
-        )
-
-        # No StartWorkers command should be returned
-        start_commands = [c for c in commands2 if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_commands), 0, "Should not start new worker when capable worker is pending")
-
-    def test_greedy_shutdown_multiple_same_capability(self):
-        """0 tasks, 3 workers with same capability -> all shut down in one command."""
-        workers = {}
-        managed = []
-        for i in range(3):
-            wid = WorkerID(f"gpu-w{i}".encode())
-            workers[wid] = _create_mock_worker_heartbeat({"gpu": -1}, queued_tasks=i)
-            managed.append(wid)
-
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
-
-        shutdown_commands = [c for c in commands if c.command == WorkerManagerCommandType.shutdownWorkers]
-        self.assertEqual(len(shutdown_commands), 1)
-        self.assertEqual(len(shutdown_commands[0].workerIDs), 3)
-
-    def test_shutdown_allows_duplicate_worker_ids(self):
-        """Worker appearing in multiple capability groups may appear multiple times in shutdown."""
-        # Worker w0 has {gpu, cpu}, w1 has {gpu}. Both capability groups trigger shutdown.
-        # w0 may appear in shutdown for both {gpu} and {gpu, cpu} groups — duplicates are allowed.
-        w0 = WorkerID(b"w0-gpu-cpu")
-        w1 = WorkerID(b"w1-gpu")
-        workers = {
-            w0: _create_mock_worker_heartbeat({"gpu": -1, "cpu": -1}, queued_tasks=0),
-            w1: _create_mock_worker_heartbeat({"gpu": -1}, queued_tasks=1),
-        }
-        managed = [w0, w1]
-
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
-
-        shutdown_commands = [c for c in commands if c.command == WorkerManagerCommandType.shutdownWorkers]
-        self.assertEqual(len(shutdown_commands), 1)
-        shutdown_ids = shutdown_commands[0].workerIDs
-        # Both workers should be present; duplicates are acceptable
-        self.assertTrue(len(shutdown_ids) >= 2)
-        self.assertIn(bytes(w0), shutdown_ids)
-        self.assertIn(bytes(w1), shutdown_ids)
-
-    def test_pending_fills_max_suppresses_capability_start(self):
-        """When pending workers reach max_concurrency, no StartWorkers should be issued."""
-        task_id = TaskID.generate_task_id()
-        task = _create_mock_task(task_id, {"gpu": 1})
-        snapshot = InformationSnapshot(tasks={task_id: task}, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=3)
-        manager_snapshot = WorkerManagerSnapshot(
-            worker_manager_id=b"mgr", max_task_concurrency=3, worker_count=0, last_seen_s=0.0, pending_worker_count=3
-        )
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], {}, {b"mgr": manager_snapshot})
-
-        start_cmds = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_cmds), 0)
-
-    def test_managed_plus_pending_below_max_allows_capability_start(self):
-        """When managed + pending < max_concurrency, capability StartWorkers should be issued."""
-        task_id = TaskID.generate_task_id()
-        task = _create_mock_task(task_id, {"gpu": 1})
-        managed = [WorkerID(b"w0")]
-        snapshot = InformationSnapshot(tasks={task_id: task}, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=5)
-        manager_snapshot = WorkerManagerSnapshot(
-            worker_manager_id=b"mgr",
-            max_task_concurrency=5,
-            worker_count=1,
-            last_seen_s=0.0,
-            pending_worker_count=2,  # 1 + 2 == 3 < 5
-        )
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {b"mgr": manager_snapshot})
-
-        start_cmds = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_cmds), 1)
-        self.assertEqual(capabilities_to_dict(start_cmds[0].capabilities), {"gpu": 1})
-
-
 class TestVanillaScalingPolicy(unittest.TestCase):
-    """Unit tests for VanillaScalingPolicy greedy shutdown."""
+    """Unit tests for VanillaScalingPolicy declarative emission."""
 
     def setUp(self):
         setup_logger()
         self.policy = VanillaScalingPolicy()
 
-    def test_greedy_shutdown_all_idle(self):
-        """0 tasks, 4 workers with varying busyness -> all 4 shut down in one command."""
-        workers = {
-            WorkerID(b"w0"): _create_mock_worker_heartbeat({}, queued_tasks=0),
-            WorkerID(b"w1"): _create_mock_worker_heartbeat({}, queued_tasks=1),
-            WorkerID(b"w2"): _create_mock_worker_heartbeat({}, queued_tasks=2),
-            WorkerID(b"w3"): _create_mock_worker_heartbeat({}, queued_tasks=5),
-        }
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"test")
-        managed = list(workers.keys())
+    def _single_request(self, snapshot, heartbeat, managed):
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+        self.assertEqual(len(commands), 1)
+        requests = list(commands[0].setDesiredTaskConcurrencyRequests)
+        self.assertEqual(len(requests), 1)
+        return requests[0]
 
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
-
-        imperative = _imperative(commands)
-        self.assertEqual(len(imperative), 1)
-        self.assertEqual(imperative[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(imperative[0].workerIDs), 4)
-
-    def test_greedy_shutdown_partial(self):
-        """5 tasks, 10 workers -> shutdown 9, keep 1 (ceil(5/10)=1)."""
-        tasks = {}
-        for _ in range(5):
-            tid = TaskID.generate_task_id()
-            tasks[tid] = _create_mock_task(tid, {})
-
-        workers = {}
-        managed = []
-        for i in range(10):
-            wid = WorkerID(f"w{i}".encode())
-            workers[wid] = _create_mock_worker_heartbeat({}, queued_tasks=i)
-            managed.append(wid)
-
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
-
-        imperative = _imperative(commands)
-        self.assertEqual(len(imperative), 1)
-        self.assertEqual(imperative[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(imperative[0].workerIDs), 9)
-        # The busiest worker (w9) should NOT be in the shutdown list
-        shutdown_set = set(imperative[0].workerIDs)
-        self.assertNotIn(bytes(WorkerID(b"w9")), shutdown_set)
-
-    def test_greedy_shutdown_no_action_when_ratio_ok(self):
-        """15 tasks, 5 workers (ratio=3 > lower=1) -> no shutdown."""
-        tasks = {}
-        for _ in range(15):
-            tid = TaskID.generate_task_id()
-            tasks[tid] = _create_mock_task(tid, {})
-
-        workers = {}
-        managed = []
-        for i in range(5):
-            wid = WorkerID(f"w{i}".encode())
-            workers[wid] = _create_mock_worker_heartbeat({}, queued_tasks=i)
-            managed.append(wid)
-
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
-        self.assertEqual(len(_imperative(commands)), 0)
-
-    def test_greedy_shutdown_worker_ordering(self):
-        """Verify least-busy workers are selected first for shutdown."""
-        tasks = {}
-        for _ in range(8):
-            tid = TaskID.generate_task_id()
-            tasks[tid] = _create_mock_task(tid, {})
-
-        # 10 workers, 8 tasks -> ratio=0.8 < 1 -> shutdown. min_keep = max(1, ceil(8/10))=1. shutdown 9.
-        workers = {}
-        managed = []
-        for i in range(10):
-            wid = WorkerID(f"w{i}".encode())
-            workers[wid] = _create_mock_worker_heartbeat({}, queued_tasks=i)
-            managed.append(wid)
-
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"test")
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
-
-        imperative = _imperative(commands)
-        self.assertEqual(len(imperative), 1)
-        # w0..w8 should be shut down (9 least busy), w9 kept
-        shutdown_ids = imperative[0].workerIDs
-        self.assertEqual(len(shutdown_ids), 9)
-        self.assertNotIn(bytes(WorkerID(b"w9")), set(shutdown_ids))
-        # First in list should be least busy
-        self.assertEqual(shutdown_ids[0], bytes(WorkerID(b"w0")))
-
-    def test_pending_fills_max_concurrency_suppresses_start(self):
-        """When pending workers alone reach max_concurrency, no StartWorkers should be issued."""
-        tasks = {}
-        for _ in range(5):
-            tid = TaskID.generate_task_id()
-            tasks[tid] = _create_mock_task(tid, {})
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=3)
-        manager_snapshot = WorkerManagerSnapshot(
-            worker_manager_id=b"mgr", max_task_concurrency=3, worker_count=0, last_seen_s=0.0, pending_worker_count=3
-        )
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], {}, {b"mgr": manager_snapshot})
-
-        start_cmds = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_cmds), 0)
-
-    def test_managed_plus_pending_equals_max_suppresses_start(self):
-        """When managed + pending == max_concurrency, no StartWorkers should be issued."""
-        tasks = {}
-        for _ in range(20):
-            tid = TaskID.generate_task_id()
-            tasks[tid] = _create_mock_task(tid, {})
-        managed = [WorkerID(b"w0"), WorkerID(b"w1")]
-        workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=10) for wid in managed}
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=5)
-        manager_snapshot = WorkerManagerSnapshot(
-            worker_manager_id=b"mgr",
-            max_task_concurrency=5,
-            worker_count=2,
-            last_seen_s=0.0,
-            pending_worker_count=3,  # 2 + 3 == 5
-        )
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {b"mgr": manager_snapshot})
-
-        start_cmds = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_cmds), 0)
-
-    def test_managed_plus_pending_below_max_allows_start(self):
-        """When managed + pending < max_concurrency, StartWorkers should still be issued."""
-        tasks = {}
-        for _ in range(20):
-            tid = TaskID.generate_task_id()
-            tasks[tid] = _create_mock_task(tid, {})
-        managed = [WorkerID(b"w0")]
-        workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=10) for wid in managed}
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=5)
-        manager_snapshot = WorkerManagerSnapshot(
-            worker_manager_id=b"mgr",
-            max_task_concurrency=5,
-            worker_count=1,
-            last_seen_s=0.0,
-            pending_worker_count=2,  # 1 + 2 == 3 < 5
-        )
-
-        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {b"mgr": manager_snapshot})
-
-        start_cmds = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-        self.assertEqual(len(start_cmds), 1)
-
-    # TODO: uncomment once finos/opengris-scaler#696 is resolved.
-    # max_task_concurrency is UInt32 in Cap'n Proto and cannot represent -1, so
-    # WorkerManagerHeartbeat.new_msg(max_task_concurrency=-1, ...) currently raises KjException.
-    # def test_unlimited_concurrency_ignores_pending(self):
-    #     """When max_concurrency == -1, StartWorkers is issued regardless of pending count."""
-    #     tid = TaskID.generate_task_id()
-    #     snapshot = InformationSnapshot(tasks={tid: _create_mock_task(tid, {})}, workers={})
-    #     heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=-1)
-    #     manager_snapshot = WorkerManagerSnapshot(
-    #         worker_manager_id=b"mgr", max_task_concurrency=-1,
-    #         worker_count=0, last_seen_s=0.0, pending_worker_count=1000,
-    #     )
-    #     commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], {}, {b"mgr": manager_snapshot})
-    #     start_cmds = [c for c in commands if c.command == WorkerManagerCommandType.startWorkers]
-    #     self.assertEqual(len(start_cmds), 1)
-
-
-class TestDeclarativeEmission(unittest.TestCase):
-    """Verify the declarative setDesiredTaskConcurrency command is always emitted."""
-
-    def setUp(self):
-        setup_logger()
-
-    def test_vanilla_emits_desired_every_heartbeat_even_when_idle(self):
-        """Empty state: declarative is still emitted with desired=0."""
-        policy = VanillaScalingPolicy()
+    def test_idle_skips_emission(self):
+        """Empty state: ratio computes desired=0 which matches current=0 connected -> no-op skip."""
         snapshot = InformationSnapshot(tasks={}, workers={})
         heartbeat = _create_worker_manager_heartbeat(b"mgr")
 
-        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {}, {})
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], {})
 
-        declarative = _declarative(commands)
-        self.assertEqual(len(declarative), 1)
-        self.assertEqual(len(_imperative(commands)), 0)
-        requests = list(declarative[0].setDesiredTaskConcurrencyRequests)
-        self.assertEqual(len(requests), 1)
-        self.assertEqual(requests[0].taskConcurrency, 0)
+        self.assertEqual(commands, [])
 
-    def test_vanilla_desired_tracks_start_delta(self):
-        """On start: desired = current + pending + 1."""
-        policy = VanillaScalingPolicy()
+    def test_tasks_with_no_workers_targets_one(self):
+        """Tasks present but no workers: desired = 1 to bootstrap."""
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(5)}
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        request = self._single_request(snapshot, heartbeat, [])
+
+        self.assertEqual(request.taskConcurrency, 1)
+
+    def test_high_task_ratio_targets_current_plus_one(self):
+        """Task/worker ratio above upper threshold scales by +1 toward equilibrium."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(20)}
         managed = [WorkerID(b"w0")]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=5) for wid in managed}
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
         heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
 
-        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
+        request = self._single_request(snapshot, heartbeat, managed)
 
-        declarative = _declarative(commands)
-        self.assertEqual(len(declarative), 1)
-        requests = list(declarative[0].setDesiredTaskConcurrencyRequests)
-        self.assertEqual(len(requests), 1)
-        # 1 managed + 0 pending + 1 (from startWorkers imperative) = 2
-        self.assertEqual(requests[0].taskConcurrency, 2)
+        self.assertEqual(request.taskConcurrency, 2)
 
-    def test_vanilla_desired_tracks_shutdown_delta(self):
-        """On shutdown: desired = current - shutdown_count."""
-        policy = VanillaScalingPolicy()
+    def test_no_tasks_with_workers_targets_zero(self):
+        """No tasks but managers exist: desired drains to 0."""
         workers = {
             WorkerID(b"w0"): _create_mock_worker_heartbeat({}, queued_tasks=0),
             WorkerID(b"w1"): _create_mock_worker_heartbeat({}, queued_tasks=1),
@@ -671,51 +202,233 @@ class TestDeclarativeEmission(unittest.TestCase):
         snapshot = InformationSnapshot(tasks={}, workers=workers)
         heartbeat = _create_worker_manager_heartbeat(b"mgr")
 
-        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {}, {})
+        request = self._single_request(snapshot, heartbeat, managed)
 
-        declarative = _declarative(commands)
-        requests = list(declarative[0].setDesiredTaskConcurrencyRequests)
-        # 3 managed, shutdown all 3 -> desired = 0
-        self.assertEqual(requests[0].taskConcurrency, 0)
+        self.assertEqual(request.taskConcurrency, 0)
 
-    def test_capability_desired_one_request_per_capset(self):
-        """Two capsets with tasks: declarative has one request per capset."""
+    def test_few_tasks_with_many_workers_targets_min_keep(self):
+        """Low task ratio shrinks toward ceil(tasks / upper_task_ratio) min_keep."""
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(5)}
+        workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(10)}
+        managed = list(workers.keys())
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        request = self._single_request(snapshot, heartbeat, managed)
+
+        # ceil(5 / 10) = 1 minimum to keep
+        self.assertEqual(request.taskConcurrency, 1)
+
+    def test_balanced_ratio_skips_when_desired_equals_current(self):
+        """Task ratio in band keeps desired == current managed count -> no-op skip."""
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(15)}
+        workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
+        managed = list(workers.keys())
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(commands, [])
+
+    def test_max_concurrency_clamps_then_skips_at_cap(self):
+        """Ratio asks for current+1 but cap clamps to current -> no-op skip."""
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(50)}
+        managed = [WorkerID(b"w0"), WorkerID(b"w1")]
+        workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=20) for wid in managed}
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=2)
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        # Ratio would say desired=3, cap clamps to 2, which equals current=2 -> skip.
+        self.assertEqual(commands, [])
+
+
+class TestNoOpSkip(unittest.TestCase):
+    """A command whose effective desired count matches the manager's current connected
+    worker count is a no-op for the worker manager. The scheduler skips emission for
+    such commands so it doesn't waste network traffic on commands that cannot change
+    anything (notably: when the manager is already at its config-given max)."""
+
+    def setUp(self):
+        setup_logger()
+
+    def test_vanilla_at_cap_with_excess_demand_skips(self):
+        """Vanilla: ratio asks for current+1, cap clamps to current -> skip emission."""
+        policy = VanillaScalingPolicy()
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
+        managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
+        workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=10) for wid in managed}
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(commands, [])
+
+    def test_vanilla_changes_emit(self):
+        """Vanilla: when ratio's desired differs from current connected, emit."""
+        policy = VanillaScalingPolicy()
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
+        managed = [WorkerID(b"w0")]
+        workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=10) for wid in managed}
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(len(commands), 1)
+        requests = list(commands[0].setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 2)
+
+    def test_capability_at_cap_skips(self):
+        """Capability: ratio's per-capset desired equals current connected -> skip emission."""
         policy = CapabilityScalingPolicy()
+        # ceil(50/5) = 10 desired for gpu capset; clamp at cap=10; current connected = 10 -> no-op.
+        tasks = {}
+        for _ in range(50):
+            tid = TaskID.generate_task_id()
+            tasks[tid] = _create_mock_task(tid, {"gpu": 1})
+        managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, capabilities={"gpu": -1})
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(commands, [])
+
+    def test_capability_unservable_capset_skips(self):
+        """Capability: a request whose capabilities aren't a subset of the manager's caps
+        contributes 0 to effective desired. With current=0, the manager would do nothing
+        either way, so the scheduler skips."""
+        policy = CapabilityScalingPolicy()
+        task_id = TaskID.generate_task_id()
+        snapshot = InformationSnapshot(tasks={task_id: _create_mock_task(task_id, {"gpu": 1})}, workers={})
+        # WM has no gpu, so it can't serve any gpu request -> effective is 0; managed=[] -> 0.
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={})
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {})
+
+        self.assertEqual(commands, [])
+
+    def test_waterfall_at_cap_skips(self):
+        """Waterfall: when the manager is full per the priority chain and already has that
+        many workers connected, emission is skipped."""
+        from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
+        from scaler.scheduler.controllers.policies.waterfall_v1.scaling.types import WaterfallRule
+        from scaler.scheduler.controllers.policies.waterfall_v1.scaling.waterfall import WaterfallScalingPolicy
+
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        # ceil(100/10) = 10; cap=10; manager has 10 connected -> effective 10 == current 10 -> skip.
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
+        managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+        manager_snapshots = {
+            b"mgr": WorkerManagerSnapshot(
+                worker_manager_id=b"mgr", max_task_concurrency=10, worker_count=10, last_seen_s=0.0, capabilities={}
+            )
+        }
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, manager_snapshots)
+
+        self.assertEqual(commands, [])
+
+
+class TestCapabilityScalingPolicy(unittest.TestCase):
+    """Unit tests for CapabilityScalingPolicy declarative emission."""
+
+    def setUp(self):
+        setup_logger()
+        self.policy = CapabilityScalingPolicy()
+
+    def _commands(self, snapshot, heartbeat, managed):
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+        self.assertEqual(len(commands), 1)
+        return commands[0]
+
+    def test_no_tasks_skips_emission(self):
+        """No tasks, no managed workers: per-capset list is empty, effective desired matches current (0) -> skip."""
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], {})
+
+        self.assertEqual(commands, [])
+
+    def test_one_capset_targets_at_least_one_worker(self):
+        """A single capset with one task targets one worker for that capset."""
+        task_id = TaskID.generate_task_id()
+        snapshot = InformationSnapshot(tasks={task_id: _create_mock_task(task_id, {"gpu": 1})}, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1})
+
+        command = self._commands(snapshot, heartbeat, [])
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(capabilities_to_dict(requests[0].capabilities), {"gpu": 1})
+        self.assertEqual(requests[0].taskConcurrency, 1)
+
+    def test_two_capsets_get_separate_requests(self):
+        """Two capsets with tasks each: declarative has one request per capset."""
         gpu_id = TaskID.generate_task_id()
         tpu_id = TaskID.generate_task_id()
         tasks = {gpu_id: _create_mock_task(gpu_id, {"gpu": 1}), tpu_id: _create_mock_task(tpu_id, {"tpu": 1})}
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1, "tpu": -1})
 
-        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {}, {})
+        command = self._commands(snapshot, heartbeat, [])
 
-        declarative = _declarative(commands)
-        self.assertEqual(len(declarative), 1)
-        requests = list(declarative[0].setDesiredTaskConcurrencyRequests)
+        requests = list(command.setDesiredTaskConcurrencyRequests)
         caps_in_requests = {frozenset(capabilities_to_dict(r.capabilities).keys()) for r in requests}
+        self.assertEqual(len(requests), 2)
         self.assertIn(frozenset({"gpu"}), caps_in_requests)
         self.assertIn(frozenset({"tpu"}), caps_in_requests)
-        self.assertEqual(len(requests), 2)
 
-    def test_capability_desired_omits_empty_capset(self):
-        """Capsets with no tasks are absent from the declarative request list."""
-        policy = CapabilityScalingPolicy()
-        snapshot = InformationSnapshot(tasks={}, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+    def test_high_task_count_scales_per_capset(self):
+        """Many tasks for one capset: desired = ceil(task_count / upper_task_ratio)."""
+        tasks = {}
+        for _ in range(20):
+            tid = TaskID.generate_task_id()
+            tasks[tid] = _create_mock_task(tid, {"gpu": 1})
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1})
 
-        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {}, {})
+        command = self._commands(snapshot, heartbeat, [])
 
-        declarative = _declarative(commands)
-        self.assertEqual(len(declarative), 1)
-        self.assertEqual(len(list(declarative[0].setDesiredTaskConcurrencyRequests)), 0)
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertEqual(len(requests), 1)
+        # ceil(20 / 5) = 4
+        self.assertEqual(requests[0].taskConcurrency, 4)
+
+    def test_max_concurrency_clamps_per_capset(self):
+        """Per-capset desired clamped by manager's maxTaskConcurrency."""
+        tasks = {}
+        for _ in range(50):
+            tid = TaskID.generate_task_id()
+            tasks[tid] = _create_mock_task(tid, {"gpu": 1})
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=3, capabilities={"gpu": -1})
+
+        command = self._commands(snapshot, heartbeat, [])
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 3)
 
 
-class TestWorkerManagerControllerPendingTracking(unittest.IsolatedAsyncioTestCase):
+class TestPendingWorkersStatus(unittest.IsolatedAsyncioTestCase):
+    """Pending-worker reporting in WorkerManagerController.get_status."""
+
     def setUp(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from scaler.scheduler.controllers.worker_manager_controller import WorkerManagerController
+
         setup_logger()
         config_controller = MagicMock()
         policy_controller = MagicMock()
-        policy_controller.get_scaling_commands.return_value = []
         policy_controller.get_scaling_status.return_value = MagicMock(managed_workers={})
 
         self.controller = WorkerManagerController(config_controller, policy_controller)
@@ -725,173 +438,67 @@ class TestWorkerManagerControllerPendingTracking(unittest.IsolatedAsyncioTestCas
         task_controller = MagicMock()
         task_controller._task_id_to_task = {}
         self.worker_controller = MagicMock()
-        self.worker_controller.get_workers_by_manager_id.return_value = []
         self.worker_controller._worker_alive_since = {}
 
         self.controller.register(binder, task_controller, self.worker_controller)
 
-    async def test_start_success_increments_pending_count(self):
-        """A successful StartWorkers response increments _pending_worker_count by len(workerIDs)."""
-        source = b"mgr-src"
-        self.controller._pending_commands[source] = MagicMock()
-        response = WorkerManagerCommandResponse(
-            command=WorkerManagerCommandType.startWorkers,
-            status=WorkerManagerCommandResponse.Status.success,
-            workerIDs=[WorkerID(b"w0")],
-        )
-
-        await self.controller.on_command_response(source, response)
-
-        self.assertEqual(self.controller._pending_worker_count.get(source, 0), 1)
-
-    async def test_multiple_start_successes_accumulate_pending(self):
-        """Each successful StartWorkers response adds len(workerIDs) to _pending_worker_count."""
-        source = b"mgr-src"
-        response = WorkerManagerCommandResponse(
-            command=WorkerManagerCommandType.startWorkers,
-            status=WorkerManagerCommandResponse.Status.success,
-            workerIDs=[WorkerID(b"w0")],
-        )
-
-        for _ in range(3):
-            self.controller._pending_commands[source] = MagicMock()
-            await self.controller.on_command_response(source, response)
-
-        self.assertEqual(self.controller._pending_worker_count.get(source, 0), 3)
-
-    async def test_declarative_noop_response_does_not_increment_pending(self):
-        """A success response with empty workerIDs (declarative no-op) must not increment pending."""
-        source = b"mgr-src"
-        self.controller._pending_commands[source] = MagicMock()
-        response = WorkerManagerCommandResponse(
-            command=WorkerManagerCommandType.startWorkers,
-            status=WorkerManagerCommandResponse.Status.success,
-            workerIDs=[],
-        )
-
-        await self.controller.on_command_response(source, response)
-
-        self.assertEqual(self.controller._pending_worker_count.get(source, 0), 0)
-
-    async def test_multi_worker_response_increments_by_worker_count(self):
-        """A success response with N workerIDs increments pending by N, not 1."""
-        source = b"mgr-src"
-        self.controller._pending_commands[source] = MagicMock()
-        response = WorkerManagerCommandResponse(
-            command=WorkerManagerCommandType.startWorkers,
-            status=WorkerManagerCommandResponse.Status.success,
-            workerIDs=[WorkerID(b"w0"), WorkerID(b"w1"), WorkerID(b"w2")],
-        )
-
-        await self.controller.on_command_response(source, response)
-
-        self.assertEqual(self.controller._pending_worker_count.get(source, 0), 3)
-
-    async def test_start_failure_does_not_increment_pending_count(self):
-        """A failed StartWorkers response must NOT increment _pending_worker_count."""
-        source = b"mgr-src"
-        self.controller._pending_commands[source] = MagicMock()
-        response = WorkerManagerCommandResponse(
-            command=WorkerManagerCommandType.startWorkers, status=WorkerManagerCommandResponse.Status.tooManyWorkers
-        )
-
-        await self.controller.on_command_response(source, response)
-
-        self.assertEqual(self.controller._pending_worker_count.get(source, 0), 0)
-
-    async def test_newly_connected_workers_decrement_pending_count(self):
-        """When new workers appear, on_heartbeat decrements pending by the newly-connected count."""
-        source = b"mgr-src"
-        manager_id = b"mgr-id"
-        heartbeat = _create_worker_manager_heartbeat(manager_id)
-        self.controller._manager_alive_since[source] = (0.0, heartbeat)
-        self.controller._manager_id_to_source[manager_id] = source
-        self.controller._pending_worker_count[source] = 3
-        self.controller._last_worker_count[source] = 0
-        self.worker_controller.get_workers_by_manager_id.return_value = [WorkerID(b"w0"), WorkerID(b"w1")]
-
-        await self.controller.on_heartbeat(source, heartbeat)
-
-        self.assertEqual(self.controller._pending_worker_count[source], 1)  # 3 - 2
-        self.assertEqual(self.controller._last_worker_count[source], 2)
-
-    async def test_pending_count_clamped_to_zero_on_excess_connections(self):
-        """_pending_worker_count must never go negative even if more workers connect than expected."""
-        source = b"mgr-src"
-        manager_id = b"mgr-id"
-        heartbeat = _create_worker_manager_heartbeat(manager_id)
-        self.controller._manager_alive_since[source] = (0.0, heartbeat)
-        self.controller._manager_id_to_source[manager_id] = source
-        self.controller._pending_worker_count[source] = 1
-        self.controller._last_worker_count[source] = 0
-        self.worker_controller.get_workers_by_manager_id.return_value = [
-            WorkerID(b"w0"),
-            WorkerID(b"w1"),
-            WorkerID(b"w2"),  # 3 connected, only 1 was pending
-        ]
-
-        await self.controller.on_heartbeat(source, heartbeat)
-
-        self.assertGreaterEqual(self.controller._pending_worker_count[source], 0)
-
-    async def test_disconnect_clears_pending_state(self):
-        """_disconnect_manager removes both _pending_worker_count and _last_worker_count entries."""
-        source = b"mgr-src"
-        manager_id = b"mgr-id"
-        heartbeat = _create_worker_manager_heartbeat(manager_id)
-        self.controller._manager_alive_since[source] = (0.0, heartbeat)
-        self.controller._manager_id_to_source[manager_id] = source
-        self.controller._pending_worker_count[source] = 5
-        self.controller._last_worker_count[source] = 3
-
-        await self.controller._disconnect_manager(source)
-
-        self.assertNotIn(source, self.controller._pending_worker_count)
-        self.assertNotIn(source, self.controller._last_worker_count)
-
-    def test_get_status_includes_pending_workers_count(self):
-        """get_status should expose pending_workers in each worker manager detail dict."""
-        source = b"mgr-src"
-        manager_id = b"mgr-id"
-        heartbeat = _create_worker_manager_heartbeat(manager_id)
-        self.controller._manager_alive_since[source] = (0.0, heartbeat)
-        self.controller._pending_worker_count[source] = 2
-        self.worker_controller.get_workers_by_manager_id.return_value = []
-
-        status = self.controller.get_status()
-
-        detail = next(d for d in status.workerManagerDetails if d.workerManagerID == manager_id)
-        self.assertEqual(detail.pendingWorkers, 2)
-
-    async def test_set_desired_command_does_not_gate_on_response(self):
-        """setDesiredTaskConcurrency must not populate _pending_commands since no response is expected."""
+    async def test_pending_equals_desired_minus_connected(self):
+        """pendingWorkers = max(0, last_desired_total - connected_count)."""
         from scaler.scheduler.controllers.worker_manager_utilties import build_set_desired_command
 
         source = b"mgr-src"
         manager_id = b"mgr-id"
         heartbeat = _create_worker_manager_heartbeat(manager_id)
-        self.controller._manager_id_to_source[manager_id] = source
 
-        declarative = build_set_desired_command([({}, 3)])
-        self.policy_controller.get_scaling_commands.return_value = [declarative]
+        # Policy returns a setDesired command totaling 5 workers for this manager (empty caps).
+        self.policy_controller.get_scaling_commands.return_value = [build_set_desired_command([({}, 5)])]
+        # 2 workers are currently connected to this manager.
+        self.worker_controller.get_workers_by_manager_id.return_value = [WorkerID(b"w0"), WorkerID(b"w1")]
 
         await self.controller.on_heartbeat(source, heartbeat)
+        status = self.controller.get_status()
 
-        self.assertNotIn(source, self.controller._pending_commands)
+        detail = next(d for d in status.workerManagerDetails if d.workerManagerID == manager_id)
+        self.assertEqual(detail.pendingWorkers, 3)  # 5 desired - 2 connected
 
-        # A subsequent heartbeat can still trigger policy evaluation (gate not wedged).
+    async def test_pending_clamped_at_zero(self):
+        """If more workers are connected than desired, pendingWorkers is 0 (never negative)."""
+        from scaler.scheduler.controllers.worker_manager_utilties import build_set_desired_command
+
+        source = b"mgr-src"
+        manager_id = b"mgr-id"
+        heartbeat = _create_worker_manager_heartbeat(manager_id)
+
+        self.policy_controller.get_scaling_commands.return_value = [build_set_desired_command([({}, 1)])]
+        self.worker_controller.get_workers_by_manager_id.return_value = [WorkerID(b"w0"), WorkerID(b"w1")]
+
         await self.controller.on_heartbeat(source, heartbeat)
-        self.assertEqual(self.policy_controller.get_scaling_commands.call_count, 2)
+        status = self.controller.get_status()
 
+        detail = next(d for d in status.workerManagerDetails if d.workerManagerID == manager_id)
+        self.assertEqual(detail.pendingWorkers, 0)
 
-def _imperative(commands):
-    """Filter out the declarative setDesiredTaskConcurrency command emitted each policy run."""
-    return [c for c in commands if c.command != WorkerManagerCommandType.setDesiredTaskConcurrency]
+    async def test_pending_only_counts_capsets_this_manager_can_serve(self):
+        """A capset whose capabilities are not a subset of the manager's capabilities is excluded."""
+        from scaler.scheduler.controllers.worker_manager_utilties import build_set_desired_command
 
+        source = b"mgr-src"
+        manager_id = b"mgr-id"
+        # Manager advertises only "cpu" capability.
+        heartbeat = WorkerManagerHeartbeat(maxTaskConcurrency=10, capabilities={"cpu": -1}, workerManagerID=manager_id)
 
-def _declarative(commands):
-    """Return the declarative setDesiredTaskConcurrency commands emitted each policy run."""
-    return [c for c in commands if c.command == WorkerManagerCommandType.setDesiredTaskConcurrency]
+        # Generic (empty caps, wildcard) -> 2; gpu-only -> 4 (not servable); cpu-only -> 3 (servable).
+        self.policy_controller.get_scaling_commands.return_value = [
+            build_set_desired_command([({}, 2), ({"gpu": -1}, 4), ({"cpu": -1}, 3)])
+        ]
+        self.worker_controller.get_workers_by_manager_id.return_value = []
+
+        await self.controller.on_heartbeat(source, heartbeat)
+        status = self.controller.get_status()
+
+        detail = next(d for d in status.workerManagerDetails if d.workerManagerID == manager_id)
+        # 2 (empty wildcard) + 3 (cpu subset) - 0 connected = 5; gpu (4) is excluded.
+        self.assertEqual(detail.pendingWorkers, 5)
 
 
 def _create_mock_task(task_id: TaskID, capabilities: dict) -> Task:
@@ -921,16 +528,18 @@ def _create_mock_worker_heartbeat(capabilities: dict, queued_tasks: int = 0) -> 
 
 
 def _create_worker_manager_heartbeat(
-    worker_manager_id: bytes, max_task_concurrency: int = 10
+    worker_manager_id: bytes, max_task_concurrency: int = 10, capabilities: Optional[Dict[str, int]] = None
 ) -> WorkerManagerHeartbeat:
     return WorkerManagerHeartbeat(
-        maxTaskConcurrency=max_task_concurrency, capabilities={}, workerManagerID=worker_manager_id
+        maxTaskConcurrency=max_task_concurrency, capabilities=capabilities or {}, workerManagerID=worker_manager_id
     )
 
 
 def _run_native_worker_manager(
     scheduler_address: str, max_task_concurrency: int = 4, worker_manager_id: str = "test_manager"
 ) -> None:
+    from scaler.worker_manager_adapter.baremetal.native import NativeWorkerManager
+
     manager = NativeWorkerManager(
         NativeWorkerManagerConfig(
             worker_manager_config=WorkerManagerConfig(

--- a/tests/scheduler/test_scaling.py
+++ b/tests/scheduler/test_scaling.py
@@ -417,6 +417,126 @@ class TestCapabilityScalingPolicy(unittest.TestCase):
         requests = list(command.setDesiredTaskConcurrencyRequests)
         self.assertEqual(requests[0].taskConcurrency, 3)
 
+    def test_capability_desired_omits_empty_capset(self):
+        """A capability set with zero observed tasks must not appear in the emitted requests."""
+        # 1 gpu task; tpu capset has no tasks even if the manager advertises tpu.
+        task_id = TaskID.generate_task_id()
+        snapshot = InformationSnapshot(tasks={task_id: _create_mock_task(task_id, {"gpu": 1})}, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1, "tpu": -1})
+
+        command = self._commands(snapshot, heartbeat, [])
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        capsets = [set(capabilities_to_dict(r.capabilities).keys()) for r in requests]
+        self.assertIn({"gpu"}, capsets)
+        self.assertNotIn({"tpu"}, capsets)
+
+    def test_starts_worker_request_when_no_capable_workers_yet(self):
+        """A task requiring a capability that no manager-side worker yet provides
+        still produces a per-capset request so the manager can spawn one."""
+        task_id = TaskID.generate_task_id()
+        snapshot = InformationSnapshot(tasks={task_id: _create_mock_task(task_id, {"gpu": 1})}, workers={})
+        # Manager advertises gpu so the request is serviceable; no managed workers yet.
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1})
+
+        command = self._commands(snapshot, heartbeat, [])
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(set(capabilities_to_dict(requests[0].capabilities).keys()), {"gpu"})
+        self.assertEqual(requests[0].taskConcurrency, 1)
+
+    def test_get_status_returns_scaling_manager_status(self):
+        """CapabilityScalingPolicy.get_status returns a ScalingManagerStatus object."""
+        from scaler.protocol.capnp import ScalingManagerStatus
+
+        managed_workers = {b"mgr": [WorkerID(b"w0")]}
+        status = self.policy.get_status(managed_workers)
+        self.assertIsInstance(status, ScalingManagerStatus)
+
+
+class TestVanillaDeclarativeEquivalents(unittest.TestCase):
+    """Declarative equivalents of the master-branch vanilla shutdown tests."""
+
+    def setUp(self):
+        setup_logger()
+        self.policy = VanillaScalingPolicy()
+
+    def test_drain_all_when_idle(self):
+        """With workers connected and no tasks, the policy targets desired=0 and emits
+        setDesired(0) so the manager can drain its workers."""
+        workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=0) for i in range(4)}
+        managed = list(workers.keys())
+        snapshot = InformationSnapshot(tasks={}, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(len(commands), 1)
+        requests = list(commands[0].setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 0)
+
+    def test_shrink_to_ratio_floor(self):
+        """With few tasks relative to workers (ratio below lower threshold), the policy
+        targets ceil(tasks/upper_task_ratio) and emits setDesired with that smaller count."""
+        # 5 tasks, 10 connected workers -> ratio 0.5 < 1; floor = max(1, ceil(5/10)) = 1.
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(5)}
+        workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(10)}
+        managed = list(workers.keys())
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(len(commands), 1)
+        requests = list(commands[0].setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 1)
+
+    def test_no_action_when_ratio_is_in_band(self):
+        """With the task/worker ratio inside [lower, upper], the policy targets the current
+        worker count -- a no-op for the manager, so emission is skipped."""
+        # 15 tasks, 5 workers -> ratio 3, in [1, 10]; desired = current = 5.
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(15)}
+        workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
+        managed = list(workers.keys())
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(commands, [])
+
+    def test_get_status_returns_scaling_manager_status(self):
+        """VanillaScalingPolicy.get_status returns a ScalingManagerStatus object."""
+        from scaler.protocol.capnp import ScalingManagerStatus
+
+        managed_workers = {b"mgr": [WorkerID(b"w0")]}
+        status = self.policy.get_status(managed_workers)
+        self.assertIsInstance(status, ScalingManagerStatus)
+
+
+class TestCapabilityDeclarativeEquivalents(unittest.TestCase):
+    """Declarative equivalents of the master-branch capability shutdown tests."""
+
+    def setUp(self):
+        setup_logger()
+        self.policy = CapabilityScalingPolicy()
+
+    def test_drain_capset_when_no_tasks(self):
+        """With 3 connected workers and no tasks, the policy emits setDesired with an
+        empty request list -- effective desired (0) differs from current (3) so the manager
+        is told to drain (via extract_desired_count returning 0 for the empty list)."""
+        managed = [WorkerID(f"w{i}".encode()) for i in range(3)]
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1})
+
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
+
+        self.assertEqual(len(commands), 1)
+        # No per-capset requests because there are no tasks -- the manager interprets this
+        # as "desired 0" and drains its workers.
+        self.assertEqual(list(commands[0].setDesiredTaskConcurrencyRequests), [])
+
 
 class TestPendingWorkersStatus(unittest.IsolatedAsyncioTestCase):
     """Pending-worker reporting in WorkerManagerController.get_status."""

--- a/tests/scheduler/test_waterfall_scaling.py
+++ b/tests/scheduler/test_waterfall_scaling.py
@@ -156,6 +156,161 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
         # Effective desired (0) matches current (0) -> no-op skip.
         self.assertEqual(commands_b, [])
 
+    def test_lower_priority_drains_first(self):
+        """When demand drops to zero, the lower-priority manager drains first;
+        the higher-priority manager holds its workers until the lower-priority manager is empty."""
+        rules = [
+            WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10),
+            WaterfallRule(priority=2, worker_manager_id=b"manager_b", max_task_concurrency=20),
+        ]
+        policy = WaterfallScalingPolicy(rules)
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        manager_snapshots = {
+            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3),
+            b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=2),
+        }
+
+        # manager_b (lower priority) is told to drain to 0
+        managed_b = [WorkerID(b"worker-3"), WorkerID(b"worker-4")]
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, managed_b, manager_snapshots)
+        self.assertEqual(len(commands_b), 1)
+        self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 0)
+
+        # manager_a (higher priority) is NOT told to drain yet -- desired matches its current count
+        managed_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, managed_a, manager_snapshots)
+        self.assertEqual(commands_a, [])
+
+    def test_higher_priority_can_drain_when_lower_offline(self):
+        """If the lower-priority manager is offline (not in snapshots), the higher-priority
+        manager is allowed to drain immediately -- there is no lower priority to wait on."""
+        rules = [
+            WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10),
+            WaterfallRule(priority=2, worker_manager_id=b"manager_b", max_task_concurrency=20),
+        ]
+        policy = WaterfallScalingPolicy(rules)
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        manager_snapshots = {
+            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3)
+        }
+
+        managed_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, managed_a, manager_snapshots)
+
+        # No lower-priority manager to wait on -- emit setDesired(0) to drain.
+        self.assertEqual(len(commands_a), 1)
+        self.assertEqual(_generic_request(commands_a[0]).taskConcurrency, 0)
+
+    def test_unknown_manager_id_returns_no_commands(self):
+        """A heartbeat from a worker manager whose ID is not in the waterfall rules
+        receives no scaling commands at all (not even an empty setDesired)."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        tasks = _create_tasks(5)
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"unknown", max_task_concurrency=10)
+        manager_snapshots = {b"unknown": _create_manager_snapshot(b"unknown", max_task_concurrency=10, worker_count=0)}
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
+
+        self.assertEqual(commands, [])
+
+    def test_exact_matching_with_runtime_ids(self):
+        """Worker manager IDs like NAT|12345 must match rules by exact bytes; a heartbeat
+        from a manager whose ID matches a rule receives the allocation for that rule."""
+        rules = [
+            WaterfallRule(priority=1, worker_manager_id=b"NAT|12345", max_task_concurrency=10),
+            WaterfallRule(priority=2, worker_manager_id=b"ECS|67890", max_task_concurrency=20),
+        ]
+        policy = WaterfallScalingPolicy(rules)
+        tasks = _create_tasks(50)  # ceil(50/10) = 5; first manager absorbs all of it
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        manager_snapshots = {
+            b"NAT|12345": _create_manager_snapshot(b"NAT|12345", max_task_concurrency=10, worker_count=0),
+            b"ECS|67890": _create_manager_snapshot(b"ECS|67890", max_task_concurrency=20, worker_count=0),
+        }
+
+        # NAT manager gets the allocation since it has capacity and the priority chain
+        # consumes it first.
+        heartbeat_nat = _create_worker_manager_heartbeat(b"NAT|12345", max_task_concurrency=10)
+        commands_nat = policy.get_scaling_commands(snapshot, heartbeat_nat, [], manager_snapshots)
+        self.assertEqual(_generic_request(commands_nat[0]).taskConcurrency, 5)
+
+        # ECS manager gets nothing since NAT has absorbed everything; effective desired==current==0 -> skip.
+        heartbeat_ecs = _create_worker_manager_heartbeat(b"ECS|67890", max_task_concurrency=20)
+        commands_ecs = policy.get_scaling_commands(snapshot, heartbeat_ecs, [], manager_snapshots)
+        self.assertEqual(commands_ecs, [])
+
+    def test_blocked_when_any_higher_priority_has_room(self):
+        """When multiple worker managers share the same higher priority, the lower-priority
+        manager is allocated nothing until *all* higher-priority capacity is consumed."""
+        rules = [
+            WaterfallRule(priority=1, worker_manager_id=b"NAT|111", max_task_concurrency=10),
+            WaterfallRule(priority=1, worker_manager_id=b"NAT|222", max_task_concurrency=10),
+            WaterfallRule(priority=2, worker_manager_id=b"ECS|333", max_task_concurrency=20),
+        ]
+        policy = WaterfallScalingPolicy(rules)
+        # 5 tasks -> total_desired = ceil(5/10) = 1. Chain absorbs the 1 at NAT|111 entirely.
+        tasks = _create_tasks(5)
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        manager_snapshots = {
+            b"NAT|111": _create_manager_snapshot(b"NAT|111", max_task_concurrency=10, worker_count=10),
+            b"NAT|222": _create_manager_snapshot(b"NAT|222", max_task_concurrency=10, worker_count=5),
+            b"ECS|333": _create_manager_snapshot(b"ECS|333", max_task_concurrency=20, worker_count=0),
+        }
+
+        heartbeat_ecs = _create_worker_manager_heartbeat(b"ECS|333", max_task_concurrency=20)
+        commands = policy.get_scaling_commands(snapshot, heartbeat_ecs, [], manager_snapshots)
+
+        # ECS allocation = 0 (higher-priority chain absorbs all demand); current = 0; no-op skip.
+        self.assertEqual(commands, [])
+
+    def test_greedy_shutdown_partial_with_tasks(self):
+        """With a small task count and many workers, the policy targets the ratio-based
+        minimum and emits a setDesired with that smaller count to drain excess workers."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=20)]
+        policy = WaterfallScalingPolicy(rules)
+        # 5 tasks; ratio yields ceil(5/10) = 1 desired total.
+        tasks = _create_tasks(5)
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        manager_snapshots = {
+            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=20, worker_count=10)
+        }
+        managed = [WorkerID(f"worker-{i}".encode()) for i in range(10)]
+        heartbeat = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=20)
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, managed, manager_snapshots)
+
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(_generic_request(commands[0]).taskConcurrency, 1)
+
+    def test_declarative_desired_zero_on_non_owning_manager(self):
+        """When the priority chain has already absorbed all demand, a lower-priority manager
+        that still has connected workers is told setDesired(0) for the generic capset."""
+        rules = [
+            WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10),
+            WaterfallRule(priority=2, worker_manager_id=b"manager_b", max_task_concurrency=20),
+        ]
+        policy = WaterfallScalingPolicy(rules)
+        tasks = _create_tasks(5)
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        manager_snapshots = {
+            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3),
+            b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=2),
+        }
+
+        managed_b = [WorkerID(b"w0"), WorkerID(b"w1")]
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, managed_b, manager_snapshots)
+
+        # 5 tasks -> total_desired=1, absorbed by manager_a entirely -> manager_b's share=0;
+        # but manager_b has 2 connected workers, so the command is not a no-op.
+        self.assertEqual(len(commands_b), 1)
+        self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 0)
+
 
 class TestWaterfallCapabilities(unittest.TestCase):
     """Capability-aware declarative emission for WaterfallScalingPolicy."""
@@ -255,6 +410,71 @@ class TestWaterfallCapabilities(unittest.TestCase):
         commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
         self.assertEqual(_capability_requests(commands[0]), [({"gpu": 2, "nvlink": 1}, 1)])
+
+    def test_capability_request_emitted_even_when_overall_ratio_is_in_band(self):
+        """A capability-specific request must still be allocated for tasks that need
+        unique capabilities, even when the cluster-wide task/worker ratio doesn't warrant
+        scaling generic workers."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        # 3 generic + 1 gpu task; 3 workers running -> generic ratio is in band (no scale)
+        # but a gpu request should still be emitted.
+        generic_tasks = _create_tasks(3)
+        gpu_tasks = _create_tasks(1, capabilities={"gpu": 1})
+        all_tasks = {**generic_tasks, **gpu_tasks}
+        workers = _create_workers(3)
+        snapshot = InformationSnapshot(tasks=all_tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"manager_a", capabilities={"gpu": 4})
+        manager_snapshots = {
+            b"manager_a": _create_manager_snapshot(b"manager_a", worker_count=0, capabilities={"gpu": 4})
+        }
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
+
+        self.assertEqual(len(commands), 1)
+        cap_requests = _capability_requests(commands[0])
+        self.assertIn("gpu", {next(iter(caps.keys()), None) for caps, _ in cap_requests})
+
+    def test_generic_capset_present_with_no_capability_tasks(self):
+        """When all tasks have no capabilities, the manager receives a generic request
+        (empty capabilities dict) carrying the ratio-derived allocation."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        tasks = _create_tasks(5)
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        manager_snapshots = {b"mgr": _create_manager_snapshot(b"mgr", worker_count=0)}
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
+
+        self.assertEqual(len(commands), 1)
+        # The generic (empty capset) request is present.
+        generic = _generic_request(commands[0])
+        self.assertIsNotNone(generic)
+        # ceil(5/10) = 1 generic worker desired
+        self.assertEqual(generic.taskConcurrency, 1)
+        # No capability-specific requests since no capability tasks exist.
+        self.assertEqual(_capability_requests(commands[0]), [])
+
+    def test_capability_match_is_key_only(self):
+        """Capability matching is name-only: a task requiring {a: 3} is considered serviceable
+        by a manager that advertises {a: 5} -- numeric values are not used for subsumption."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        tasks = _create_tasks(1, capabilities={"a": 3})
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        # Manager's advertised "a" value (5) differs from the task's required "a" value (3).
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"a": 5})
+        manager_snapshots = {b"mgr": _create_manager_snapshot(b"mgr", worker_count=0, capabilities={"a": 5})}
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
+
+        # The manager is considered capable despite the value mismatch, so a request for
+        # the {a} capset is allocated to it.
+        self.assertEqual(len(commands), 1)
+        cap_requests = _capability_requests(commands[0])
+        self.assertEqual(len(cap_requests), 1)
+        self.assertEqual(set(cap_requests[0][0].keys()), {"a"})
 
 
 class TestWaterfallV1Policy(unittest.TestCase):

--- a/tests/scheduler/test_waterfall_scaling.py
+++ b/tests/scheduler/test_waterfall_scaling.py
@@ -1,9 +1,9 @@
 import asyncio
 import time
 import unittest
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
-from scaler.protocol.capnp import Resource, Task, WorkerHeartbeat, WorkerManagerCommandType, WorkerManagerHeartbeat
+from scaler.protocol.capnp import Resource, Task, WorkerHeartbeat, WorkerManagerHeartbeat
 from scaler.protocol.helpers import capabilities_to_dict
 from scaler.scheduler.controllers.policies.library.utility import create_policy
 from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
@@ -15,8 +15,25 @@ from scaler.utility.logging.utility import setup_logger
 from scaler.utility.snapshot import InformationSnapshot
 
 
+def _generic_request(command):
+    """Return the empty-capabilities (generic) DesiredTaskConcurrencyRequest from a command."""
+    for r in command.setDesiredTaskConcurrencyRequests:
+        if not capabilities_to_dict(r.capabilities):
+            return r
+    return None
+
+
+def _capability_requests(command):
+    """Return only capability-bearing requests as (caps_dict, taskConcurrency) tuples."""
+    return [
+        (capabilities_to_dict(r.capabilities), r.taskConcurrency)
+        for r in command.setDesiredTaskConcurrencyRequests
+        if capabilities_to_dict(r.capabilities)
+    ]
+
+
 class TestWaterfallScalingPolicy(unittest.TestCase):
-    """Unit tests for WaterfallScalingPolicy with stateless interface."""
+    """Unit tests for declarative WaterfallScalingPolicy emission."""
 
     def setUp(self):
         setup_logger()
@@ -26,569 +43,192 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
         ]
         self.policy = WaterfallScalingPolicy(self.rules)
 
-    def test_single_priority_scale_up(self):
-        """Single manager with tasks and no workers should scale up."""
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
-
+    def test_unknown_manager_emits_no_commands(self):
+        """Manager with unknown worker_manager_id receives no scaling commands."""
         tasks = _create_tasks(5)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=0)
-        }
+        manager_snapshots = {b"unknown": _create_manager_snapshot(b"unknown", max_task_concurrency=10, worker_count=0)}
+        heartbeat = _create_worker_manager_heartbeat(b"unknown", max_task_concurrency=10)
 
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
+        self.assertEqual(len(commands), 0)
 
-    def test_priority_cascade_higher_priority_fills_first(self):
-        """Lower-priority manager should not scale up while higher-priority has capacity."""
+    def test_higher_priority_takes_full_load_when_within_capacity(self):
+        """When tasks fit in the higher-priority manager's capacity, lower-priority desired is 0."""
         tasks = _create_tasks(5)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Manager A (priority 1) has capacity remaining
         manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3),
+            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=0),
             b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=0),
         }
 
-        # Heartbeat from manager_a: should scale up
         heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
-        commands_a = self.policy.get_scaling_commands(
-            snapshot, heartbeat_a, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_a = _imperative(commands_a)
-        self.assertEqual(len(commands_a), 1)
-        self.assertEqual(commands_a[0].command, WorkerManagerCommandType.startWorkers)
+        commands_a = self.policy.get_scaling_commands(snapshot, heartbeat_a, [], manager_snapshots)
+        self.assertEqual(_generic_request(commands_a[0]).taskConcurrency, 1)
 
-        # Heartbeat from manager_b: should NOT scale up (manager_a still has room)
         heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        commands_b = self.policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_b = _imperative(commands_b)
-        self.assertEqual(len(commands_b), 0)
+        commands_b = self.policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
+        # Manager B's effective desired is 0 (chain consumes the whole 1 worker at manager_a), and its
+        # current connected count is also 0 -> no-op skip, no command emitted.
+        self.assertEqual(commands_b, [])
 
-    def test_overflow_to_lower_priority(self):
-        """Lower-priority manager should scale up when higher-priority is at capacity."""
-        tasks = _create_tasks(5)
+    def test_overflow_to_lower_priority_when_higher_at_capacity(self):
+        """When higher priority is at full capacity, the overflow lands on lower-priority desired."""
+        # Many tasks (50) so total_desired = ceil(50/10) = 5 spread across managers.
+        tasks = _create_tasks(150)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Manager A at full capacity
+        # manager_a is full so its capacity (10) is consumed; remainder (5) goes to manager_b.
         manager_snapshots = {
             b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=10),
             b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=0),
         }
 
         heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        commands = self.policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
+        commands_b = self.policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
 
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
+        # total_desired = ceil(150/10) = 15. Manager_a's cap is 10 -> consumed 10. Remaining for B = 5.
+        self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 5)
 
-    def test_offline_manager_fallback(self):
-        """Lower-priority manager should scale up when higher-priority is offline (absent from snapshots)."""
+    def test_higher_priority_offline_routes_load_to_lower(self):
+        """When the higher-priority manager is offline, a lower-priority manager picks up the load."""
         tasks = _create_tasks(5)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Manager A is offline (cleaned up by WorkerManagerController, not in snapshots)
         manager_snapshots = {
             b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=0)
         }
 
         heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        commands = self.policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
+        commands_b = self.policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
 
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
+        # Higher-priority is offline (absent) so its capacity contributes 0; lower picks up all of it.
+        self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 1)
 
-    def test_reverse_shutdown_order(self):
-        """Higher-priority manager should not shut down while lower-priority still has workers."""
-        workers = _create_workers(5, queued_tasks=0)
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-        managed_worker_capabilities: Dict[str, int] = {}
+    def test_no_tasks_skips_emission(self):
+        """No tasks and no managed workers: effective desired (0) matches current (0) -> no-op skip."""
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        manager_snapshots = {b"manager_a": _create_manager_snapshot(b"manager_a")}
+        heartbeat = _create_worker_manager_heartbeat(b"manager_a")
 
-        # Both managers have workers
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3),
-            b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=2),
-        }
+        commands = self.policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
-        # Heartbeat from manager_b (lower priority): should shut down all its workers greedily
-        managed_worker_ids_b = [WorkerID(b"worker-3"), WorkerID(b"worker-4")]
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        commands_b = self.policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids_b, managed_worker_capabilities, manager_snapshots
-        )
-        commands_b = _imperative(commands_b)
-        self.assertEqual(len(commands_b), 1)
-        self.assertEqual(commands_b[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(commands_b[0].workerIDs), 2)
+        self.assertEqual(commands, [])
 
-        # Heartbeat from manager_a (higher priority): should NOT shut down (B still has workers)
-        managed_worker_ids_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
-        commands_a = self.policy.get_scaling_commands(
-            snapshot, heartbeat_a, managed_worker_ids_a, managed_worker_capabilities, manager_snapshots
-        )
-        commands_a = _imperative(commands_a)
-        self.assertEqual(len(commands_a), 0)
-
-    def test_manager_not_in_config(self):
-        """Manager with unknown worker_manager_id should receive no commands."""
-        tasks = _create_tasks(5)
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-        manager_snapshots = {b"unknown": _create_manager_snapshot(b"unknown", max_task_concurrency=10, worker_count=0)}
-
-        heartbeat = _create_worker_manager_heartbeat(b"unknown", max_task_concurrency=10)
-        commands = self.policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-
-        self.assertEqual(len(commands), 0)
-
-    def test_effective_capacity_min_config_and_heartbeat(self):
-        """Effective capacity should be min(config max_task_concurrency, heartbeat max_task_concurrency)."""
-        # Rule says max_task_concurrency=5, heartbeat says max_task_concurrency=3
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=5)]
+    def test_max_task_concurrency_clamps_via_heartbeat(self):
+        """The manager's heartbeat-reported maxTaskConcurrency clamps its allocation."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=20)]
         policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(5)
+        tasks = _create_tasks(50)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-
-        # Already at 3 workers (heartbeat limit)
-        managed_worker_ids = [WorkerID(b"w1"), WorkerID(b"w2"), WorkerID(b"w3")]
-        managed_worker_capabilities: Dict[str, int] = {}
         manager_snapshots = {
             b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=3, worker_count=3)
         }
-
         heartbeat = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=3)
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
 
-        # Should NOT scale up: at effective capacity (min(5, 3) = 3)
-        self.assertEqual(len(commands), 0)
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
-    def test_no_workers_no_tasks(self):
-        """No tasks and no workers should return no commands."""
-        snapshot = InformationSnapshot(tasks={}, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-        manager_snapshots = {b"manager_a": _create_manager_snapshot(b"manager_a")}
+        # min(rule cap 20, heartbeat cap 3) = 3 clamps the desired worker count.
+        self.assertEqual(_generic_request(commands[0]).taskConcurrency, 3)
 
-        heartbeat = _create_worker_manager_heartbeat(b"manager_a")
-        commands = self.policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-
-        self.assertEqual(len(commands), 0)
-
-    def test_same_priority_concurrent_scaling(self):
-        """Two managers at same priority should both be able to scale up concurrently."""
+    def test_same_priority_share_capacity(self):
+        """Two managers at the same priority each absorb a portion of the desired load."""
         rules = [
             WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10),
             WaterfallRule(priority=1, worker_manager_id=b"manager_b", max_task_concurrency=10),
         ]
         policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(5)
+        # 100 tasks -> total_desired = 10
+        tasks = _create_tasks(100)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
         manager_snapshots = {
             b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=0),
             b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=10, worker_count=0),
         }
 
-        # Both should scale up
+        # Sorting by priority is stable; with equal priority the iteration order is the rules' input order.
         heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
-        commands_a = policy.get_scaling_commands(
-            snapshot, heartbeat_a, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_a = _imperative(commands_a)
-        self.assertEqual(len(commands_a), 1)
-        self.assertEqual(commands_a[0].command, WorkerManagerCommandType.startWorkers)
+        commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, [], manager_snapshots)
+        self.assertEqual(_generic_request(commands_a[0]).taskConcurrency, 10)
 
         heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=10)
-        commands_b = policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_b = _imperative(commands_b)
-        self.assertEqual(len(commands_b), 1)
-        self.assertEqual(commands_b[0].command, WorkerManagerCommandType.startWorkers)
-
-    def test_scale_down_least_busy_worker(self):
-        """When shutting down greedily, should shut down all workers sorted by busyness (least busy first)."""
-        workers = {
-            WorkerID(b"worker-busy"): _create_mock_worker_heartbeat(queued_tasks=5),
-            WorkerID(b"worker-idle"): _create_mock_worker_heartbeat(queued_tasks=0),
-        }
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-
-        managed_worker_ids = [WorkerID(b"worker-busy"), WorkerID(b"worker-idle")]
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # No lower-priority managers with workers
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=2)
-        }
-
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
-
-        heartbeat = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-
-        # With 0 tasks, all workers should be shut down greedily
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(commands[0].workerIDs), 2)
-        # Least busy first
-        self.assertEqual(commands[0].workerIDs[0], bytes(WorkerID(b"worker-idle")))
-        self.assertEqual(commands[0].workerIDs[1], bytes(WorkerID(b"worker-busy")))
-
-    def test_higher_priority_manager_never_seen(self):
-        """If higher-priority manager was never seen, lower-priority should scale up."""
-        tasks = _create_tasks(5)
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Only manager_b in snapshots, manager_a never seen
-        manager_snapshots = {
-            b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=0)
-        }
-
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        commands = self.policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
-
-    def test_shutdown_allowed_when_lower_priority_offline(self):
-        """Higher-priority manager can shut down if lower-priority manager is offline (absent from snapshots)."""
-        workers = _create_workers(3, queued_tasks=0)
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-
-        managed_worker_ids_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Manager B is offline (cleaned up by WorkerManagerController, not in snapshots)
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3)
-        }
-
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
-        commands = self.policy.get_scaling_commands(
-            snapshot, heartbeat_a, managed_worker_ids_a, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-
-        # With 0 tasks, all 3 workers should be shut down greedily
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(commands[0].workerIDs), 3)
-
-    def test_exact_matching_with_runtime_ids(self):
-        """Worker manager IDs like NAT|12345 should match rules with exact worker_manager_id."""
-        rules = [
-            WaterfallRule(priority=1, worker_manager_id=b"NAT|12345", max_task_concurrency=10),
-            WaterfallRule(priority=2, worker_manager_id=b"ECS|67890", max_task_concurrency=20),
-        ]
-        policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(5)
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        manager_snapshots = {
-            b"NAT|12345": _create_manager_snapshot(b"NAT|12345", max_task_concurrency=10, worker_count=3),
-            b"ECS|67890": _create_manager_snapshot(b"ECS|67890", max_task_concurrency=20, worker_count=0),
-        }
-
-        # Heartbeat from NAT manager: should scale up (still has capacity)
-        heartbeat_nat = _create_worker_manager_heartbeat(b"NAT|12345", max_task_concurrency=10)
-        commands_nat = policy.get_scaling_commands(
-            snapshot, heartbeat_nat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_nat = _imperative(commands_nat)
-        self.assertEqual(len(commands_nat), 1)
-        self.assertEqual(commands_nat[0].command, WorkerManagerCommandType.startWorkers)
-
-        # Heartbeat from ECS manager: should NOT scale up (NAT still has room)
-        heartbeat_ecs = _create_worker_manager_heartbeat(b"ECS|67890", max_task_concurrency=20)
-        commands_ecs = policy.get_scaling_commands(
-            snapshot, heartbeat_ecs, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_ecs = _imperative(commands_ecs)
-        self.assertEqual(len(commands_ecs), 0)
-
-    def test_multiple_managers_same_priority(self):
-        """Multiple worker managers at the same priority should all need to be at capacity before overflow."""
-        rules = [
-            WaterfallRule(priority=1, worker_manager_id=b"NAT|111", max_task_concurrency=10),
-            WaterfallRule(priority=1, worker_manager_id=b"NAT|222", max_task_concurrency=10),
-            WaterfallRule(priority=2, worker_manager_id=b"ECS|333", max_task_concurrency=20),
-        ]
-        policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(5)
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Two NAT managers, both at capacity
-        manager_snapshots = {
-            b"NAT|111": _create_manager_snapshot(b"NAT|111", max_task_concurrency=10, worker_count=10),
-            b"NAT|222": _create_manager_snapshot(b"NAT|222", max_task_concurrency=10, worker_count=10),
-            b"ECS|333": _create_manager_snapshot(b"ECS|333", max_task_concurrency=20, worker_count=0),
-        }
-
-        # ECS manager should scale up since all NAT managers are at capacity
-        heartbeat_ecs = _create_worker_manager_heartbeat(b"ECS|333", max_task_concurrency=20)
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat_ecs, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
-
-    def test_blocked_when_any_higher_priority_has_room(self):
-        """Lower priority should not scale up if any manager at a higher priority still has room."""
-        rules = [
-            WaterfallRule(priority=1, worker_manager_id=b"NAT|111", max_task_concurrency=10),
-            WaterfallRule(priority=1, worker_manager_id=b"NAT|222", max_task_concurrency=10),
-            WaterfallRule(priority=2, worker_manager_id=b"ECS|333", max_task_concurrency=20),
-        ]
-        policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(5)
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # One NAT manager full, another still has room
-        manager_snapshots = {
-            b"NAT|111": _create_manager_snapshot(b"NAT|111", max_task_concurrency=10, worker_count=10),
-            b"NAT|222": _create_manager_snapshot(b"NAT|222", max_task_concurrency=10, worker_count=5),
-            b"ECS|333": _create_manager_snapshot(b"ECS|333", max_task_concurrency=20, worker_count=0),
-        }
-
-        # ECS should NOT scale up — NAT|222 still has room
-        heartbeat_ecs = _create_worker_manager_heartbeat(b"ECS|333", max_task_concurrency=20)
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat_ecs, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-        self.assertEqual(len(commands), 0)
-
-    def test_greedy_shutdown_partial_with_tasks(self):
-        """With tasks present, keeps ceil(T/upper) workers, shuts down rest."""
-        # 5 tasks, 10 workers -> ratio=0.5 < 1. min_keep = max(1, ceil(5/10))=1. Shutdown 9.
-        tasks = _create_tasks(5)
-        workers = _create_workers(10, queued_tasks=0)
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-
-        managed_worker_ids = list(workers.keys())
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=20)]
-        policy = WaterfallScalingPolicy(rules)
-
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=20, worker_count=10)
-        }
-
-        heartbeat = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=20)
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.shutdownWorkers)
-        # 10 workers - 1 kept = 9 shut down
-        self.assertEqual(len(commands[0].workerIDs), 9)
-
-    def test_declarative_desired_zero_on_non_owning_manager(self):
-        """A non-owning manager (higher-priority has capacity) must emit desired=0."""
-        tasks = _create_tasks(5)
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Manager A (priority 1) has room; manager B is lower priority and should not scale.
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=3),
-            b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=0),
-        }
-
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        commands_b = self.policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-
-        declarative = _declarative(commands_b)
-        self.assertEqual(len(declarative), 1)
-        requests = list(declarative[0].setDesiredTaskConcurrencyRequests)
-        self.assertEqual(len(requests), 1)
-        self.assertEqual(requests[0].taskConcurrency, 0)
+        commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
+        # First manager consumed all of its capacity; nothing left for the second at same priority.
+        # Effective desired (0) matches current (0) -> no-op skip.
+        self.assertEqual(commands_b, [])
 
 
 class TestWaterfallCapabilities(unittest.TestCase):
-    """Tests for capability-aware scaling in WaterfallScalingPolicy."""
+    """Capability-aware declarative emission for WaterfallScalingPolicy."""
 
     def setUp(self):
         setup_logger()
 
-    def test_unmet_capability_scales_up_capable_manager(self):
-        """Manager that can provide the required capability should start workers with that capability."""
+    def test_capable_manager_emits_capability_request(self):
+        """A capable manager emits a per-capset DesiredTaskConcurrencyRequest with that capset."""
         rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_gpu", max_task_concurrency=10)]
         policy = WaterfallScalingPolicy(rules)
-
         tasks = _create_tasks(1, capabilities={"gpu": 1})
-        workers = _create_workers(2)  # existing workers have no capabilities
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
         heartbeat = _create_worker_manager_heartbeat(b"manager_gpu", capabilities={"gpu": 4})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
         manager_snapshots = {
             b"manager_gpu": _create_manager_snapshot(b"manager_gpu", worker_count=0, capabilities={"gpu": 4})
         }
 
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertIn("gpu", capabilities_to_dict(commands[0].capabilities))
+        cap_requests = _capability_requests(commands[0])
+        self.assertEqual(len(cap_requests), 1)
+        self.assertEqual(cap_requests[0], ({"gpu": 1}, 1))
 
-    def test_unmet_capability_skips_incapable_higher_priority(self):
-        """Higher-priority manager that cannot provide the capability should be skipped."""
-        rules = [
-            WaterfallRule(priority=1, worker_manager_id=b"manager_cpu", max_task_concurrency=10),
-            WaterfallRule(priority=2, worker_manager_id=b"manager_gpu", max_task_concurrency=10),
-        ]
+    def test_incapable_manager_emits_no_capability_request(self):
+        """A manager that can't satisfy a capset emits no request for that capset."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_cpu", max_task_concurrency=10)]
         policy = WaterfallScalingPolicy(rules)
-
         tasks = _create_tasks(1, capabilities={"gpu": 1})
         snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"manager_cpu", capabilities={})
+        manager_snapshots = {b"manager_cpu": _create_manager_snapshot(b"manager_cpu", worker_count=0, capabilities={})}
 
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-        manager_snapshots = {
-            b"manager_cpu": _create_manager_snapshot(b"manager_cpu", worker_count=0, capabilities={}),
-            b"manager_gpu": _create_manager_snapshot(b"manager_gpu", worker_count=0, capabilities={"gpu": 4}),
-        }
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
-        # manager_cpu heartbeat: cannot provide gpu, should not issue start for gpu
-        heartbeat_cpu = _create_worker_manager_heartbeat(b"manager_cpu", capabilities={})
-        commands_cpu = policy.get_scaling_commands(
-            snapshot, heartbeat_cpu, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_cpu = _imperative(commands_cpu)
-        # Falls through to generic start (tasks exist, no workers) — but capability check returns empty
-        # because manager_cpu can't provide gpu. Generic start still fires.
-        gpu_commands = [c for c in commands_cpu if capabilities_to_dict(c.capabilities).get("gpu")]
-        self.assertEqual(len(gpu_commands), 0)
+        self.assertEqual(_capability_requests(commands[0]), [])
 
-        # manager_gpu heartbeat: can provide gpu, should issue start with gpu
-        heartbeat_gpu = _create_worker_manager_heartbeat(b"manager_gpu", capabilities={"gpu": 4})
-        commands_gpu = policy.get_scaling_commands(
-            snapshot, heartbeat_gpu, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_gpu = _imperative(commands_gpu)
-        self.assertEqual(len(commands_gpu), 1)
-        self.assertEqual(commands_gpu[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertIn("gpu", capabilities_to_dict(commands_gpu[0].capabilities))
-
-    def test_unmet_capability_respects_waterfall_priority(self):
-        """When multiple managers can provide the capability, higher priority should start first."""
+    def test_higher_priority_capable_owns_capset(self):
+        """When two managers can satisfy the capset, only the higher-priority one allocates it."""
         rules = [
             WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10),
             WaterfallRule(priority=2, worker_manager_id=b"manager_b", max_task_concurrency=10),
         ]
         policy = WaterfallScalingPolicy(rules)
-
         tasks = _create_tasks(1, capabilities={"gpu": 1})
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
         manager_snapshots = {
             b"manager_a": _create_manager_snapshot(b"manager_a", worker_count=0, capabilities={"gpu": 4}),
             b"manager_b": _create_manager_snapshot(b"manager_b", worker_count=0, capabilities={"gpu": 4}),
         }
 
-        # manager_a (higher priority) should start
         heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", capabilities={"gpu": 4})
-        commands_a = policy.get_scaling_commands(
-            snapshot, heartbeat_a, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_a = _imperative(commands_a)
-        self.assertEqual(len(commands_a), 1)
-        self.assertIn("gpu", capabilities_to_dict(commands_a[0].capabilities))
+        commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, [], manager_snapshots)
+        self.assertEqual(_capability_requests(commands_a[0]), [({"gpu": 1}, 1)])
 
-        # manager_b should NOT start (higher-priority manager_a has capacity)
         heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", capabilities={"gpu": 4})
-        commands_b = policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_b = _imperative(commands_b)
-        self.assertEqual(len(commands_b), 0)
+        commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
+        # Higher-priority A owns the gpu capset; B's effective desired (0) matches its
+        # current connected count (0) -> no-op skip.
+        self.assertEqual(commands_b, [])
 
-    def test_unmet_capability_overflows_to_lower_priority(self):
-        """Lower-priority manager should start when higher-priority capable manager is at capacity."""
+    def test_capset_overflow_to_lower_priority_when_higher_full(self):
+        """When the higher-priority capable manager is full for the capset, overflow goes to the next."""
         rules = [
-            WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=5),
+            WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=2),
             WaterfallRule(priority=2, worker_manager_id=b"manager_b", max_task_concurrency=10),
         ]
         policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(1, capabilities={"gpu": 1})
+        tasks = _create_tasks(50, capabilities={"gpu": 1})
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
         manager_snapshots = {
             b"manager_a": _create_manager_snapshot(
-                b"manager_a", max_task_concurrency=5, worker_count=5, capabilities={"gpu": 4}
+                b"manager_a", max_task_concurrency=2, worker_count=2, capabilities={"gpu": 4}
             ),
             b"manager_b": _create_manager_snapshot(
                 b"manager_b", max_task_concurrency=10, worker_count=0, capabilities={"gpu": 4}
@@ -596,144 +236,25 @@ class TestWaterfallCapabilities(unittest.TestCase):
         }
 
         heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", capabilities={"gpu": 4})
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-        self.assertEqual(len(commands), 1)
-        self.assertIn("gpu", capabilities_to_dict(commands[0].capabilities))
+        commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
 
-    def test_capability_check_precedes_ratio(self):
-        """Unmet capabilities should trigger start even when overall ratio is within bounds."""
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
+        # total_desired = ceil(50/10) = 5. manager_a cap=2 absorbs 2, manager_b allocates remaining 3.
+        self.assertEqual(_capability_requests(commands_b[0]), [({"gpu": 1}, 3)])
 
-        # 3 generic tasks + 1 GPU task, 3 workers → ratio = 4/3 ≈ 1.3 (within [1, 10])
-        generic_tasks = _create_tasks(3)
-        gpu_tasks = _create_tasks(1, capabilities={"gpu": 1})
-        all_tasks = {**generic_tasks, **gpu_tasks}
-        workers = _create_workers(3)
-        snapshot = InformationSnapshot(tasks=all_tasks, workers=workers)
-
-        heartbeat = _create_worker_manager_heartbeat(b"manager_a", capabilities={"gpu": 4})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-        manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", worker_count=0, capabilities={"gpu": 4})
-        }
-
-        commands = policy.get_scaling_commands(
-            snapshot, heartbeat, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands = _imperative(commands)
-        self.assertEqual(len(commands), 1)
-        self.assertIn("gpu", capabilities_to_dict(commands[0].capabilities))
-
-    def test_start_command_includes_capabilities(self):
-        """StartWorkers command for unmet capability should carry the exact capability dict."""
+    def test_capability_request_carries_concrete_dict(self):
+        """The request's capabilities field carries the exact dict from the originating tasks."""
         rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
         policy = WaterfallScalingPolicy(rules)
-
         tasks = _create_tasks(1, capabilities={"gpu": 2, "nvlink": 1})
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-
         heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": 8, "nvlink": 4})
         manager_snapshots = {
             b"mgr": _create_manager_snapshot(b"mgr", worker_count=0, capabilities={"gpu": 8, "nvlink": 4})
         }
 
-        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {}, manager_snapshots)
-        commands = _imperative(commands)
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(capabilities_to_dict(commands[0].capabilities), {"gpu": 2, "nvlink": 1})
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
 
-    def test_shutdown_prefers_no_capability_workers(self):
-        """When shutting down, workers without capabilities should be shut down first."""
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
-
-        workers = {
-            WorkerID(b"worker-gpu"): _create_mock_worker_heartbeat(queued_tasks=0, capabilities={"gpu": 4}),
-            WorkerID(b"worker-bare"): _create_mock_worker_heartbeat(queued_tasks=0, capabilities={}),
-        }
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-
-        managed_worker_ids = [WorkerID(b"worker-gpu"), WorkerID(b"worker-bare")]
-        manager_snapshots = {b"mgr": _create_manager_snapshot(b"mgr", worker_count=2)}
-
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
-        commands = policy.get_scaling_commands(snapshot, heartbeat, managed_worker_ids, {}, manager_snapshots)
-        commands = _imperative(commands)
-
-        # With 0 tasks, both workers are shut down greedily; no-cap worker comes first
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(commands[0].workerIDs), 2)
-        self.assertEqual(commands[0].workerIDs[0], bytes(WorkerID(b"worker-bare")))
-        self.assertEqual(commands[0].workerIDs[1], bytes(WorkerID(b"worker-gpu")))
-
-    def test_shutdown_fallback_to_capable_workers(self):
-        """When all workers have capabilities, shutdown should still pick the least busy first."""
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
-
-        workers = {
-            WorkerID(b"worker-busy"): _create_mock_worker_heartbeat(queued_tasks=5, capabilities={"gpu": 4}),
-            WorkerID(b"worker-idle"): _create_mock_worker_heartbeat(queued_tasks=0, capabilities={"gpu": 4}),
-        }
-        snapshot = InformationSnapshot(tasks={}, workers=workers)
-
-        managed_worker_ids = [WorkerID(b"worker-busy"), WorkerID(b"worker-idle")]
-        manager_snapshots = {b"mgr": _create_manager_snapshot(b"mgr", worker_count=2)}
-
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
-        commands = policy.get_scaling_commands(snapshot, heartbeat, managed_worker_ids, {}, manager_snapshots)
-        commands = _imperative(commands)
-
-        # With 0 tasks, both shut down greedily; least busy first
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.shutdownWorkers)
-        self.assertEqual(len(commands[0].workerIDs), 2)
-        self.assertEqual(commands[0].workerIDs[0], bytes(WorkerID(b"worker-idle")))
-        self.assertEqual(commands[0].workerIDs[1], bytes(WorkerID(b"worker-busy")))
-
-    def test_generic_tasks_unchanged(self):
-        """Tasks with no capabilities should use existing ratio-based logic (no regression)."""
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
-
-        tasks = _create_tasks(5)  # no capabilities
-        snapshot = InformationSnapshot(tasks=tasks, workers={})
-
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
-        manager_snapshots = {b"mgr": _create_manager_snapshot(b"mgr", worker_count=0)}
-
-        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {}, manager_snapshots)
-        commands = _imperative(commands)
-        self.assertEqual(len(commands), 1)
-        self.assertEqual(commands[0].command, WorkerManagerCommandType.startWorkers)
-        self.assertEqual(capabilities_to_dict(commands[0].capabilities), {})
-
-    def test_value_agnostic_matching(self):
-        """Capability matching should be key-only; values are ignored."""
-        rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
-        policy = WaterfallScalingPolicy(rules)
-
-        # Task requires {a: 3}, workers provide {a: 5} — should be considered capable
-        tasks = _create_tasks(1, capabilities={"a": 3})
-        workers = _create_workers(2, capabilities={"a": 5})
-        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"a": 5})
-        manager_snapshots = {b"mgr": _create_manager_snapshot(b"mgr", worker_count=2, capabilities={"a": 5})}
-
-        # Should NOT issue capability start — workers already handle {a}
-        commands = policy.get_scaling_commands(snapshot, heartbeat, [], {}, manager_snapshots)
-        commands = _imperative(commands)
-        capability_starts = [
-            c for c in commands if c.command == WorkerManagerCommandType.startWorkers and c.capabilities
-        ]
-        self.assertEqual(len(capability_starts), 0)
+        self.assertEqual(_capability_requests(commands[0]), [({"gpu": 2, "nvlink": 1}, 1)])
 
 
 class TestWaterfallV1Policy(unittest.TestCase):
@@ -742,7 +263,6 @@ class TestWaterfallV1Policy(unittest.TestCase):
     def setUp(self):
         setup_logger()
         # EvenLoadAllocatePolicy creates an AsyncPriorityQueue which requires an event loop.
-        # On Python 3.8, there is no implicit event loop in the main thread, so create one.
         try:
             asyncio.get_event_loop()
         except RuntimeError:
@@ -802,37 +322,26 @@ class TestWaterfallV1Policy(unittest.TestCase):
             WaterfallV1Policy("1,mgr_a,10\n2,mgr_a,20")
 
     def test_policy_delegates_to_scaling_policy(self):
-        """Policy controller should delegate scaling commands to its scaling policy."""
+        """Policy controller delegates declarative emission to its scaling policy."""
         policy = WaterfallV1Policy("1,manager_a,10\n2,manager_b,20")
 
         tasks = _create_tasks(5)
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        managed_worker_ids: List[WorkerID] = []
-        managed_worker_capabilities: Dict[str, int] = {}
-
-        # Manager A heartbeat with manager snapshots showing A has capacity
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
         manager_snapshots = {
-            b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=0)
-        }
-        commands_a = policy.get_scaling_commands(
-            snapshot, heartbeat_a, managed_worker_ids, managed_worker_capabilities, manager_snapshots
-        )
-        commands_a = _imperative(commands_a)
-        self.assertEqual(len(commands_a), 1)
-        self.assertEqual(commands_a[0].command, WorkerManagerCommandType.startWorkers)
-
-        # Manager B heartbeat: manager A still has room, so B should NOT scale up
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
-        manager_snapshots_with_both = {
             b"manager_a": _create_manager_snapshot(b"manager_a", max_task_concurrency=10, worker_count=0),
             b"manager_b": _create_manager_snapshot(b"manager_b", max_task_concurrency=20, worker_count=0),
         }
-        commands_b = policy.get_scaling_commands(
-            snapshot, heartbeat_b, managed_worker_ids, managed_worker_capabilities, manager_snapshots_with_both
-        )
-        commands_b = _imperative(commands_b)
-        self.assertEqual(len(commands_b), 0)
+
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, [], manager_snapshots)
+        self.assertEqual(len(commands_a), 1)
+        self.assertEqual(_generic_request(commands_a[0]).taskConcurrency, 1)
+
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, [], manager_snapshots)
+        # Higher-priority A absorbs all 1 desired worker; B's effective share (0) matches
+        # B's current connected count (0) -> no-op skip.
+        self.assertEqual(commands_b, [])
 
     def test_scaling_status(self):
         """get_scaling_status should return a ScalingManagerStatus."""
@@ -846,15 +355,7 @@ class TestWaterfallV1Policy(unittest.TestCase):
 
 
 class TestWaterfallV1PolicyAssignmentWithCapabilities(unittest.TestCase):
-    """
-    Tests that WaterfallV1Policy.assign_task respects task capabilities.
-
-    Bug being exposed:
-        WaterfallV1Policy delegates assign_task to EvenLoadAllocatePolicy,
-        which ignores task capabilities and routes a task requiring "gpu" to
-        any available worker (even one without the capability), instead of to
-        the worker that actually has it.
-    """
+    """Tests that WaterfallV1Policy.assign_task respects task capabilities."""
 
     def setUp(self):
         setup_logger()
@@ -909,16 +410,6 @@ class TestWaterfallV1PolicyAssignmentWithCapabilities(unittest.TestCase):
             policy.has_available_worker({"gpu": -1}),
             "has_available_worker should return False when no worker has the requested capability",
         )
-
-
-def _imperative(commands):
-    """Filter out the declarative setDesiredTaskConcurrency command emitted each policy run."""
-    return [c for c in commands if c.command != WorkerManagerCommandType.setDesiredTaskConcurrency]
-
-
-def _declarative(commands):
-    """Return the declarative setDesiredTaskConcurrency commands emitted each policy run."""
-    return [c for c in commands if c.command == WorkerManagerCommandType.setDesiredTaskConcurrency]
 
 
 def _create_mock_task(task_id: TaskID, capabilities: Optional[Dict[str, int]] = None) -> Task:

--- a/tests/worker_manager_adapter/test_worker_manager_core.py
+++ b/tests/worker_manager_adapter/test_worker_manager_core.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
@@ -11,36 +12,29 @@ from scaler.protocol.capnp import (
     TaskCancel,
     WorkerHeartbeatEcho,
     WorkerManagerCommand,
-    WorkerManagerCommandResponse,
-    WorkerManagerCommandType,
 )
-from scaler.protocol.helpers import capabilities_to_dict
 from scaler.utility.exceptions import ClientShutdownException
 from scaler.utility.identifiers import ClientID, ObjectID, TaskID, WorkerID
 from scaler.utility.logging.utility import setup_logger
 from scaler.utility.metadata.task_flags import TaskFlags
-from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner, ImperativeWorkerProvisioner
+from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner
 from scaler.worker_manager_adapter.worker_manager_runner import WorkerManagerRunner
 from scaler.worker_manager_adapter.worker_process import WorkerProcess
 from tests.utility.utility import logging_test_name
-
-Status = WorkerManagerCommandResponse.Status
 
 
 class TestWorkerManagerHandleCommand(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         setup_logger()
         logging_test_name(self)
-        self.capabilities = {"cpu": 4}
-        self.provisioner = MagicMock(spec=ImperativeWorkerProvisioner)
-        self.provisioner.start_worker = AsyncMock()
-        self.provisioner.shutdown_workers = AsyncMock()
+        self.provisioner = MagicMock(spec=DeclarativeWorkerProvisioner)
+        self.provisioner.set_desired_task_concurrency = AsyncMock()
         self.send_mock = AsyncMock()
         self.runner = WorkerManagerRunner(
             address=MagicMock(),
             name="test_runner",
             heartbeat_interval_seconds=5,
-            capabilities=self.capabilities,
+            capabilities={"cpu": 4},
             max_provisioner_units=4,
             worker_manager_id=b"mgr",
             worker_provisioner=self.provisioner,
@@ -49,111 +43,38 @@ class TestWorkerManagerHandleCommand(unittest.IsolatedAsyncioTestCase):
         connector.send = self.send_mock
         self.runner._connector_external = connector
 
-    def _sent_response(self) -> WorkerManagerCommandResponse:
-        self.send_mock.assert_called_once()
-        return self.send_mock.call_args[0][0]
-
-    async def test_start_workers_success_populates_capabilities_and_worker_ids(self) -> None:
-        worker_id = bytes(WorkerID.generate_worker_id("w0"))
-        self.provisioner.start_worker.return_value = ([worker_id], Status.success)
-
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.startWorkers
-        await self.runner._handle_command(cmd)
-
-        response = self._sent_response()
-        self.assertIsInstance(response, WorkerManagerCommandResponse)
-        self.assertEqual(response.status, Status.success)
-        self.assertEqual(list(response.workerIDs), [worker_id])
-        self.assertEqual(capabilities_to_dict(response.capabilities), self.capabilities)
-
-    async def test_start_workers_failure_returns_empty_capabilities_and_ids(self) -> None:
-        self.provisioner.start_worker.return_value = ([], Status.tooManyWorkers)
-
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.startWorkers
-        await self.runner._handle_command(cmd)
-
-        response = self._sent_response()
-        self.assertEqual(response.status, Status.tooManyWorkers)
-        self.assertEqual(list(response.workerIDs), [])
-        self.assertEqual(dict(response.capabilities), {})
-
-    async def test_shutdown_workers_echoes_ids_with_empty_capabilities(self) -> None:
-        worker_ids = [bytes(WorkerID.generate_worker_id(f"w{i}")) for i in range(2)]
-        self.provisioner.shutdown_workers.return_value = (worker_ids, Status.success)
-
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.shutdownWorkers
-        cmd.workerIDs = worker_ids
-        await self.runner._handle_command(cmd)
-
-        response = self._sent_response()
-        self.assertEqual(response.status, Status.success)
-        self.assertEqual(list(response.workerIDs), worker_ids)
-        self.assertEqual(dict(response.capabilities), {})
-        self.provisioner.shutdown_workers.assert_called_once_with(worker_ids)
-
-    async def test_unknown_command_type_is_silently_ignored(self) -> None:
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = object()
-
-        await self.runner._handle_command(cmd)
-
-        self.send_mock.assert_not_called()
-
-    async def test_set_desired_task_concurrency_is_silently_ignored(self) -> None:
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.setDesiredTaskConcurrency
-
-        await self.runner._handle_command(cmd)
-
-        self.send_mock.assert_not_called()
-        self.provisioner.start_worker.assert_not_called()
-        self.provisioner.shutdown_workers.assert_not_called()
-
     async def test_set_desired_task_concurrency_calls_declarative_provisioner(self) -> None:
-        declarative_provisioner = MagicMock(spec=DeclarativeWorkerProvisioner)
-        declarative_provisioner.set_desired_task_concurrency = AsyncMock()
-        self.runner._worker_provisioner = declarative_provisioner
-
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.setDesiredTaskConcurrency
         requests = [MagicMock()]
+        cmd = MagicMock(spec=WorkerManagerCommand)
         cmd.setDesiredTaskConcurrencyRequests = requests
 
         await self.runner._handle_command(cmd)
 
-        declarative_provisioner.set_desired_task_concurrency.assert_called_once_with(requests)
+        self.provisioner.set_desired_task_concurrency.assert_called_once_with(requests)
         self.send_mock.assert_not_called()
 
-    async def test_start_workers_sends_noop_success_for_declarative_provisioner(self) -> None:
-        declarative_provisioner = MagicMock(spec=DeclarativeWorkerProvisioner)
-        self.runner._worker_provisioner = declarative_provisioner
-
+    async def test_unknown_command_payload_logs_warning_without_crashing(self) -> None:
         cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.startWorkers
-        await self.runner._handle_command(cmd)
+        # Remove the only recognized payload field to simulate an unknown variant from a
+        # newer scheduler (or a remote adapter) that this runner does not understand.
+        del cmd.setDesiredTaskConcurrencyRequests
 
-        response = self._sent_response()
-        self.assertIsInstance(response, WorkerManagerCommandResponse)
-        self.assertEqual(response.status, Status.success)
-        self.assertEqual(list(response.workerIDs), [])
-        self.assertEqual(dict(response.capabilities), {})
+        with self.assertLogs(level=logging.WARNING) as captured:
+            await self.runner._handle_command(cmd)
 
-    async def test_shutdown_workers_sends_noop_success_for_declarative_provisioner(self) -> None:
-        declarative_provisioner = MagicMock(spec=DeclarativeWorkerProvisioner)
-        self.runner._worker_provisioner = declarative_provisioner
+        self.assertTrue(any("Unknown action" in m for m in captured.output))
+        self.provisioner.set_desired_task_concurrency.assert_not_called()
+        self.send_mock.assert_not_called()
 
-        cmd = MagicMock(spec=WorkerManagerCommand)
-        cmd.command = WorkerManagerCommandType.shutdownWorkers
-        await self.runner._handle_command(cmd)
+    async def test_unknown_message_type_logs_warning_without_crashing(self) -> None:
+        class _Unknown:
+            pass
 
-        response = self._sent_response()
-        self.assertIsInstance(response, WorkerManagerCommandResponse)
-        self.assertEqual(response.status, Status.success)
-        self.assertEqual(list(response.workerIDs), [])
-        self.assertEqual(dict(response.capabilities), {})
+        with self.assertLogs(level=logging.WARNING) as captured:
+            await self.runner._on_receive_external(_Unknown())  # type: ignore[arg-type]
+
+        self.assertTrue(any("Unknown action" in m or "unrecognized" in m for m in captured.output))
+        self.send_mock.assert_not_called()
 
 
 class TestWorkerProcessOnReceiveExternal(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
# READY FOR REVIEW.

This PR drops support to old, imperative style worker manager commands (namely `startWorker/shutdownWorker`). Change scope is quite large, and breaking, as:
- protocol was changed, no more response expected from a command and argument list was simplified.
- all the code scaffolding old commands were removed, including generation of commands and grouping workers etc.
- tests were heavily modified because some tests stop to make sense. Lots of tests were simply renamed but are functionally equivalent.

worker manager's  change (removing code scaffolding old command) is also done in this PR. This is necessary for the scheduler to migrate. If you want I am happy to make it a separate one.