### PR TITLE
Fix process exit with 127 on Windows CI

### DIFF
--- a/src/scaler/utility/graph/topological_sorter.py
+++ b/src/scaler/utility/graph/topological_sorter.py
@@ -1,11 +1,19 @@
 import logging
+import sys
 
-try:
-    from scaler.utility.graph.topological_sorter_graphblas import TopologicalSorter
+# python-graphblas's native Matrix.__del__ has been observed to corrupt the heap on Windows
+# (STATUS_HEAP_CORRUPTION 0xC0000374) when finalized during a GC cycle that fires on a
+# non-main thread (e.g. asyncio.gather scheduling inside ScalerClientAgent). Until that is
+# fixed upstream, fall back to the stdlib graphlib backend on Windows. See issue #786.
+if sys.platform == "win32":
+    from graphlib import TopologicalSorter  # type: ignore[assignment]
+else:
+    try:
+        from scaler.utility.graph.topological_sorter_graphblas import TopologicalSorter
 
-    logging.info("using GraphBLAS for calculate graph")
-except ImportError as e:
-    assert isinstance(e, Exception)
-    from graphlib import TopologicalSorter  # type: ignore[assignment, no-redef]
+        logging.info("using GraphBLAS for calculate graph")
+    except ImportError as e:
+        assert isinstance(e, Exception)
+        from graphlib import TopologicalSorter  # type: ignore[assignment, no-redef]
 
-    assert isinstance(TopologicalSorter, object)
+        assert isinstance(TopologicalSorter, object)


### PR DESCRIPTION
# READY FOR REVIEW.

This branch aims to solve problem of worker processor exit with code=127 on CI (Windows only).

Stack traces in a previous action shows the dump in `graphblas/core.py`. The run is linked [here](https://github.com/finos/opengris-scaler/actions/runs/26308601740/job/77451524560). I've reran the workflow for a few times, and it seems like the same error is not showing up.

Might be related: https://github.com/python-graphblas/python-graphblas/issues/559