### PR TITLE
fix: launchpad UX improvements

### DIFF
--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -1,7 +1,14 @@
 const { useState, useEffect, useCallback, useRef } = React;
 
 /* ── NumericStepper ── */
-function NumericStepper({ value, onChange, min = 0, max = Infinity, step = 1, width = 56 }) {
+function NumericStepper({
+  value,
+  onChange,
+  min = 0,
+  max = Infinity,
+  step = 1,
+  width = 56,
+}) {
   const [hov, setHov] = useState(null);
   const [localValue, setLocalValue] = useState(null);
   const btnStyle = (side) => ({
@@ -120,7 +127,14 @@ function PanelBox({ title, children, style }) {
 }
 
 /* ── WorkerManagerCard ── */
-function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fullWidth }) {
+function WorkerManagerCard({
+  wm,
+  onChange,
+  onRemove,
+  allInstances,
+  canRemove,
+  fullWidth,
+}) {
   const [localId, setLocalId] = useState(wm.id);
   const [showAdv, setShowAdv] = useState(false);
   useEffect(() => {
@@ -177,7 +191,11 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
             cursor: disabled ? "not-allowed" : "pointer",
             border: "none",
             background: value === val ? "rgba(0,200,224,0.18)" : "transparent",
-            color: disabled ? "var(--text-dim)" : value === val ? "var(--text-accent)" : "var(--text-muted)",
+            color: disabled
+              ? "var(--text-dim)"
+              : value === val
+                ? "var(--text-accent)"
+                : "var(--text-muted)",
             transition: "background 0.15s, color 0.15s",
           }}
         >
@@ -210,9 +228,14 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
       <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <Label>Type</Label>
-          <WorkerManagerTypeSelect value={wm.type} onChange={(v) => set("type", v)} />
+          <WorkerManagerTypeSelect
+            value={wm.type}
+            onChange={(v) => set("type", v)}
+          />
         </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: 4, flex: 1 }}>
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: 4, flex: 1 }}
+        >
           <Label help="Unique name for this worker manager.">Name</Label>
           <input
             value={localId}
@@ -243,7 +266,11 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
         <>
           <div>
             <Label>Worker Instance Type</Label>
-            <InstancePicker value={wm.instanceType} onChange={(v) => set("instanceType", v)} defaultCat="all" />
+            <InstancePicker
+              value={wm.instanceType}
+              onChange={(v) => set("instanceType", v)}
+              defaultCat="all"
+            />
           </div>
           <div>
             <Label>Budget</Label>
@@ -302,11 +329,26 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
             }}
           >
             <span>Advanced</span>
-            <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: showAdv ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: showAdv ? "2px" : "-2px" }} />
+            <span
+              style={{
+                display: "inline-block",
+                width: 7,
+                height: 7,
+                borderRight: "1.5px solid var(--text-muted)",
+                borderBottom: "1.5px solid var(--text-muted)",
+                transform: showAdv ? "rotate(225deg)" : "rotate(45deg)",
+                position: "relative",
+                top: showAdv ? "2px" : "-2px",
+              }}
+            />
           </button>
           {showAdv && (
             <div>
-              <Label help={"- Installed on each worker instance\n- opengris-scaler must be included"}>
+              <Label
+                help={
+                  "- Installed on each worker instance\n- opengris-scaler must be included"
+                }
+              >
                 requirements.txt
               </Label>
               <textarea
@@ -340,8 +382,16 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
               alignItems: "baseline",
             }}
           >
-            <span style={{ fontSize: 10, color: "var(--text-muted)" }}>Cost</span>
-            <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-success)" }}>
+            <span style={{ fontSize: 10, color: "var(--text-muted)" }}>
+              Cost
+            </span>
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: "var(--text-success)",
+              }}
+            >
               USD {costPerHr.toFixed(2)}/h
             </span>
           </div>
@@ -390,7 +440,12 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
           <div style={{ display: "flex", gap: 10 }}>
             <div style={{ flex: 1 }}>
               <Label>vCPU</Label>
-              <NumericStepper value={wm.ecsTaskCpu || 4} onChange={(v) => set("ecsTaskCpu", v)} min={1} max={64} />
+              <NumericStepper
+                value={wm.ecsTaskCpu || 4}
+                onChange={(v) => set("ecsTaskCpu", v)}
+                min={1}
+                max={64}
+              />
             </div>
             <div style={{ flex: 1 }}>
               <Label>Memory (GB)</Label>
@@ -481,7 +536,6 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
           </div>
         </>
       )}
-
     </div>
   );
 }
@@ -503,9 +557,18 @@ function CopyBtn({ value }) {
       style={{
         background: hov && !copied ? "rgba(0,200,224,0.08)" : "none",
         border:
-          "1px solid " + (copied ? "var(--border-success)" : hov ? "var(--border-strong)" : "var(--border-accent)"),
+          "1px solid " +
+          (copied
+            ? "var(--border-success)"
+            : hov
+              ? "var(--border-strong)"
+              : "var(--border-accent)"),
         borderRadius: 3,
-        color: copied ? "var(--text-success)" : hov ? "var(--text-accent)" : "var(--text-muted)",
+        color: copied
+          ? "var(--text-success)"
+          : hov
+            ? "var(--text-accent)"
+            : "var(--text-muted)",
         fontFamily: "inherit",
         fontSize: 10,
         padding: "2px 7px",
@@ -530,7 +593,12 @@ function DeploymentCard({ state, onDownload, keyMaterial, isRunning }) {
     {
       label: "SSH",
       value: state.public_ip
-        ? "chmod 400 " + state.key_file + " &&\nssh -i " + state.key_file + " ec2-user@" + state.public_ip
+        ? "chmod 400 " +
+          state.key_file +
+          " &&\nssh -i " +
+          state.key_file +
+          " ec2-user@" +
+          state.public_ip
         : null,
       code: true,
     },
@@ -669,7 +737,9 @@ function DeploymentCard({ state, onDownload, keyMaterial, isRunning }) {
           </span>
           {keyMaterial ? (
             <button
-              onClick={() => downloadText(keyMaterial.name + ".pem", keyMaterial.mat)}
+              onClick={() =>
+                downloadText(keyMaterial.name + ".pem", keyMaterial.mat)
+              }
               style={{
                 background: "none",
                 border: "1px solid var(--border-accent)",
@@ -685,11 +755,23 @@ function DeploymentCard({ state, onDownload, keyMaterial, isRunning }) {
               ↓ {keyMaterial.name}.pem
             </button>
           ) : isRunning ? (
-            <span style={{ fontSize: 12, color: "var(--text-dim)", fontStyle: "italic" }}>
+            <span
+              style={{
+                fontSize: 12,
+                color: "var(--text-dim)",
+                fontStyle: "italic",
+              }}
+            >
               pending…
             </span>
           ) : (
-            <span style={{ fontSize: 11, color: "var(--text-dim)", lineHeight: 1.5 }}>
+            <span
+              style={{
+                fontSize: 11,
+                color: "var(--text-dim)",
+                lineHeight: 1.5,
+              }}
+            >
               not saved — download during provisioning
               <br />
               or retrieve from the AWS console
@@ -703,26 +785,60 @@ function DeploymentCard({ state, onDownload, keyMaterial, isRunning }) {
 
 /* ── Python syntax highlighter (theme-aware, no external deps) ── */
 const PY_KEYWORDS = new Set([
-  "False", "None", "True", "and", "as", "assert", "async", "await",
-  "break", "class", "continue", "def", "del", "elif", "else", "except",
-  "finally", "for", "from", "global", "if", "import", "in", "is",
-  "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try",
-  "while", "with", "yield",
+  "False",
+  "None",
+  "True",
+  "and",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "break",
+  "class",
+  "continue",
+  "def",
+  "del",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "from",
+  "global",
+  "if",
+  "import",
+  "in",
+  "is",
+  "lambda",
+  "nonlocal",
+  "not",
+  "or",
+  "pass",
+  "raise",
+  "return",
+  "try",
+  "while",
+  "with",
+  "yield",
 ]);
 
 function tokenizePython(code) {
   const tokens = [];
-  const re = /(#[^\n]*)|("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|(\b\d+(?:\.\d+)?\b)|([A-Za-z_]\w*)(\s*\()?|(\s+|[^\w\s#"']+)/g;
+  const re =
+    /(#[^\n]*)|("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|(\b\d+(?:\.\d+)?\b)|([A-Za-z_]\w*)(\s*\()?|(\s+|[^\w\s#"']+)/g;
   let m;
   while ((m = re.exec(code)) !== null) {
-    if (m[1])       tokens.push({ text: m[1], color: "var(--text-dim)" });
-    else if (m[2])  tokens.push({ text: m[2], color: "var(--text-warning)" });
-    else if (m[3])  tokens.push({ text: m[3], color: "var(--text-danger)" });
+    if (m[1]) tokens.push({ text: m[1], color: "var(--text-dim)" });
+    else if (m[2]) tokens.push({ text: m[2], color: "var(--text-warning)" });
+    else if (m[3]) tokens.push({ text: m[3], color: "var(--text-danger)" });
     else if (m[4]) {
-      const word = m[4], call = m[5] || "";
+      const word = m[4],
+        call = m[5] || "";
       const color = PY_KEYWORDS.has(word)
         ? "var(--text-accent)"
-        : call ? "var(--text-success)" : "var(--text-primary)";
+        : call
+          ? "var(--text-success)"
+          : "var(--text-primary)";
       tokens.push({ text: word, color });
       if (call) tokens.push({ text: call, color: "var(--text-primary)" });
     } else {
@@ -750,7 +866,9 @@ function PyCode({ code }) {
       }}
     >
       {tokens.map((t, i) => (
-        <span key={i} style={{ color: t.color }}>{t.text}</span>
+        <span key={i} style={{ color: t.color }}>
+          {t.text}
+        </span>
       ))}
     </pre>
   );
@@ -788,7 +906,9 @@ with Client(address="${addr}") as client:
       </div>
       {ready ? (
         <>
-          <div style={{ fontSize: 11, color: "var(--text-dim)", lineHeight: 1.5 }}>
+          <div
+            style={{ fontSize: 11, color: "var(--text-dim)", lineHeight: 1.5 }}
+          >
             Connect a client to your deployment and submit tasks:
           </div>
           <div style={{ position: "relative" }}>
@@ -799,7 +919,13 @@ with Client(address="${addr}") as client:
           </div>
         </>
       ) : (
-        <div style={{ fontSize: 11, color: "var(--text-dim)", fontStyle: "italic" }}>
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-dim)",
+            fontStyle: "italic",
+          }}
+        >
           Waiting for scheduler…
         </div>
       )}
@@ -808,13 +934,27 @@ with Client(address="${addr}") as client:
 }
 
 /* ── TopNav ── */
-function TopNav({ activeTab, setActiveTab, theme, setTheme, showPostLaunch, launchControl, guiAddress }) {
+function TopNav({
+  activeTab,
+  setActiveTab,
+  theme,
+  setTheme,
+  showPostLaunch,
+  launchControl,
+  guiAddress,
+}) {
   const tabs = [
     { id: "config", label: "Config" },
     { id: "deployment", label: "Deployment", postLaunch: true },
     { id: "logs", label: "Scheduler Logs", postLaunch: true },
     // { id: "gui", label: "GUI", postLaunch: true },
-    { id: "gui", label: "GUI", postLaunch: true, isLink: true, href: guiAddress },
+    {
+      id: "gui",
+      label: "GUI",
+      postLaunch: true,
+      isLink: true,
+      href: guiAddress,
+    },
   ];
   return (
     <div
@@ -867,8 +1007,14 @@ function TopNav({ activeTab, setActiveTab, theme, setTheme, showPostLaunch, laun
                   padding: "14px 18px",
                   background: "transparent",
                   border: "none",
-                  borderBottom: activeTab === t.id ? "2px solid var(--tab-active)" : "2px solid transparent",
-                  color: activeTab === t.id ? "var(--text-accent)" : "var(--text-muted)",
+                  borderBottom:
+                    activeTab === t.id
+                      ? "2px solid var(--tab-active)"
+                      : "2px solid transparent",
+                  color:
+                    activeTab === t.id
+                      ? "var(--text-accent)"
+                      : "var(--text-muted)",
                   fontFamily: "inherit",
                   fontSize: 12,
                   cursor: "pointer",
@@ -876,7 +1022,7 @@ function TopNav({ activeTab, setActiveTab, theme, setTheme, showPostLaunch, laun
               >
                 {t.label}
               </button>
-            )
+            ),
           )}
       </div>
       {launchControl && <div style={{ marginRight: 16 }}>{launchControl}</div>}
@@ -894,17 +1040,17 @@ function TopNav({ activeTab, setActiveTab, theme, setTheme, showPostLaunch, laun
           value={theme}
           onChange={(e) => setTheme(e.target.value)}
           style={{
-          background: "var(--bg-surface)",
-          border: "1px solid var(--border-accent)",
-          borderRadius: 3,
-          color: "var(--text-secondary)",
-          fontFamily: "inherit",
-          fontSize: 10,
-          padding: "4px 8px",
-          cursor: "pointer",
-          outline: "none",
-        }}
-      >
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-accent)",
+            borderRadius: 3,
+            color: "var(--text-secondary)",
+            fontFamily: "inherit",
+            fontSize: 10,
+            padding: "4px 8px",
+            cursor: "pointer",
+            outline: "none",
+          }}
+        >
           <option value="dark">Dark</option>
           <option value="light">Light</option>
           <option value="zenburn">Zenburn</option>
@@ -922,15 +1068,20 @@ function App() {
   const [transport, setTransport] = useState("ws");
   const [networkBackend, setNetBack] = useState("ymq");
   const [pythonVersion, setPyVer] = useState("3.14");
-  const [schedulerRequirements, setSchedulerReqs] = useState("opengris-scaler[all]");
+  const [schedulerRequirements, setSchedulerReqs] = useState(
+    "opengris-scaler[all]",
+  );
   const [schedulerType, setSchedulerType] = useState("c5.xlarge");
   const [schedulerPort, setSchedPort] = useState(6788);
   const [objectStoragePort, setObjPort] = useState(6789);
   const [showSchedAdv, setShowSchedAdv] = useState(false);
   const [activeTab, setActiveTab] = useState("config");
-  const [theme, setTheme] = useState(() =>
-    localStorage.getItem("launchpad-theme") ||
-    (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"),
+  const [theme, setTheme] = useState(
+    () =>
+      localStorage.getItem("launchpad-theme") ||
+      (window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"),
   );
 
   const wmCounterRef = useRef(1);
@@ -1058,7 +1209,8 @@ function App() {
         : Math.max(0, Math.floor((wm.budgetCap || 0) / (inst.price || 1)));
     return count * inst.price;
   });
-  const totalCostPerHr = schedulerInst.price + wmCosts.reduce((a, b) => a + b, 0);
+  const totalCostPerHr =
+    schedulerInst.price + wmCosts.reduce((a, b) => a + b, 0);
 
   const addWorkerManager = useCallback(() => {
     wmCounterRef.current += 1;
@@ -1087,11 +1239,15 @@ function App() {
     });
   }, []);
   const updateWorkerManager = useCallback(
-    (id, updated) => setWorkerManagers((prev) => prev.map((wm) => (wm.id === id ? updated : wm))),
+    (id, updated) =>
+      setWorkerManagers((prev) =>
+        prev.map((wm) => (wm.id === id ? updated : wm)),
+      ),
     [],
   );
 
-  const hasCredentials = accessKeyId.trim().length > 0 && secretKey.trim().length > 0;
+  const hasCredentials =
+    accessKeyId.trim().length > 0 && secretKey.trim().length > 0;
 
   const monitorPort = schedulerPort + 2;
   const GUI_PORT = 50001;
@@ -1099,13 +1255,21 @@ function App() {
   if (schedulerPort === objectStoragePort)
     portConflicts.push("Scheduler port and object storage port must differ.");
   if (objectStoragePort === monitorPort)
-    portConflicts.push(`Object storage port conflicts with the monitor port (scheduler + 2 = ${monitorPort}).`);
+    portConflicts.push(
+      `Object storage port conflicts with the monitor port (scheduler + 2 = ${monitorPort}).`,
+    );
   if (schedulerPort === GUI_PORT)
-    portConflicts.push(`Scheduler port conflicts with the GUI port (${GUI_PORT}).`);
+    portConflicts.push(
+      `Scheduler port conflicts with the GUI port (${GUI_PORT}).`,
+    );
   if (objectStoragePort === GUI_PORT)
-    portConflicts.push(`Object storage port conflicts with the GUI port (${GUI_PORT}).`);
+    portConflicts.push(
+      `Object storage port conflicts with the GUI port (${GUI_PORT}).`,
+    );
   if (monitorPort === GUI_PORT)
-    portConflicts.push(`Monitor port (scheduler + 2 = ${monitorPort}) conflicts with the GUI port (${GUI_PORT}).`);
+    portConflicts.push(
+      `Monitor port (scheduler + 2 = ${monitorPort}) conflicts with the GUI port (${GUI_PORT}).`,
+    );
 
   const checks = [
     {
@@ -1219,7 +1383,9 @@ function App() {
           "• Key pair: " +
           (provState.key_pair_name || "—") +
           "\n" +
-          (provState.iam && provState.iam.created ? "• IAM role & profile\n" : "") +
+          (provState.iam && provState.iam.created
+            ? "• IAM role & profile\n"
+            : "") +
           "\nThis cannot be undone.",
       )
     )
@@ -1229,7 +1395,12 @@ function App() {
     const controller = new AbortController();
     abortRef.current = controller;
     try {
-      await teardown(provState, { accessKeyId, secretKey }, addLog, controller.signal);
+      await teardown(
+        provState,
+        { accessKeyId, secretKey },
+        addLog,
+        controller.signal,
+      );
       try {
         localStorage.removeItem("scaler_state");
         localStorage.removeItem("scaler_log");
@@ -1239,9 +1410,17 @@ function App() {
       setPhase("idle");
     } catch (err) {
       if (err.name === "AbortError") {
-        addLog("\nTeardown aborted. Some resources may still exist — run Destroy again to retry.", "warn");
+        addLog(
+          "\nTeardown aborted. Some resources may still exist — run Destroy again to retry.",
+          "warn",
+        );
       } else {
-        addLog("\nError during teardown: " + err.message + "\nFix the issue and run Destroy again to retry.", "err");
+        addLog(
+          "\nError during teardown: " +
+            err.message +
+            "\nFix the issue and run Destroy again to retry.",
+          "err",
+        );
       }
       setPhase("ready");
     } finally {
@@ -1283,7 +1462,6 @@ function App() {
       localStorage.removeItem("scaler_log");
     } catch (_) {}
   }, []);
-
 
   const Label = ({ children, help }) => (
     <div
@@ -1333,7 +1511,11 @@ function App() {
             cursor: dis ? "not-allowed" : "pointer",
             border: "none",
             background: value === val ? "rgba(0,200,224,0.18)" : "transparent",
-            color: dis ? "var(--text-dim)" : value === val ? "var(--text-accent)" : "var(--text-muted)",
+            color: dis
+              ? "var(--text-dim)"
+              : value === val
+                ? "var(--text-accent)"
+                : "var(--text-muted)",
             transition: "background 0.15s, color 0.15s",
           }}
         >
@@ -1362,7 +1544,18 @@ function App() {
       }}
     >
       <span>{label}</span>
-      <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: show ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: show ? "2px" : "-2px" }} />
+      <span
+        style={{
+          display: "inline-block",
+          width: 7,
+          height: 7,
+          borderRight: "1.5px solid var(--text-muted)",
+          borderBottom: "1.5px solid var(--text-muted)",
+          transform: show ? "rotate(225deg)" : "rotate(45deg)",
+          position: "relative",
+          top: show ? "2px" : "-2px",
+        }}
+      />
     </button>
   );
 
@@ -1377,7 +1570,9 @@ function App() {
           background: !hasCredentials
             ? "rgba(255,80,60,0.04)"
             : "linear-gradient(135deg, oklch(0.32 0.18 15) 0%, oklch(0.26 0.14 30) 100%)",
-          border: "1px solid " + (!hasCredentials ? "var(--border-danger)" : "oklch(0.48 0.18 15)"),
+          border:
+            "1px solid " +
+            (!hasCredentials ? "var(--border-danger)" : "oklch(0.48 0.18 15)"),
           borderRadius: 4,
           color: !hasCredentials ? "var(--text-danger)" : "oklch(0.88 0.1 30)",
           fontFamily: "inherit",
@@ -1401,7 +1596,9 @@ function App() {
           background: !formReady
             ? "var(--bg-surface)"
             : "linear-gradient(135deg, oklch(0.38 0.16 155) 0%, oklch(0.32 0.14 200) 100%)",
-          border: "1px solid " + (!formReady ? "var(--border-accent)" : "oklch(0.55 0.16 155)"),
+          border:
+            "1px solid " +
+            (!formReady ? "var(--border-accent)" : "oklch(0.55 0.16 155)"),
           borderRadius: 4,
           color: !formReady ? "var(--text-muted)" : "oklch(0.92 0.1 155)",
           fontFamily: "inherit",
@@ -1425,7 +1622,9 @@ function App() {
           background: !hasCredentials
             ? "rgba(255,80,60,0.04)"
             : "linear-gradient(135deg, oklch(0.32 0.18 15) 0%, oklch(0.26 0.14 30) 100%)",
-          border: "1px solid " + (!hasCredentials ? "var(--border-danger)" : "oklch(0.48 0.18 15)"),
+          border:
+            "1px solid " +
+            (!hasCredentials ? "var(--border-danger)" : "oklch(0.48 0.18 15)"),
           borderRadius: 4,
           color: !hasCredentials ? "var(--text-danger)" : "oklch(0.88 0.1 30)",
           fontFamily: "inherit",
@@ -1445,10 +1644,20 @@ function App() {
         <div
           style={{
             padding: "6px 12px",
-            background: phase === "destroying" ? "rgba(255,80,60,0.04)" : "rgba(0,200,224,0.04)",
-            border: "1px solid " + (phase === "destroying" ? "var(--border-danger)" : "var(--border-accent)"),
+            background:
+              phase === "destroying"
+                ? "rgba(255,80,60,0.04)"
+                : "rgba(0,200,224,0.04)",
+            border:
+              "1px solid " +
+              (phase === "destroying"
+                ? "var(--border-danger)"
+                : "var(--border-accent)"),
             borderRadius: 4,
-            color: phase === "destroying" ? "var(--text-danger)" : "var(--text-muted)",
+            color:
+              phase === "destroying"
+                ? "var(--text-danger)"
+                : "var(--text-muted)",
             fontSize: 11,
           }}
         >
@@ -1495,7 +1704,9 @@ function App() {
         setActiveTab={setActiveTab}
         theme={theme}
         setTheme={setTheme}
-        showPostLaunch={phase !== "idle" || ["deployment", "logs", "gui"].includes(activeTab)}
+        showPostLaunch={
+          phase !== "idle" || ["deployment", "logs", "gui"].includes(activeTab)
+        }
         launchControl={launchControl}
         guiAddress={phase === "ready" ? provState?.gui_address : undefined}
       />
@@ -1559,9 +1770,13 @@ function App() {
                           cursor: disabled ? "default" : "pointer",
                           border: "none",
                           marginBottom: -1,
-                          borderBottom: active ? "2px solid var(--tab-active)" : "2px solid transparent",
+                          borderBottom: active
+                            ? "2px solid var(--tab-active)"
+                            : "2px solid transparent",
                           background: "transparent",
-                          color: active ? "var(--text-label)" : "var(--text-dim)",
+                          color: active
+                            ? "var(--text-label)"
+                            : "var(--text-dim)",
                           opacity: disabled ? 0.35 : 1,
                         }}
                       >
@@ -1571,10 +1786,14 @@ function App() {
                   })}
                 </div>
                 <div>
-                  <Label help="The AWS region where your cluster will be deployed.">AWS Region</Label>
+                  <Label help="The AWS region where your cluster will be deployed.">
+                    AWS Region
+                  </Label>
                   <RegionSelect value={region} onChange={setRegion} />
                 </div>
-                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 6 }}
+                >
                   <div
                     style={{
                       background: "var(--bg-surface)",
@@ -1647,8 +1866,12 @@ function App() {
                       textDecoration: "none",
                       alignSelf: "flex-end",
                     }}
-                    onMouseOver={(e) => (e.currentTarget.style.color = "var(--text-accent)")}
-                    onMouseOut={(e) => (e.currentTarget.style.color = "var(--text-muted)")}
+                    onMouseOver={(e) =>
+                      (e.currentTarget.style.color = "var(--text-accent)")
+                    }
+                    onMouseOut={(e) =>
+                      (e.currentTarget.style.color = "var(--text-muted)")
+                    }
                   >
                     Generate access keys in AWS Console ↗
                   </a>
@@ -1659,8 +1882,10 @@ function App() {
                       lineHeight: 1.5,
                     }}
                   >
-                    Your credentials are used from this browser to provision AWS resources and are made available to
-                    the scheduler instance for worker management. They are not stored by this application.
+                    Your credentials are used from this browser to provision AWS
+                    resources and are made available to the scheduler instance
+                    for worker management. They are not stored by this
+                    application.
                   </span>
                 </div>
               </PanelBox>
@@ -1704,7 +1929,11 @@ function App() {
                   <Label help="EC2 instance type for the scheduler. Compute-optimized (c5/c6i) works well for most deployments.">
                     Instance Type
                   </Label>
-                  <InstancePicker value={schedulerType} onChange={setSchedulerType} defaultCat="all" />
+                  <InstancePicker
+                    value={schedulerType}
+                    onChange={setSchedulerType}
+                    defaultCat="all"
+                  />
                 </div>
                 <div
                   style={{
@@ -1735,7 +1964,11 @@ function App() {
                     USD {schedulerInst.price.toFixed(2)}/h
                   </span>
                 </div>
-                {advBtn(showSchedAdv, () => setShowSchedAdv((v) => !v), "Advanced")}
+                {advBtn(
+                  showSchedAdv,
+                  () => setShowSchedAdv((v) => !v),
+                  "Advanced",
+                )}
                 {showSchedAdv && (
                   <div
                     style={{
@@ -1746,7 +1979,13 @@ function App() {
                   >
                     <div>
                       <Label>Scheduler Port</Label>
-                      <NumericStepper value={schedulerPort} onChange={setSchedPort} min={1024} max={65535} width={80} />
+                      <NumericStepper
+                        value={schedulerPort}
+                        onChange={setSchedPort}
+                        min={1024}
+                        max={65535}
+                        width={80}
+                      />
                     </div>
                     <div>
                       <Label>Object Storage Port</Label>
@@ -1759,14 +1998,24 @@ function App() {
                       />
                     </div>
                     {portConflicts.length > 0 && (
-                      <div style={{ color: "var(--text-danger)", fontSize: 11, lineHeight: 1.5 }}>
+                      <div
+                        style={{
+                          color: "var(--text-danger)",
+                          fontSize: 11,
+                          lineHeight: 1.5,
+                        }}
+                      >
                         {portConflicts.map((msg, i) => (
                           <div key={i}>{msg}</div>
                         ))}
                       </div>
                     )}
                     <div>
-                      <Label help={"- Installed on the scheduler instance\n- Shared by native worker manager workers (same instance)\n- opengris-scaler must be included"}>
+                      <Label
+                        help={
+                          "- Installed on the scheduler instance\n- Shared by native worker manager workers (same instance)\n- opengris-scaler must be included"
+                        }
+                      >
                         requirements.txt
                       </Label>
                       <textarea
@@ -1802,9 +2051,21 @@ function App() {
               >
                 <PanelBox title="Policy">
                   {[
-                    { label: "Engine", help: "Policy engine that controls task allocation and worker scaling.", options: ["simple", "waterfall_v1"] },
-                    { label: "Allocate", help: "How tasks are assigned to workers. even_load distributes work evenly; capability routes tasks to workers that advertise matching capabilities.", options: ["even_load", "capability"] },
-                    { label: "Scaling", help: "How the scheduler scales worker counts up or down. vanilla uses a task-to-worker ratio; capability scales per-capability group; no disables autoscaling.", options: ["vanilla", "no", "capability"] },
+                    {
+                      label: "Engine",
+                      help: "Policy engine that controls task allocation and worker scaling.",
+                      options: ["simple", "waterfall_v1"],
+                    },
+                    {
+                      label: "Allocate",
+                      help: "How tasks are assigned to workers. even_load distributes work evenly; capability routes tasks to workers that advertise matching capabilities.",
+                      options: ["even_load", "capability"],
+                    },
+                    {
+                      label: "Scaling",
+                      help: "How the scheduler scales worker counts up or down. vanilla uses a task-to-worker ratio; capability scales per-capability group; no disables autoscaling.",
+                      options: ["vanilla", "no", "capability"],
+                    },
                   ].map(({ label, help, options }) => (
                     <div key={label}>
                       <Label help={help}>{label}</Label>
@@ -1825,21 +2086,27 @@ function App() {
                             WebkitAppearance: "none",
                           }}
                         >
-                          {options.map((o) => <option key={o} value={o}>{o}</option>)}
+                          {options.map((o) => (
+                            <option key={o} value={o}>
+                              {o}
+                            </option>
+                          ))}
                         </select>
-                        <span style={{
-                          position: "absolute",
-                          right: 10,
-                          top: "50%",
-                          display: "block",
-                          width: 7,
-                          height: 7,
-                          borderRight: "1.5px solid var(--text-muted)",
-                          borderBottom: "1.5px solid var(--text-muted)",
-                          transform: "rotate(45deg)",
-                          marginTop: "-5px",
-                          pointerEvents: "none",
-                        }} />
+                        <span
+                          style={{
+                            position: "absolute",
+                            right: 10,
+                            top: "50%",
+                            display: "block",
+                            width: 7,
+                            height: 7,
+                            borderRight: "1.5px solid var(--text-muted)",
+                            borderBottom: "1.5px solid var(--text-muted)",
+                            transform: "rotate(45deg)",
+                            marginTop: "-5px",
+                            pointerEvents: "none",
+                          }}
+                        />
                       </div>
                     </div>
                   ))}
@@ -1849,7 +2116,10 @@ function App() {
 
             {/* Column 3: Worker Managers + Cost Summary */}
             <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <PanelBox title={`Worker Managers (${workerManagers.length})`} style={{ gap: 8, padding: "16px 22px" }}>
+              <PanelBox
+                title={`Worker Managers (${workerManagers.length})`}
+                style={{ gap: 8, padding: "16px 22px" }}
+              >
                 <div
                   style={{
                     display: "flex",
@@ -1877,8 +2147,14 @@ function App() {
                         style={{
                           display: "flex",
                           alignItems: "stretch",
-                          background: selectedWmId === wm.id ? "rgba(0,200,224,0.1)" : "transparent",
-                          borderLeft: selectedWmId === wm.id ? "2px solid var(--tab-active)" : "2px solid transparent",
+                          background:
+                            selectedWmId === wm.id
+                              ? "rgba(0,200,224,0.1)"
+                              : "transparent",
+                          borderLeft:
+                            selectedWmId === wm.id
+                              ? "2px solid var(--tab-active)"
+                              : "2px solid transparent",
                           borderBottom: "1px solid rgba(255,255,255,0.04)",
                           transition: "background 0.12s",
                         }}
@@ -1890,7 +2166,10 @@ function App() {
                             flex: 1,
                             background: "transparent",
                             border: "none",
-                            color: selectedWmId === wm.id ? "var(--text-accent)" : "var(--text-muted)",
+                            color:
+                              selectedWmId === wm.id
+                                ? "var(--text-accent)"
+                                : "var(--text-muted)",
                             fontFamily: "inherit",
                             fontSize: 10,
                             padding: "10px 6px 10px 10px",
@@ -1926,26 +2205,40 @@ function App() {
                               transition: "color 0.12s",
                             }}
                             onMouseEnter={(e) => {
-                              e.currentTarget.style.color = "var(--text-danger)";
-                              e.currentTarget.querySelector("span").style.borderColor = "var(--border-danger)";
-                              e.currentTarget.querySelector("span").style.background = "rgba(229,72,77,0.08)";
+                              e.currentTarget.style.color =
+                                "var(--text-danger)";
+                              e.currentTarget.querySelector(
+                                "span",
+                              ).style.borderColor = "var(--border-danger)";
+                              e.currentTarget.querySelector(
+                                "span",
+                              ).style.background = "rgba(229,72,77,0.08)";
                             }}
                             onMouseLeave={(e) => {
                               e.currentTarget.style.color = "var(--text-muted)";
-                              e.currentTarget.querySelector("span").style.borderColor = "var(--border-accent)";
-                              e.currentTarget.querySelector("span").style.background = "transparent";
+                              e.currentTarget.querySelector(
+                                "span",
+                              ).style.borderColor = "var(--border-accent)";
+                              e.currentTarget.querySelector(
+                                "span",
+                              ).style.background = "transparent";
                             }}
                           >
-                            <span style={{
-                              display: "inline-flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              width: 14,
-                              height: 14,
-                              border: "1px solid var(--border-accent)",
-                              borderRadius: 2,
-                              transition: "border-color 0.12s, background 0.12s",
-                            }}>✕</span>
+                            <span
+                              style={{
+                                display: "inline-flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                width: 14,
+                                height: 14,
+                                border: "1px solid var(--border-accent)",
+                                borderRadius: 2,
+                                transition:
+                                  "border-color 0.12s, background 0.12s",
+                              }}
+                            >
+                              ✕
+                            </span>
                           </button>
                         )}
                       </div>
@@ -1953,7 +2246,8 @@ function App() {
                     <button
                       onClick={addWorkerManager}
                       onMouseEnter={(e) => {
-                        e.currentTarget.style.background = "rgba(0,200,224,0.08)";
+                        e.currentTarget.style.background =
+                          "rgba(0,200,224,0.08)";
                         e.currentTarget.style.color = "var(--text-accent)";
                       }}
                       onMouseLeave={(e) => {
@@ -1987,7 +2281,8 @@ function App() {
                           key={wm._uid}
                           wm={wm}
                           onChange={(updated) => {
-                            if (updated.id !== wm.id) setSelectedWmId(updated.id);
+                            if (updated.id !== wm.id)
+                              setSelectedWmId(updated.id);
                             updateWorkerManager(wm.id, updated);
                           }}
                           onRemove={() => removeWorkerManager(wm.id)}
@@ -2032,11 +2327,16 @@ function App() {
                         </span>
                       </div>
                     );
-                  const inst = allInstances.find((i) => i.type === wm.instanceType) || { price: 0 };
+                  const inst = allInstances.find(
+                    (i) => i.type === wm.instanceType,
+                  ) || { price: 0 };
                   const count =
                     wm.capMode === "instances"
                       ? Math.max(0, wm.instanceCap || 0)
-                      : Math.max(0, Math.floor((wm.budgetCap || 0) / (inst.price || 1)));
+                      : Math.max(
+                          0,
+                          Math.floor((wm.budgetCap || 0) / (inst.price || 1)),
+                        );
                   return (
                     <div
                       key={wm._uid}
@@ -2054,7 +2354,9 @@ function App() {
                       >
                         {label} · {count}× {wm.instanceType}
                       </span>
-                      <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                      <span
+                        style={{ fontSize: 12, color: "var(--text-secondary)" }}
+                      >
                         USD {(count * inst.price).toFixed(2)}/h
                       </span>
                     </div>
@@ -2075,7 +2377,9 @@ function App() {
                   >
                     Scheduler · {schedulerType}
                   </span>
-                  <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                  <span
+                    style={{ fontSize: 12, color: "var(--text-secondary)" }}
+                  >
                     USD {schedulerInst.price.toFixed(2)}/h
                   </span>
                 </div>
@@ -2156,7 +2460,12 @@ function App() {
           }}
         >
           {/* Left: terminal only */}
-          <LiveTerminal lines={log} isRunning={isRunning} bare style={{ minHeight: 0 }} />
+          <LiveTerminal
+            lines={log}
+            isRunning={isRunning}
+            bare
+            style={{ minHeight: 0 }}
+          />
           {/* Right: active deployment card */}
           <div
             style={{
@@ -2193,12 +2502,18 @@ function App() {
                 <DeploymentCard
                   state={provState}
                   onDownload={() =>
-                    downloadText("scaler-state-" + provState.name_suffix + ".json", JSON.stringify(provState, null, 2))
+                    downloadText(
+                      "scaler-state-" + provState.name_suffix + ".json",
+                      JSON.stringify(provState, null, 2),
+                    )
                   }
                   isRunning={isRunning}
                   keyMaterial={keyMaterial}
                 />
-                <GettingStartedCard schedulerAddress={provState.scheduler_address} ready={phase === "ready"} />
+                <GettingStartedCard
+                  schedulerAddress={provState.scheduler_address}
+                  ready={phase === "ready"}
+                />
               </div>
             )}
             {phase === "error" && (
@@ -2241,7 +2556,9 @@ function App() {
           }}
         >
           {!provState?.instance_id ? (
-            <div style={{ color: "var(--text-muted)", fontSize: 12 }}>No instance deployed yet.</div>
+            <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+              No instance deployed yet.
+            </div>
           ) : (
             <SchedulerLogTerminal
               instanceId={provState.instance_id}
@@ -2285,7 +2602,9 @@ function App() {
                 flexShrink: 0,
               }}
             >
-              <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{provState.gui_address}</span>
+              <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                {provState.gui_address}
+              </span>
               <a
                 href={provState.gui_address}
                 target="_blank"
@@ -2302,9 +2621,13 @@ function App() {
                 Open in new tab
               </a>
               {guiReady ? (
-                <span style={{ fontSize: 10, color: "var(--text-success)" }}>server ready</span>
+                <span style={{ fontSize: 10, color: "var(--text-success)" }}>
+                  server ready
+                </span>
               ) : (
-                <span style={{ fontSize: 10, color: "var(--text-dim)" }}>waiting for server… {guiElapsed}s</span>
+                <span style={{ fontSize: 10, color: "var(--text-dim)" }}>
+                  waiting for server… {guiElapsed}s
+                </span>
               )}
             </div>
             {guiReady ? (
@@ -2329,8 +2652,12 @@ function App() {
                   color: "var(--text-muted)",
                 }}
               >
-                <div style={{ fontSize: 13 }}>Waiting for GUI server to start</div>
-                <div style={{ fontSize: 11, color: "var(--text-dim)" }}>{guiElapsed}s elapsed · retrying every 5s</div>
+                <div style={{ fontSize: 13 }}>
+                  Waiting for GUI server to start
+                </div>
+                <div style={{ fontSize: 11, color: "var(--text-dim)" }}>
+                  {guiElapsed}s elapsed · retrying every 5s
+                </div>
               </div>
             )}
           </>

--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -236,31 +236,6 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
             }}
           />
         </div>
-        {canRemove && (
-          <button
-            onClick={onRemove}
-            style={{
-              background: "none",
-              border: "1px solid var(--border-danger)",
-              borderRadius: 3,
-              color: "var(--text-danger)",
-              fontFamily: "inherit",
-              fontSize: 12,
-              width: 28,
-              height: 28,
-              cursor: "pointer",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-              transition: "border-color 0.15s",
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.borderColor = "rgba(255,80,60,0.6)")}
-            onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--border-danger)")}
-          >
-            ✕
-          </button>
-        )}
       </div>
 
       {/* orb_aws_ec2 */}
@@ -271,68 +246,43 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
             <InstancePicker value={wm.instanceType} onChange={(v) => set("instanceType", v)} defaultCat="all" />
           </div>
           <div>
-            <Label>Scale Limit</Label>
-            <ToggleRow
-              options={[
-                ["instances", "Instance cap"],
-                ["budget", "USD/hr cap"],
-              ]}
-              value={wm.capMode}
-              onChange={(v) => set("capMode", v)}
-            />
-            <div style={{ marginTop: 7 }}>
+            <Label>Budget</Label>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
               {wm.capMode === "instances" ? (
-                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <NumericStepper
-                    value={wm.instanceCap || 1}
-                    onChange={(v) => set("instanceCap", v)}
-                    min={1}
-                    max={1000}
-                  />
-                  <span style={{ fontSize: 11, color: "var(--text-muted)" }}>max instances</span>
-                </div>
+                <NumericStepper
+                  value={wm.instanceCap || 1}
+                  onChange={(v) => set("instanceCap", v)}
+                  min={1}
+                  max={1000}
+                />
               ) : (
-                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <NumericStepper
-                    value={wm.budgetCap || 10}
-                    onChange={(v) => set("budgetCap", v)}
-                    min={0}
-                    step={0.5}
-                    width={64}
-                  />
-                  <span style={{ fontSize: 11, color: "var(--text-muted)" }}>max USD/h</span>
-                </div>
+                <NumericStepper
+                  value={wm.budgetCap || 10}
+                  onChange={(v) => set("budgetCap", v)}
+                  min={0}
+                  step={0.5}
+                  width={64}
+                />
               )}
+              <select
+                value={wm.capMode}
+                onChange={(e) => set("capMode", e.target.value)}
+                style={{
+                  background: "var(--bg-surface)",
+                  border: "1px solid var(--border-accent)",
+                  borderRadius: 3,
+                  padding: "6px 8px",
+                  color: "var(--text-primary)",
+                  fontFamily: "inherit",
+                  fontSize: 11,
+                  outline: "none",
+                  cursor: "pointer",
+                }}
+              >
+                <option value="budget">USD/h cap</option>
+                <option value="instances">instance cap</option>
+              </select>
             </div>
-          </div>
-          <div
-            style={{
-              padding: "8px 10px",
-              background: "rgba(0,255,136,0.04)",
-              border: "1px solid var(--border-success)",
-              borderRadius: 3,
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "baseline",
-            }}
-          >
-            <span
-              style={{
-                fontSize: 10,
-                color: "var(--text-muted)",
-              }}
-            >
-              Cost
-            </span>
-            <span
-              style={{
-                fontSize: 13,
-                fontWeight: 600,
-                color: "var(--text-success)",
-              }}
-            >
-              USD {costPerHr.toFixed(2)}/h
-            </span>
           </div>
           <button
             onClick={() => setShowAdv((v) => !v)}
@@ -352,7 +302,7 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
             }}
           >
             <span>Advanced</span>
-            <span style={{ fontSize: 11 }}>{showAdv ? "▴" : "▾"}</span>
+            <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: showAdv ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: showAdv ? "2px" : "-2px" }} />
           </button>
           {showAdv && (
             <div>
@@ -379,6 +329,22 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
               />
             </div>
           )}
+          <div
+            style={{
+              padding: "8px 10px",
+              background: "rgba(0,255,136,0.04)",
+              border: "1px solid var(--border-success)",
+              borderRadius: 3,
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "baseline",
+            }}
+          >
+            <span style={{ fontSize: 10, color: "var(--text-muted)" }}>Cost</span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-success)" }}>
+              USD {costPerHr.toFixed(2)}/h
+            </span>
+          </div>
         </>
       )}
 
@@ -516,55 +482,6 @@ function WorkerManagerCard({ wm, onChange, onRemove, allInstances, canRemove, fu
         </>
       )}
 
-      {/* baremetal_native */}
-      {wm.type === "baremetal_native" && (
-        <>
-          <div>
-            <Label>Mode</Label>
-            <ToggleRow
-              options={[
-                ["dynamic", "Dynamic"],
-                ["fixed", "Fixed"],
-              ]}
-              value={wm.mode || "fixed"}
-              onChange={(v) => set("mode", v)}
-            />
-          </div>
-          <div>
-            <Label>Worker Type Prefix</Label>
-            <input
-              value={wm.workerType || ""}
-              onChange={(e) => set("workerType", e.target.value)}
-              style={inp}
-              placeholder="optional"
-            />
-          </div>
-          {(wm.mode || "fixed") === "fixed" ? (
-            <div>
-              <Label help="Exact number of worker processes to pre-spawn.">Number of Workers</Label>
-              <NumericStepper
-                value={wm.maxTaskConcurrency != null && wm.maxTaskConcurrency >= 1 ? wm.maxTaskConcurrency : 4}
-                onChange={(v) => set("maxTaskConcurrency", Math.max(1, v))}
-                min={1}
-              />
-            </div>
-          ) : (
-            <div>
-              <Label help="Maximum concurrent workers the scheduler may spawn. -1 = no limit (uses cpu_count).">
-                Max Task Concurrency
-              </Label>
-              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <NumericStepper
-                  value={wm.maxTaskConcurrency != null ? wm.maxTaskConcurrency : -1}
-                  onChange={(v) => set("maxTaskConcurrency", v)}
-                  min={-1}
-                />
-                <span style={{ fontSize: 11, color: "var(--text-muted)" }}>(-1 = no limit)</span>
-              </div>
-            </div>
-          )}
-        </>
-      )}
     </div>
   );
 }
@@ -632,13 +549,7 @@ function DeploymentCard({ state, onDownload, keyMaterial, isRunning }) {
         animation: "fadeSlideIn 0.3s ease",
       }}
     >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
+      <div style={{ display: "flex", alignItems: "center" }}>
         <div
           style={{
             fontSize: 11,
@@ -648,22 +559,6 @@ function DeploymentCard({ state, onDownload, keyMaterial, isRunning }) {
         >
           Active Deployment
         </div>
-        <button
-          onClick={onDownload}
-          style={{
-            background: "none",
-            border: "1px solid var(--border-accent)",
-            borderRadius: 3,
-            color: "var(--text-muted)",
-            fontFamily: "inherit",
-            fontSize: 10,
-            padding: "3px 9px",
-            cursor: "pointer",
-            letterSpacing: "0.05em",
-          }}
-        >
-          ↓ State JSON
-        </button>
       </div>
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
@@ -1045,7 +940,7 @@ function App() {
       id: "wm-1",
       type: "orb_aws_ec2",
       instanceType: "t3.medium",
-      capMode: "instances",
+      capMode: "budget",
       instanceCap: 4,
       budgetCap: 10,
       requirements: "opengris-scaler[all]",
@@ -1176,7 +1071,7 @@ function App() {
         id: newId,
         type: "orb_aws_ec2",
         instanceType: "t3.medium",
-        capMode: "instances",
+        capMode: "budget",
         instanceCap: 4,
         budgetCap: 10,
         requirements: "opengris-scaler[all]",
@@ -1389,29 +1284,6 @@ function App() {
     } catch (_) {}
   }, []);
 
-  const handleLoadState = useCallback(
-    (e) => {
-      const file = e.target.files[0];
-      if (!file) return;
-      const reader = new FileReader();
-      reader.onload = (ev) => {
-        try {
-          const state = JSON.parse(ev.target.result);
-          savePartial(state);
-          setLog([]);
-          try {
-            localStorage.removeItem("scaler_log");
-          } catch (_) {}
-          setPhase("ready");
-        } catch {
-          alert("Invalid state file — expected JSON from a previous provision run.");
-        }
-      };
-      reader.readAsText(file);
-      e.target.value = "";
-    },
-    [savePartial],
-  );
 
   const Label = ({ children, help }) => (
     <div
@@ -1490,7 +1362,7 @@ function App() {
       }}
     >
       <span>{label}</span>
-      <span style={{ fontSize: 11 }}>{show ? "▴" : "▾"}</span>
+      <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: show ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: show ? "2px" : "-2px" }} />
     </button>
   );
 
@@ -1787,8 +1659,8 @@ function App() {
                       lineHeight: 1.5,
                     }}
                   >
-                    Your credentials are never stored anywhere and never leave your machine. All API calls are made
-                    directly from your browser.
+                    Your credentials are used from this browser to provision AWS resources and are made available to
+                    the scheduler instance for worker management. They are not stored by this application.
                   </span>
                 </div>
               </PanelBox>
@@ -1797,7 +1669,7 @@ function App() {
                 <div>
                   <Label
                     help={
-                      "WebSocket — connect to your cluster from a browser or any WebSocket client. Requires YMQ.\n---\nTCP — direct socket connection; slightly lower overhead. Works with YMQ or ZMQ."
+                      "WebSocket — connect to your cluster from a browser or any WebSocket client.\n---\nTCP — direct socket connection; slightly lower overhead."
                     }
                   >
                     Transport Protocol
@@ -1808,30 +1680,7 @@ function App() {
                       ["tcp", "TCP"],
                     ]}
                     value={transport}
-                    onSelect={(v) => {
-                      setTransport(v);
-                      if (v === "ws") setNetBack("ymq");
-                    }}
-                  />
-                </div>
-                <div>
-                  <Label
-                    help={
-                      "YMQ — OpenGRIS's built-in high-performance networking layer. Required for WebSocket connections. Recommended.\n---\nZMQ — industry-standard messaging library. TCP only. Use if you need ZMQ compatibility."
-                    }
-                  >
-                    Network Backend
-                  </Label>
-                  <TogglePair
-                    options={[
-                      ["ymq", "YMQ"],
-                      ["zmq", "ZMQ", transport === "ws"],
-                    ]}
-                    value={networkBackend}
-                    onSelect={(v) => {
-                      setNetBack(v);
-                      if (v === "zmq") setTransport("tcp");
-                    }}
+                    onSelect={setTransport}
                   />
                 </div>
                 <div>
@@ -1952,86 +1801,61 @@ function App() {
                 }}
               >
                 <PanelBox title="Policy">
-                  <div>
-                    <Label help="Policy engine that controls task allocation and worker scaling.">Engine</Label>
-                    <select
-                      disabled
-                      style={{
-                        width: "100%",
-                        background: "var(--bg-surface)",
-                        border: "1px solid var(--border-accent)",
-                        borderRadius: 3,
-                        padding: "7px 10px",
-                        color: "var(--text-primary)",
-                        fontFamily: "inherit",
-                        fontSize: 12,
-                        outline: "none",
-                      }}
-                    >
-                      <option value="simple">simple</option>
-                      <option value="waterfall_v1">waterfall_v1</option>
-                    </select>
-                  </div>
-                  <div>
-                    <Label help="How tasks are assigned to workers. even_load distributes work evenly; capability routes tasks to workers that advertise matching capabilities.">
-                      Allocate
-                    </Label>
-                    <select
-                      disabled
-                      style={{
-                        width: "100%",
-                        background: "var(--bg-surface)",
-                        border: "1px solid var(--border-accent)",
-                        borderRadius: 3,
-                        padding: "7px 10px",
-                        color: "var(--text-primary)",
-                        fontFamily: "inherit",
-                        fontSize: 12,
-                        outline: "none",
-                      }}
-                    >
-                      <option value="even_load">even_load</option>
-                      <option value="capability">capability</option>
-                    </select>
-                  </div>
-                  <div>
-                    <Label help="How the scheduler scales worker counts up or down. vanilla uses a task-to-worker ratio; capability scales per-capability group; no disables autoscaling.">
-                      Scaling
-                    </Label>
-                    <select
-                      disabled
-                      style={{
-                        width: "100%",
-                        background: "var(--bg-surface)",
-                        border: "1px solid var(--border-accent)",
-                        borderRadius: 3,
-                        padding: "7px 10px",
-                        color: "var(--text-primary)",
-                        fontFamily: "inherit",
-                        fontSize: 12,
-                        outline: "none",
-                      }}
-                    >
-                      <option value="vanilla">vanilla</option>
-                      <option value="no">no</option>
-                      <option value="capability">capability</option>
-                    </select>
-                  </div>
+                  {[
+                    { label: "Engine", help: "Policy engine that controls task allocation and worker scaling.", options: ["simple", "waterfall_v1"] },
+                    { label: "Allocate", help: "How tasks are assigned to workers. even_load distributes work evenly; capability routes tasks to workers that advertise matching capabilities.", options: ["even_load", "capability"] },
+                    { label: "Scaling", help: "How the scheduler scales worker counts up or down. vanilla uses a task-to-worker ratio; capability scales per-capability group; no disables autoscaling.", options: ["vanilla", "no", "capability"] },
+                  ].map(({ label, help, options }) => (
+                    <div key={label}>
+                      <Label help={help}>{label}</Label>
+                      <div style={{ position: "relative" }}>
+                        <select
+                          disabled
+                          style={{
+                            width: "100%",
+                            background: "var(--bg-surface)",
+                            border: "1px solid var(--border-accent)",
+                            borderRadius: 3,
+                            padding: "7px 28px 7px 10px",
+                            color: "var(--text-primary)",
+                            fontFamily: "inherit",
+                            fontSize: 12,
+                            outline: "none",
+                            appearance: "none",
+                            WebkitAppearance: "none",
+                          }}
+                        >
+                          {options.map((o) => <option key={o} value={o}>{o}</option>)}
+                        </select>
+                        <span style={{
+                          position: "absolute",
+                          right: 10,
+                          top: "50%",
+                          display: "block",
+                          width: 7,
+                          height: 7,
+                          borderRight: "1.5px solid var(--text-muted)",
+                          borderBottom: "1.5px solid var(--text-muted)",
+                          transform: "rotate(45deg)",
+                          marginTop: "-5px",
+                          pointerEvents: "none",
+                        }} />
+                      </div>
+                    </div>
+                  ))}
                 </PanelBox>
               </div>
             </div>
 
             {/* Column 3: Worker Managers + Cost Summary */}
             <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <PanelBox title={`Worker Managers (${workerManagers.length})`} style={{ gap: 8, padding: "16px 22px 0" }}>
+              <PanelBox title={`Worker Managers (${workerManagers.length})`} style={{ gap: 8, padding: "16px 22px" }}>
                 <div
                   style={{
                     display: "flex",
                     marginLeft: -22,
                     marginRight: -22,
                     borderTop: "1px solid var(--border-accent)",
-                    height: 360,
-                    overflow: "hidden",
                   }}
                 >
                   {/* vertical tab list */}
@@ -2043,35 +1867,88 @@ function App() {
                       flexDirection: "column",
                       flexShrink: 0,
                       overflowY: "auto",
+                      maxHeight: 420,
+                      alignSelf: "flex-start",
                     }}
                   >
                     {workerManagers.map((wm) => (
-                      <button
+                      <div
                         key={wm.id}
-                        title={wm.id}
-                        onClick={() => setSelectedWmId(wm.id)}
                         style={{
+                          display: "flex",
+                          alignItems: "stretch",
                           background: selectedWmId === wm.id ? "rgba(0,200,224,0.1)" : "transparent",
                           borderLeft: selectedWmId === wm.id ? "2px solid var(--tab-active)" : "2px solid transparent",
-                          borderRight: "none",
-                          borderTop: "none",
                           borderBottom: "1px solid rgba(255,255,255,0.04)",
-                          color: selectedWmId === wm.id ? "var(--text-accent)" : "var(--text-muted)",
-                          fontFamily: "inherit",
-                          fontSize: 10,
-                          padding: "10px 10px",
-                          textAlign: "left",
-                          cursor: "pointer",
-                          letterSpacing: "0.05em",
-                          transition: "background 0.12s, color 0.12s",
-                          width: "100%",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
+                          transition: "background 0.12s",
                         }}
                       >
-                        {wm.id}
-                      </button>
+                        <button
+                          title={wm.id}
+                          onClick={() => setSelectedWmId(wm.id)}
+                          style={{
+                            flex: 1,
+                            background: "transparent",
+                            border: "none",
+                            color: selectedWmId === wm.id ? "var(--text-accent)" : "var(--text-muted)",
+                            fontFamily: "inherit",
+                            fontSize: 10,
+                            padding: "10px 6px 10px 10px",
+                            textAlign: "left",
+                            cursor: "pointer",
+                            letterSpacing: "0.05em",
+                            transition: "color 0.12s",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                            minWidth: 0,
+                          }}
+                        >
+                          {wm.id}
+                        </button>
+                        {workerManagers.length > 1 && (
+                          <button
+                            onClick={() => removeWorkerManager(wm.id)}
+                            title="Remove"
+                            style={{
+                              background: "transparent",
+                              border: "none",
+                              color: "var(--text-muted)",
+                              fontFamily: "inherit",
+                              fontSize: 9,
+                              padding: 0,
+                              margin: "0 7px",
+                              cursor: "pointer",
+                              flexShrink: 0,
+                              alignSelf: "center",
+                              display: "flex",
+                              alignItems: "center",
+                              transition: "color 0.12s",
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.color = "var(--text-danger)";
+                              e.currentTarget.querySelector("span").style.borderColor = "var(--border-danger)";
+                              e.currentTarget.querySelector("span").style.background = "rgba(229,72,77,0.08)";
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.color = "var(--text-muted)";
+                              e.currentTarget.querySelector("span").style.borderColor = "var(--border-accent)";
+                              e.currentTarget.querySelector("span").style.background = "transparent";
+                            }}
+                          >
+                            <span style={{
+                              display: "inline-flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              width: 14,
+                              height: 14,
+                              border: "1px solid var(--border-accent)",
+                              borderRadius: 2,
+                              transition: "border-color 0.12s, background 0.12s",
+                            }}>✕</span>
+                          </button>
+                        )}
+                      </div>
                     ))}
                     <button
                       onClick={addWorkerManager}
@@ -2102,7 +1979,7 @@ function App() {
                     </button>
                   </div>
                   {/* selected card */}
-                  <div style={{ flex: 1, overflowY: "auto", padding: "14px 16px" }}>
+                  <div style={{ flex: 1, padding: "14px 16px" }}>
                     {workerManagers
                       .filter((wm) => wm.id === selectedWmId)
                       .map((wm) => (
@@ -2234,29 +2111,8 @@ function App() {
             </div>
           </div>
 
-          {/* Load state / download config links (idle only) */}
           {phase === "idle" && (
             <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
-              <label
-                style={{
-                  fontSize: 10,
-                  color: "var(--text-accent)",
-                  cursor: "pointer",
-                  textDecoration: "underline",
-                  textDecorationColor: "var(--border-accent)",
-                }}
-              >
-                Load state from file
-                <input type="file" accept=".json" onChange={handleLoadState} style={{ display: "none" }} />
-              </label>
-              <span
-                style={{
-                  width: 1,
-                  height: 12,
-                  background: "var(--text-muted)",
-                  display: "inline-block",
-                }}
-              />
               <button
                 onClick={handleDownloadConfig}
                 style={{

--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -973,57 +973,60 @@ function TopNav({
         style={{ height: 34, marginRight: 28, flexShrink: 0 }}
       />
       <div style={{ display: "flex", flex: 1 }}>
-        {tabs
-          .filter((t) => !t.postLaunch || showPostLaunch)
-          .map((t) =>
-            t.isLink ? (
-              <a
-                key={t.id}
-                href={t.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  padding: "14px 18px",
-                  background: "transparent",
-                  border: "none",
-                  borderBottom: "2px solid transparent",
-                  color: t.href ? "var(--text-muted)" : "var(--text-dim)",
-                  fontFamily: "inherit",
-                  fontSize: 12,
-                  cursor: t.href ? "pointer" : "default",
-                  textDecoration: "none",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  pointerEvents: t.href ? undefined : "none",
-                }}
-              >
-                {t.label} ↗
-              </a>
-            ) : (
-              <button
-                key={t.id}
-                onClick={() => setActiveTab(t.id)}
-                style={{
-                  padding: "14px 18px",
-                  background: "transparent",
-                  border: "none",
-                  borderBottom:
-                    activeTab === t.id
-                      ? "2px solid var(--tab-active)"
-                      : "2px solid transparent",
-                  color:
-                    activeTab === t.id
-                      ? "var(--text-accent)"
-                      : "var(--text-muted)",
-                  fontFamily: "inherit",
-                  fontSize: 12,
-                  cursor: "pointer",
-                }}
-              >
-                {t.label}
-              </button>
-            ),
-          )}
+        {tabs.map((t) => {
+          const disabled = t.postLaunch && !showPostLaunch;
+          return t.isLink ? (
+            <a
+              key={t.id}
+              href={disabled ? undefined : t.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                padding: "14px 18px",
+                background: "transparent",
+                border: "none",
+                borderBottom: "2px solid transparent",
+                color:
+                  disabled || !t.href ? "var(--text-dim)" : "var(--text-muted)",
+                fontFamily: "inherit",
+                fontSize: 12,
+                cursor: disabled || !t.href ? "default" : "pointer",
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+                pointerEvents: disabled || !t.href ? "none" : undefined,
+                opacity: disabled ? 0.4 : 1,
+              }}
+            >
+              {t.label} ↗
+            </a>
+          ) : (
+            <button
+              key={t.id}
+              onClick={() => !disabled && setActiveTab(t.id)}
+              style={{
+                padding: "14px 18px",
+                background: "transparent",
+                border: "none",
+                borderBottom:
+                  activeTab === t.id
+                    ? "2px solid var(--tab-active)"
+                    : "2px solid transparent",
+                color: disabled
+                  ? "var(--text-dim)"
+                  : activeTab === t.id
+                    ? "var(--text-accent)"
+                    : "var(--text-muted)",
+                fontFamily: "inherit",
+                fontSize: 12,
+                cursor: disabled ? "default" : "pointer",
+                opacity: disabled ? 0.4 : 1,
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
       </div>
       {launchControl && <div style={{ marginRight: 16 }}>{launchControl}</div>}
       <label

--- a/docs/html_extra/launchpad/components.jsx
+++ b/docs/html_extra/launchpad/components.jsx
@@ -65,7 +65,9 @@ function RegionSelect({ value, onChange }) {
   const [dropdownStyle, setDropdownStyle] = useState({});
 
   const filtered = regions.filter(
-    (r) => r.value.toLowerCase().includes(search.toLowerCase()) || r.label.toLowerCase().includes(search.toLowerCase()),
+    (r) =>
+      r.value.toLowerCase().includes(search.toLowerCase()) ||
+      r.label.toLowerCase().includes(search.toLowerCase()),
   );
 
   useEffect(() => {
@@ -122,7 +124,9 @@ function RegionSelect({ value, onChange }) {
         }}
       >
         <span style={{ flex: 1 }}>
-          <span style={{ color: "var(--text-secondary)", fontWeight: 600 }}>{value}</span>
+          <span style={{ color: "var(--text-secondary)", fontWeight: 600 }}>
+            {value}
+          </span>
           {selected && (
             <span
               style={{
@@ -135,7 +139,19 @@ function RegionSelect({ value, onChange }) {
             </span>
           )}
         </span>
-        <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: open ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: open ? "2px" : "-2px", flexShrink: 0 }} />
+        <span
+          style={{
+            display: "inline-block",
+            width: 7,
+            height: 7,
+            borderRight: "1.5px solid var(--text-muted)",
+            borderBottom: "1.5px solid var(--text-muted)",
+            transform: open ? "rotate(225deg)" : "rotate(45deg)",
+            position: "relative",
+            top: open ? "2px" : "-2px",
+            flexShrink: 0,
+          }}
+        />
       </button>
       {open &&
         ReactDOM.createPortal(
@@ -190,27 +206,37 @@ function RegionSelect({ value, onChange }) {
                     display: "flex",
                     alignItems: "baseline",
                     gap: 10,
-                    background: r.value === value ? "rgba(0,200,224,0.08)" : "transparent",
+                    background:
+                      r.value === value
+                        ? "rgba(0,200,224,0.08)"
+                        : "transparent",
                     borderBottom: "1px solid rgba(255,255,255,0.03)",
                   }}
                   onMouseEnter={(e) => {
-                    if (r.value !== value) e.currentTarget.style.background = "var(--bg-surface)";
+                    if (r.value !== value)
+                      e.currentTarget.style.background = "var(--bg-surface)";
                   }}
                   onMouseLeave={(e) => {
-                    if (r.value !== value) e.currentTarget.style.background = "transparent";
+                    if (r.value !== value)
+                      e.currentTarget.style.background = "transparent";
                   }}
                 >
                   <span
                     style={{
                       fontSize: 12,
                       fontWeight: 600,
-                      color: r.value === value ? "var(--text-success)" : "var(--text-primary)",
+                      color:
+                        r.value === value
+                          ? "var(--text-success)"
+                          : "var(--text-primary)",
                       flexShrink: 0,
                     }}
                   >
                     {r.value}
                   </span>
-                  <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{r.label}</span>
+                  <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                    {r.label}
+                  </span>
                 </div>
               ))}
               {filtered.length === 0 && (
@@ -262,7 +288,8 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
   const instances = window.SCALER_INSTANCES || [];
 
   const filtered = instances.filter((i) => {
-    if (search && !i.type.toLowerCase().includes(search.toLowerCase())) return false;
+    if (search && !i.type.toLowerCase().includes(search.toLowerCase()))
+      return false;
     if (filterCat !== "all" && i.cat !== filterCat) return false;
     if (filterGpu && i.gpu === 0) return false;
     if (minVcpu && i.vcpu < parseInt(minVcpu)) return false;
@@ -435,10 +462,15 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
             onClick={() => setFilterCat(cat)}
             style={{
               flex: 1,
-              background: filterCat === cat ? "rgba(0,200,224,0.1)" : "transparent",
+              background:
+                filterCat === cat ? "rgba(0,200,224,0.1)" : "transparent",
               border: "none",
-              borderBottom: filterCat === cat ? "2px solid var(--tab-active)" : "2px solid transparent",
-              color: filterCat === cat ? "var(--tab-active)" : "var(--text-muted)",
+              borderBottom:
+                filterCat === cat
+                  ? "2px solid var(--tab-active)"
+                  : "2px solid transparent",
+              color:
+                filterCat === cat ? "var(--tab-active)" : "var(--text-muted)",
               fontFamily: "inherit",
               fontSize: "10px",
               padding: "7px 4px",
@@ -469,24 +501,28 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
             No instances match
           </div>
         )}
-        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <table
+          style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}
+        >
           <thead>
             <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
-              {["Instance", "vCPU", "Mem (GB)", "GPU", "Network", "USD/h"].map((h) => (
-                <th
-                  key={h}
-                  style={{
-                    padding: "6px 10px",
-                    color: "var(--text-dim)",
-                    fontWeight: 500,
-                    textAlign: "left",
-                    fontSize: 10,
-                    letterSpacing: "0.05em",
-                  }}
-                >
-                  {h}
-                </th>
-              ))}
+              {["Instance", "vCPU", "Mem (GB)", "GPU", "Network", "USD/h"].map(
+                (h) => (
+                  <th
+                    key={h}
+                    style={{
+                      padding: "6px 10px",
+                      color: "var(--text-dim)",
+                      fontWeight: 500,
+                      textAlign: "left",
+                      fontSize: 10,
+                      letterSpacing: "0.05em",
+                    }}
+                  >
+                    {h}
+                  </th>
+                ),
+              )}
             </tr>
           </thead>
           <tbody>
@@ -501,22 +537,32 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
                   borderBottom: "1px solid rgba(255,255,255,0.03)",
                   cursor: "pointer",
                   background:
-                    i.type === value ? "rgba(0,200,224,0.08)" : i.featured ? "rgba(255,255,255,0.06)" : "transparent",
+                    i.type === value
+                      ? "rgba(0,200,224,0.08)"
+                      : i.featured
+                        ? "rgba(255,255,255,0.06)"
+                        : "transparent",
                   transition: "background 0.1s",
                 }}
                 onMouseEnter={(e) => {
-                  if (i.type !== value) e.currentTarget.style.background = "rgba(255,255,255,0.08)";
+                  if (i.type !== value)
+                    e.currentTarget.style.background = "rgba(255,255,255,0.08)";
                 }}
                 onMouseLeave={(e) => {
                   if (i.type !== value)
-                    e.currentTarget.style.background = i.featured ? "rgba(255,255,255,0.06)" : "transparent";
+                    e.currentTarget.style.background = i.featured
+                      ? "rgba(255,255,255,0.06)"
+                      : "transparent";
                 }}
               >
                 <td
                   style={{
                     padding: "7px 10px",
                     fontWeight: 600,
-                    color: i.type === value ? "var(--text-success)" : "var(--text-primary)",
+                    color:
+                      i.type === value
+                        ? "var(--text-success)"
+                        : "var(--text-primary)",
                   }}
                 >
                   <span
@@ -551,7 +597,8 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
                 <td
                   style={{
                     padding: "7px 10px",
-                    color: i.gpu > 0 ? "var(--text-warning)" : "var(--text-dim)",
+                    color:
+                      i.gpu > 0 ? "var(--text-warning)" : "var(--text-dim)",
                   }}
                 >
                   {i.gpu > 0 ? `${i.gpu}× ${i.gpuType} (${i.gpuMem}GB)` : "—"}
@@ -606,7 +653,9 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
         <span style={{ flex: 1 }}>
           {value ? (
             <span>
-              <span style={{ color: "var(--text-success)", fontWeight: 600 }}>{value}</span>
+              <span style={{ color: "var(--text-success)", fontWeight: 600 }}>
+                {value}
+              </span>
               {selected && (
                 <span
                   style={{
@@ -616,7 +665,9 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
                   }}
                 >
                   {selected.vcpu} vCPU · {selected.mem} GB
-                  {selected.gpu > 0 ? ` · ${selected.gpu}× ${selected.gpuType}` : ""}
+                  {selected.gpu > 0
+                    ? ` · ${selected.gpu}× ${selected.gpuType}`
+                    : ""}
                 </span>
               )}
             </span>
@@ -635,7 +686,19 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
             USD {selected.price.toFixed(2)}/h
           </span>
         )}
-        <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: open ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: open ? "2px" : "-2px", flexShrink: 0 }} />
+        <span
+          style={{
+            display: "inline-block",
+            width: 7,
+            height: 7,
+            borderRight: "1.5px solid var(--text-muted)",
+            borderBottom: "1.5px solid var(--text-muted)",
+            transform: open ? "rotate(225deg)" : "rotate(45deg)",
+            position: "relative",
+            top: open ? "2px" : "-2px",
+            flexShrink: 0,
+          }}
+        />
       </button>
       {open && ReactDOM.createPortal(dropdown, document.body)}
     </div>
@@ -837,7 +900,10 @@ function DeployDetails({ visible, style }) {
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
         {fields.map(({ label, value, href }) => (
-          <div key={label} style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            key={label}
+            style={{ display: "flex", alignItems: "center", gap: 12 }}
+          >
             <span
               style={{
                 fontSize: 11,
@@ -862,8 +928,12 @@ function DeployDetails({ visible, style }) {
                   textDecoration: "none",
                   borderBottom: "1px solid var(--border-accent)",
                 }}
-                onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-primary)")}
-                onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-accent)")}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.style.color = "var(--text-primary)")
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.style.color = "var(--text-accent)")
+                }
               >
                 {value}
               </a>
@@ -900,7 +970,8 @@ function HelpTip({ text }) {
   useEffect(() => {
     if (!open) return;
     function handleClick(e) {
-      if (btnRef.current && !btnRef.current.contains(e.target)) setBtnRect(null);
+      if (btnRef.current && !btnRef.current.contains(e.target))
+        setBtnRect(null);
     }
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
@@ -1112,7 +1183,11 @@ function LiveTerminal({ lines, isRunning, title, style, bare }) {
   );
 
   if (bare) {
-    return <div style={{ display: "flex", flexDirection: "column", ...style }}>{content}</div>;
+    return (
+      <div style={{ display: "flex", flexDirection: "column", ...style }}>
+        {content}
+      </div>
+    );
   }
 
   return (
@@ -1183,8 +1258,8 @@ function LiveTerminal({ lines, isRunning, title, style, bare }) {
 const POLL_INTERVALS = [
   { label: "15s", value: 15000 },
   { label: "30s", value: 30000 },
-  { label: "1m",  value: 60000 },
-  { label: "5m",  value: 300000 },
+  { label: "1m", value: 60000 },
+  { label: "5m", value: 300000 },
 ];
 
 function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
@@ -1198,13 +1273,18 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
   const pollRef = useRef(null);
   const triggerRef = useRef(null);
   const intervalMsRef = useRef(intervalMs);
-  useEffect(() => { intervalMsRef.current = intervalMs; }, [intervalMs]);
+  useEffect(() => {
+    intervalMsRef.current = intervalMs;
+  }, [intervalMs]);
 
   const fetchLogs = useCallback(async () => {
     try {
       const ssm = new AWS.SSM({
         region,
-        credentials: new AWS.Credentials(credentials.accessKeyId, credentials.secretKey),
+        credentials: new AWS.Credentials(
+          credentials.accessKeyId,
+          credentials.secretKey,
+        ),
       });
       let commandId;
       try {
@@ -1213,7 +1293,9 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
             InstanceIds: [instanceId],
             DocumentName: "AWS-RunShellScript",
             Parameters: {
-              commands: ["tail -n 150 /var/log/scaler.log 2>/dev/null || echo '(log not yet available)'"],
+              commands: [
+                "tail -n 150 /var/log/scaler.log 2>/dev/null || echo '(log not yet available)'",
+              ],
             },
             TimeoutSeconds: 30,
           })
@@ -1221,13 +1303,26 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
         commandId = r.Command.CommandId;
       } catch (err) {
         if (err.code === "InvalidInstanceId") {
-          setLines([{ text: "Instance not yet registered with SSM — retrying…", cls: "warn" }]);
+          setLines([
+            {
+              text: "Instance not yet registered with SSM — retrying…",
+              cls: "warn",
+            },
+          ]);
         } else if (err.code === "AccessDeniedException") {
           setStatus("error");
-          setError("Permission denied. Your IAM user needs ssm:SendCommand and ssm:GetCommandInvocation.");
-        } else if (err.code === "InvalidClientTokenId" || err.code === "AuthFailure" || /invalid.*token/i.test(err.message)) {
+          setError(
+            "Permission denied. Your IAM user needs ssm:SendCommand and ssm:GetCommandInvocation.",
+          );
+        } else if (
+          err.code === "InvalidClientTokenId" ||
+          err.code === "AuthFailure" ||
+          /invalid.*token/i.test(err.message)
+        ) {
           setStatus("error");
-          setError("Invalid AWS credentials. Re-enter your Access Key ID and Secret Access Key in the Configuration tab.");
+          setError(
+            "Invalid AWS credentials. Re-enter your Access Key ID and Secret Access Key in the Configuration tab.",
+          );
         } else {
           setStatus("error");
           setError("SSM error: " + err.message);
@@ -1244,7 +1339,11 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
             })
             .promise();
           if (inv.Status === "Success" || inv.Status === "Failed") {
-            setLines((inv.StandardOutputContent || "").split("\n").map((text) => ({ text, cls: "info" })));
+            setLines(
+              (inv.StandardOutputContent || "")
+                .split("\n")
+                .map((text) => ({ text, cls: "info" })),
+            );
             break;
           }
         } catch (_) {
@@ -1289,7 +1388,10 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
   }, [isActive, instanceId, hasCredentials, fetchLogs, intervalMs]);
 
   useEffect(() => {
-    if (!nextFetchAt) { setCountdown(null); return; }
+    if (!nextFetchAt) {
+      setCountdown(null);
+      return;
+    }
     const tick = setInterval(() => {
       setCountdown(Math.max(0, Math.round((nextFetchAt - Date.now()) / 1000)));
     }, 1000);
@@ -1298,17 +1400,32 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
 
   if (!hasCredentials)
     return (
-      <div style={{ padding: 24, color: "var(--text-secondary)", fontSize: 12 }}>
-        Re-enter your AWS credentials in the Configuration tab to view scheduler logs.
+      <div
+        style={{ padding: 24, color: "var(--text-secondary)", fontSize: 12 }}
+      >
+        Re-enter your AWS credentials in the Configuration tab to view scheduler
+        logs.
       </div>
     );
   if (status === "error")
-    return <div style={{ padding: 24, color: "var(--text-danger)", fontSize: 12 }}>{errorMsg}</div>;
+    return (
+      <div style={{ padding: 24, color: "var(--text-danger)", fontSize: 12 }}>
+        {errorMsg}
+      </div>
+    );
 
-  const labelMs = POLL_INTERVALS.find((o) => o.value === intervalMs)?.label ?? "15s";
+  const labelMs =
+    POLL_INTERVALS.find((o) => o.value === intervalMs)?.label ?? "15s";
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        minHeight: 0,
+      }}
+    >
       <div
         style={{
           display: "flex",
@@ -1318,11 +1435,25 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
           flexShrink: 0,
         }}
       >
-        <span style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
           /var/log/scaler.log
         </span>
         <span style={{ fontSize: 11, color: "var(--text-dim)" }}>·</span>
-        <span style={{ fontSize: 11, color: "var(--text-muted)", display: "flex", alignItems: "center", gap: 6 }}>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--text-muted)",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+          }}
+        >
           refresh every
           <select
             value={intervalMs}
@@ -1338,7 +1469,9 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
             }}
           >
             {POLL_INTERVALS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
             ))}
           </select>
         </span>
@@ -1507,7 +1640,19 @@ function WorkerManagerTypeSelect({ value, onChange }) {
             {selected ? selected.label : "Select type…"}
           </span>
         </span>
-        <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: open ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: open ? "2px" : "-2px", flexShrink: 0 }} />
+        <span
+          style={{
+            display: "inline-block",
+            width: 7,
+            height: 7,
+            borderRight: "1.5px solid var(--text-muted)",
+            borderBottom: "1.5px solid var(--text-muted)",
+            transform: open ? "rotate(225deg)" : "rotate(45deg)",
+            position: "relative",
+            top: open ? "2px" : "-2px",
+            flexShrink: 0,
+          }}
+        />
       </button>
       {open &&
         ReactDOM.createPortal(
@@ -1539,14 +1684,17 @@ function WorkerManagerTypeSelect({ value, onChange }) {
                   alignItems: "center",
                   gap: 10,
                   opacity: t.disabled ? 0.4 : 1,
-                  background: t.value === value ? "rgba(0,200,224,0.08)" : "transparent",
+                  background:
+                    t.value === value ? "rgba(0,200,224,0.08)" : "transparent",
                   borderBottom: "1px solid rgba(255,255,255,0.04)",
                 }}
                 onMouseEnter={(e) => {
-                  if (!t.disabled && t.value !== value) e.currentTarget.style.background = "var(--bg-surface)";
+                  if (!t.disabled && t.value !== value)
+                    e.currentTarget.style.background = "var(--bg-surface)";
                 }}
                 onMouseLeave={(e) => {
-                  if (!t.disabled && t.value !== value) e.currentTarget.style.background = "transparent";
+                  if (!t.disabled && t.value !== value)
+                    e.currentTarget.style.background = "transparent";
                 }}
               >
                 <span
@@ -1554,8 +1702,14 @@ function WorkerManagerTypeSelect({ value, onChange }) {
                     fontSize: 9,
                     fontWeight: 700,
                     letterSpacing: "0.06em",
-                    color: t.value === value ? "var(--text-success)" : "var(--text-accent)",
-                    background: t.value === value ? "rgba(0,255,136,0.1)" : "rgba(0,200,224,0.1)",
+                    color:
+                      t.value === value
+                        ? "var(--text-success)"
+                        : "var(--text-accent)",
+                    background:
+                      t.value === value
+                        ? "rgba(0,255,136,0.1)"
+                        : "rgba(0,200,224,0.1)",
                     border: `1px solid ${t.value === value ? "rgba(0,255,136,0.2)" : "rgba(0,200,224,0.18)"}`,
                     borderRadius: 2,
                     padding: "1px 5px",
@@ -1571,7 +1725,10 @@ function WorkerManagerTypeSelect({ value, onChange }) {
                     style={{
                       display: "block",
                       fontSize: 12,
-                      color: t.value === value ? "var(--text-success)" : "var(--text-primary)",
+                      color:
+                        t.value === value
+                          ? "var(--text-success)"
+                          : "var(--text-primary)",
                       fontWeight: 600,
                     }}
                   >

--- a/docs/html_extra/launchpad/components.jsx
+++ b/docs/html_extra/launchpad/components.jsx
@@ -315,11 +315,13 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
     if (!triggerRef.current) return;
     const r = triggerRef.current.getBoundingClientRect();
     const vh = window.innerHeight;
+    const vw = window.innerWidth;
     const gap = 4;
-    const minW = Math.max(540, r.width);
+    const minW = Math.min(Math.max(540, r.width), vw - 8);
     const POPUP_H = 370;
     const spaceBelow = vh - r.bottom - gap;
     const spaceAbove = r.top - gap;
+    const left = Math.min(r.left, vw - minW - 4);
 
     let style;
     if (spaceBelow >= POPUP_H || spaceBelow >= spaceAbove) {
@@ -327,7 +329,7 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
       style = {
         position: "fixed",
         top: r.bottom + gap,
-        left: r.left,
+        left,
         minWidth: minW,
         maxResultsH: Math.min(280, availH),
       };
@@ -336,7 +338,7 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
       style = {
         position: "fixed",
         bottom: vh - r.top + gap,
-        left: r.left,
+        left,
         minWidth: minW,
         maxResultsH: Math.min(280, availH),
       };

--- a/docs/html_extra/launchpad/components.jsx
+++ b/docs/html_extra/launchpad/components.jsx
@@ -135,7 +135,7 @@ function RegionSelect({ value, onChange }) {
             </span>
           )}
         </span>
-        <span style={{ color: "var(--text-muted)", fontSize: 10, flexShrink: 0 }}>{open ? "▲" : "▼"}</span>
+        <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: open ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: open ? "2px" : "-2px", flexShrink: 0 }} />
       </button>
       {open &&
         ReactDOM.createPortal(
@@ -635,7 +635,7 @@ function InstancePicker({ value, onChange, defaultCat = "gpu" }) {
             USD {selected.price.toFixed(2)}/h
           </span>
         )}
-        <span style={{ color: "var(--text-muted)", fontSize: 10 }}>{open ? "▲" : "▼"}</span>
+        <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: open ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: open ? "2px" : "-2px", flexShrink: 0 }} />
       </button>
       {open && ReactDOM.createPortal(dropdown, document.body)}
     </div>
@@ -1383,32 +1383,26 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
 const WM_TYPE_DEFS = [
   {
     value: "orb_aws_ec2",
-    label: "ORB / AWS EC2",
-    badge: "EC2",
+    label: "AWS EC2",
+    badge: "AWS",
     desc: "Managed EC2 instances via ORB worker manager",
   },
   {
     value: "aws_raw_ecs",
     label: "AWS ECS",
-    badge: "ECS",
+    badge: "AWS",
     desc: "Container tasks on Elastic Container Service",
   },
   {
     value: "aws_hpc",
-    label: "AWS Batch (HPC)",
-    badge: "HPC",
+    label: "AWS Batch",
+    badge: "AWS",
     desc: "High-performance compute via AWS Batch",
-  },
-  {
-    value: "baremetal_native",
-    label: "Bare Metal",
-    badge: "BARE",
-    desc: "Directly attached bare-metal workers",
   },
   {
     value: "symphony",
     label: "IBM Spectrum Symphony",
-    badge: "SYM",
+    badge: "IBM",
     desc: "IBM Spectrum Symphony grid via soamapi",
   },
   {
@@ -1513,7 +1507,7 @@ function WorkerManagerTypeSelect({ value, onChange }) {
             {selected ? selected.label : "Select type…"}
           </span>
         </span>
-        <span style={{ color: "var(--text-muted)", fontSize: 9, flexShrink: 0 }}>{open ? "▲" : "▼"}</span>
+        <span style={{ display: "inline-block", width: 7, height: 7, borderRight: "1.5px solid var(--text-muted)", borderBottom: "1.5px solid var(--text-muted)", transform: open ? "rotate(225deg)" : "rotate(45deg)", position: "relative", top: open ? "2px" : "-2px", flexShrink: 0 }} />
       </button>
       {open &&
         ReactDOM.createPortal(

--- a/docs/html_extra/launchpad/index.html
+++ b/docs/html_extra/launchpad/index.html
@@ -47,7 +47,8 @@
       }
 
       :root {
-        --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+        --font-mono:
+          "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
       }
       :root,
       [data-theme="dark"] {
@@ -144,7 +145,7 @@
           transform: translateY(0);
         }
       }
-input[type="number"] {
+      input[type="number"] {
         -moz-appearance: textfield;
       }
       input[type="number"]::-webkit-inner-spin-button,

--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -16,7 +16,14 @@ const _ORB_INLINE_POLICY = JSON.stringify({
   Statement: [
     {
       Effect: "Allow",
-      Action: ["ec2:*", "autoscaling:*", "iam:GetRole", "iam:PassRole", "ssm:GetParameter", "sts:GetCallerIdentity"],
+      Action: [
+        "ec2:*",
+        "autoscaling:*",
+        "iam:GetRole",
+        "iam:PassRole",
+        "ssm:GetParameter",
+        "sts:GetCallerIdentity",
+      ],
       Resource: "*",
     },
   ],
@@ -32,7 +39,8 @@ function randomSuffix(n) {
 
 function sleep(ms, signal) {
   return new Promise(function (resolve, reject) {
-    if (signal && signal.aborted) return reject(new DOMException("Aborted", "AbortError"));
+    if (signal && signal.aborted)
+      return reject(new DOMException("Aborted", "AbortError"));
     var timer = setTimeout(resolve, ms);
     if (signal)
       signal.addEventListener(
@@ -52,7 +60,8 @@ function withAbort(promise, signal) {
   return Promise.race([
     promise,
     new Promise(function (_, reject) {
-      if (signal.aborted) return reject(new DOMException("Aborted", "AbortError"));
+      if (signal.aborted)
+        return reject(new DOMException("Aborted", "AbortError"));
       signal.addEventListener(
         "abort",
         function () {
@@ -107,7 +116,8 @@ security_group_ids = ["<SECURITY_GROUP_ID>"]
 logging_level = "INFO"
 instance_tags = {scaler-deployment = "${suffix}"}
 `;
-        if (cfg.networkBackend !== "zmq") block += `network_backend = "${cfg.networkBackend || "ymq"}"\n`;
+        if (cfg.networkBackend !== "zmq")
+          block += `network_backend = "${cfg.networkBackend || "ymq"}"\n`;
       } else if (wm.type === "aws_raw_ecs") {
         block += `aws_region = "${cfg.region}"
 ecs_cluster = "${wm.ecsCluster || "scaler-cluster"}"
@@ -118,7 +128,8 @@ ecs_task_cpu = ${wm.ecsTaskCpu || 4}
 ecs_task_memory = ${wm.ecsTaskMemory || 30}
 ecs_python_version = "${cfg.pythonVersion}"
 `;
-        if (wm.requirements) block += `ecs_python_requirements = "${wm.requirements}"\n`;
+        if (wm.requirements)
+          block += `ecs_python_requirements = "${wm.requirements}"\n`;
       } else if (wm.type === "aws_hpc") {
         block += `aws_region = "${cfg.region}"
 job_queue = "${wm.jobQueue || ""}"
@@ -234,7 +245,8 @@ security_group_ids = ["${cfg.securityGroupId}"]
 logging_level = "INFO"
 instance_tags = {scaler-deployment = "${cfg.nameSuffix}"}
 `;
-        if (cfg.networkBackend !== "zmq") block += `network_backend = "${cfg.networkBackend || "ymq"}"\n`;
+        if (cfg.networkBackend !== "zmq")
+          block += `network_backend = "${cfg.networkBackend || "ymq"}"\n`;
       } else if (wm.type === "aws_raw_ecs") {
         block += `aws_region = "${cfg.region}"
 ecs_cluster = "${wm.ecsCluster || "scaler-cluster"}"
@@ -245,7 +257,8 @@ ecs_task_cpu = ${wm.ecsTaskCpu || 4}
 ecs_task_memory = ${wm.ecsTaskMemory || 30}
 ecs_python_version = "${cfg.pythonVersion}"
 `;
-        if (wm.requirements) block += `ecs_python_requirements = "${wm.requirements}"\n`;
+        if (wm.requirements)
+          block += `ecs_python_requirements = "${wm.requirements}"\n`;
       } else if (wm.type === "aws_hpc") {
         block += `aws_region = "${cfg.region}"
 job_queue = "${wm.jobQueue || ""}"
@@ -345,7 +358,8 @@ async function getLatestAl2023Ami(ec2) {
       ],
     })
     .promise();
-  if (!resp.Images || resp.Images.length === 0) throw new Error("No AL2023 x86_64 AMI found in this region");
+  if (!resp.Images || resp.Images.length === 0)
+    throw new Error("No AL2023 x86_64 AMI found in this region");
   var sorted = resp.Images.slice().sort(function (a, b) {
     return a.CreationDate.localeCompare(b.CreationDate);
   });
@@ -355,7 +369,8 @@ async function getLatestAl2023Ami(ec2) {
 async function waitForWs(host, port, timeoutMs, intervalMs, signal) {
   var deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (signal && signal.aborted) throw new DOMException("Aborted", "AbortError");
+    if (signal && signal.aborted)
+      throw new DOMException("Aborted", "AbortError");
     var ok = await new Promise(function (resolve) {
       var ws = new WebSocket("ws://" + host + ":" + port + "/");
       var done = false;
@@ -407,7 +422,8 @@ async function ignoreNotFound(fn) {
   try {
     await fn();
   } catch (e) {
-    if (e.code !== "NoSuchEntity" && e.code !== "NoSuchEntityException") throw e;
+    if (e.code !== "NoSuchEntity" && e.code !== "NoSuchEntityException")
+      throw e;
   }
 }
 
@@ -448,7 +464,10 @@ async function createIamStack(iam, suffix, addLog, signal) {
 
   addLog("Creating instance profile '" + profileName + "'...", "cmd");
   try {
-    await withAbort(iam.createInstanceProfile({ InstanceProfileName: profileName }).promise(), signal);
+    await withAbort(
+      iam.createInstanceProfile({ InstanceProfileName: profileName }).promise(),
+      signal,
+    );
     await withAbort(
       iam
         .addRoleToInstanceProfile({
@@ -460,7 +479,9 @@ async function createIamStack(iam, suffix, addLog, signal) {
     );
   } catch (err) {
     try {
-      await iam.deleteRolePolicy({ RoleName: roleName, PolicyName: "ScalerORBPolicy" }).promise();
+      await iam
+        .deleteRolePolicy({ RoleName: roleName, PolicyName: "ScalerORBPolicy" })
+        .promise();
       await iam.deleteRole({ RoleName: roleName }).promise();
     } catch (_) {}
     throw err;
@@ -490,12 +511,16 @@ async function destroyIamStack(iam, iamState, addLog) {
 
   addLog("Deleting instance profile '" + profileName + "'...", "cmd");
   await ignoreNotFound(function () {
-    return iam.deleteInstanceProfile({ InstanceProfileName: profileName }).promise();
+    return iam
+      .deleteInstanceProfile({ InstanceProfileName: profileName })
+      .promise();
   });
 
   addLog("Deleting role '" + roleName + "'...", "cmd");
   try {
-    var attachedPolicies = await iam.listAttachedRolePolicies({ RoleName: roleName }).promise();
+    var attachedPolicies = await iam
+      .listAttachedRolePolicies({ RoleName: roleName })
+      .promise();
     for (var i = 0; i < attachedPolicies.AttachedPolicies.length; i++) {
       await iam
         .detachRolePolicy({
@@ -504,7 +529,9 @@ async function destroyIamStack(iam, iamState, addLog) {
         })
         .promise();
     }
-    var inlinePolicies = await iam.listRolePolicies({ RoleName: roleName }).promise();
+    var inlinePolicies = await iam
+      .listRolePolicies({ RoleName: roleName })
+      .promise();
     for (var j = 0; j < inlinePolicies.PolicyNames.length; j++) {
       await iam
         .deleteRolePolicy({
@@ -515,11 +542,19 @@ async function destroyIamStack(iam, iamState, addLog) {
     }
     await iam.deleteRole({ RoleName: roleName }).promise();
   } catch (e) {
-    if (e.code !== "NoSuchEntity" && e.code !== "NoSuchEntityException") throw e;
+    if (e.code !== "NoSuchEntity" && e.code !== "NoSuchEntityException")
+      throw e;
   }
 }
 
-async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal) {
+async function provision(
+  cfg,
+  creds,
+  addLog,
+  onPartialState,
+  onKeyReady,
+  signal,
+) {
   var clients = makeAwsClients(cfg.region, creds);
   var ec2 = clients.ec2,
     iam = clients.iam;
@@ -530,7 +565,12 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
   addLog("─".repeat(52), "dim");
 
   // 1. AMI
-  addLog(cfg.amiId ? "Using AMI: " + cfg.amiId : "Discovering latest AL2023 x86_64 AMI...", "cmd");
+  addLog(
+    cfg.amiId
+      ? "Using AMI: " + cfg.amiId
+      : "Discovering latest AL2023 x86_64 AMI...",
+    "cmd",
+  );
   var amiId = cfg.amiId || (await withAbort(getLatestAl2023Ami(ec2), signal));
   addLog("  → " + amiId, "info");
 
@@ -542,7 +582,10 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
       role_name: "",
       created: false,
     };
-    addLog("  → Using existing instance profile: " + cfg.instanceProfileName, "info");
+    addLog(
+      "  → Using existing instance profile: " + cfg.instanceProfileName,
+      "info",
+    );
   } else {
     iamState = await createIamStack(iam, suffix, addLog, signal);
     addLog("  ✓ IAM role and profile created", "ok");
@@ -576,7 +619,10 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
   // 4. Security group
   var myIp = await withAbort(getMyPublicIp(), signal);
   var sgName = "scaler-sg-" + suffix;
-  addLog("Creating security group '" + sgName + "' (your IP: " + myIp + ")...", "cmd");
+  addLog(
+    "Creating security group '" + sgName + "' (your IP: " + myIp + ")...",
+    "cmd",
+  );
   var sgResp = await withAbort(
     ec2
       .createSecurityGroup({
@@ -608,7 +654,9 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
             IpProtocol: "tcp",
             FromPort: 22,
             ToPort: 22,
-            IpRanges: [{ CidrIp: myIp + "/32", Description: "SSH from local machine" }],
+            IpRanges: [
+              { CidrIp: myIp + "/32", Description: "SSH from local machine" },
+            ],
           },
           {
             IpProtocol: "tcp",
@@ -692,7 +740,9 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
       break;
     } catch (err) {
       var iamNotReady =
-        err.code === "InvalidParameterValue" && err.message && err.message.includes("Invalid IAM Instance Profile");
+        err.code === "InvalidParameterValue" &&
+        err.message &&
+        err.message.includes("Invalid IAM Instance Profile");
       if (!iamNotReady || Date.now() >= iamDeadline) throw err;
       addLog("  → IAM profile not yet visible to EC2, retrying in 5s…", "dim");
       await sleep(5000, signal);
@@ -705,9 +755,15 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
 
   // 6. Wait for running state
   addLog("Waiting for instance to reach running state...", "cmd");
-  await withAbort(ec2.waitFor("instanceRunning", { InstanceIds: [instanceId] }).promise(), signal);
+  await withAbort(
+    ec2.waitFor("instanceRunning", { InstanceIds: [instanceId] }).promise(),
+    signal,
+  );
 
-  var desc = await withAbort(ec2.describeInstances({ InstanceIds: [instanceId] }).promise(), signal);
+  var desc = await withAbort(
+    ec2.describeInstances({ InstanceIds: [instanceId] }).promise(),
+    signal,
+  );
   var inst = desc.Reservations[0].Instances[0];
   var publicIp = inst.PublicIpAddress;
   var privateIp = inst.PrivateIpAddress;
@@ -723,7 +779,10 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
   addLog("  → Private IP: " + privateIp, "info");
 
   // Allow all inbound traffic from the VPC's CIDR so ORB workers can reach the scheduler.
-  var vpcDesc = await withAbort(ec2.describeVpcs({ VpcIds: [vpcId] }).promise(), signal);
+  var vpcDesc = await withAbort(
+    ec2.describeVpcs({ VpcIds: [vpcId] }).promise(),
+    signal,
+  );
   var vpcCidr = vpcDesc.Vpcs[0].CidrBlock;
   await withAbort(
     ec2
@@ -744,13 +803,18 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
       .promise(),
     signal,
   );
-  addLog("  → VPC: " + vpcId + "  CIDR: " + vpcCidr + "  subnet: " + subnetId, "info");
+  addLog(
+    "  → VPC: " + vpcId + "  CIDR: " + vpcCidr + "  subnet: " + subnetId,
+    "info",
+  );
   onPartialState(partial);
 
   // 7. Build addresses and persist complete state
   var addrSlash = cfg.transport === "ws" ? "/" : "";
-  var schedAddr = cfg.transport + "://" + publicIp + ":" + cfg.schedulerPort + addrSlash;
-  var objAddr = cfg.transport + "://" + publicIp + ":" + cfg.objectStoragePort + addrSlash;
+  var schedAddr =
+    cfg.transport + "://" + publicIp + ":" + cfg.schedulerPort + addrSlash;
+  var objAddr =
+    cfg.transport + "://" + publicIp + ":" + cfg.objectStoragePort + addrSlash;
 
   var state = {
     region: cfg.region,
@@ -768,7 +832,13 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
     object_storage_port: cfg.objectStoragePort,
     scheduler_address: schedAddr,
     object_storage_address: objAddr,
-    monitor_address: cfg.transport + "://" + publicIp + ":" + (cfg.schedulerPort + 2) + addrSlash,
+    monitor_address:
+      cfg.transport +
+      "://" +
+      publicIp +
+      ":" +
+      (cfg.schedulerPort + 2) +
+      addrSlash,
     gui_address: "http://" + publicIp + ":50001",
     iam: iamState,
     worker_name: "scaler-worker-" + suffix,
@@ -776,7 +846,10 @@ async function provision(cfg, creds, addLog, onPartialState, onKeyReady, signal)
   onPartialState(state);
 
   // 8. Poll for scheduler readiness — temporarily skipped: browsers block ws:// from https pages (mixed content).
-  addLog("  ℹ Skipping scheduler connection check (browser security restriction) — assuming ready", "warn");
+  addLog(
+    "  ℹ Skipping scheduler connection check (browser security restriction) — assuming ready",
+    "warn",
+  );
   // if (cfg.transport === "ws") {
   //   addLog(
   //     "Waiting up to " + cfg.pollTimeout + "s for scheduler at " + publicIp + ":" + cfg.schedulerPort + "...",
@@ -809,7 +882,12 @@ async function teardown(state, creds, addLog, signal) {
 
   // Terminate all deployment instances (scheduler + any ORB workers) in one pass.
   // Search by scaler-deployment tag; fall back to explicit instance_id for old state files.
-  addLog("Searching for deployment instances (scaler-deployment=" + state.name_suffix + ")...", "cmd");
+  addLog(
+    "Searching for deployment instances (scaler-deployment=" +
+      state.name_suffix +
+      ")...",
+    "cmd",
+  );
   var instanceIdSet = {};
   if (state.name_suffix) {
     var tagResp = await withAbort(
@@ -835,10 +913,24 @@ async function teardown(state, creds, addLog, signal) {
   if (state.instance_id) instanceIdSet[state.instance_id] = true;
   var allInstanceIds = Object.keys(instanceIdSet);
   if (allInstanceIds.length > 0) {
-    addLog("  → Terminating " + allInstanceIds.length + " instance(s): " + allInstanceIds.join(", "), "info");
+    addLog(
+      "  → Terminating " +
+        allInstanceIds.length +
+        " instance(s): " +
+        allInstanceIds.join(", "),
+      "info",
+    );
     try {
-      await withAbort(ec2.terminateInstances({ InstanceIds: allInstanceIds }).promise(), signal);
-      await withAbort(ec2.waitFor("instanceTerminated", { InstanceIds: allInstanceIds }).promise(), signal);
+      await withAbort(
+        ec2.terminateInstances({ InstanceIds: allInstanceIds }).promise(),
+        signal,
+      );
+      await withAbort(
+        ec2
+          .waitFor("instanceTerminated", { InstanceIds: allInstanceIds })
+          .promise(),
+        signal,
+      );
       addLog("  ✓ All instances terminated", "ok");
     } catch (e) {
       if (e.name === "AbortError") throw e;
@@ -851,7 +943,10 @@ async function teardown(state, creds, addLog, signal) {
   if (state.security_group_id) {
     addLog("Deleting security group " + state.security_group_id + "...", "cmd");
     try {
-      await withAbort(ec2.deleteSecurityGroup({ GroupId: state.security_group_id }).promise(), signal);
+      await withAbort(
+        ec2.deleteSecurityGroup({ GroupId: state.security_group_id }).promise(),
+        signal,
+      );
       addLog("  ✓ Security group deleted", "ok");
     } catch (e) {
       if (e.name === "AbortError") throw e;
@@ -862,7 +957,10 @@ async function teardown(state, creds, addLog, signal) {
   if (state.key_pair_name) {
     addLog("Deleting key pair '" + state.key_pair_name + "'...", "cmd");
     try {
-      await withAbort(ec2.deleteKeyPair({ KeyName: state.key_pair_name }).promise(), signal);
+      await withAbort(
+        ec2.deleteKeyPair({ KeyName: state.key_pair_name }).promise(),
+        signal,
+      );
       addLog("  ✓ Key pair deleted", "ok");
     } catch (e) {
       if (e.name === "AbortError") throw e;


### PR DESCRIPTION
Live: https://magniloquency.github.io/scaler/launchpad/

---

## Summary

- Rename "Scale Limit" to "Budget"; replace toggle row with inline dropdown defaulting to USD/h cap; Advanced section moved above cost line
- Worker manager delete button moved to vertical tabs with a boxed icon; pane now grows with content instead of fixed-height scrolling
- Worker manager type dropdown uses provider name badges (AWS, IBM, OCI) and simplified labels (AWS EC2, AWS Batch, etc.); bare metal type removed
- Remove network backend selector (always YMQ); update transport help text accordingly
- Remove state file save/load feature (Load state from file / State JSON download)
- Update API key disclaimer text to accurately reflect that credentials are passed to the scheduler instance
- Replace Unicode triangle arrows with CSS border chevrons throughout, matching native select appearance; policy panel selects now use the same custom chevron
- Clamp instance picker dropdown position and width so it does not overflow the right edge of the viewport on small windows
- Always show Deployment, Scheduler Logs, and GUI tabs; render them greyed out and non-interactive when there is no active deployment