### PR TITLE
scheduler: skip client heartbeat timeout for clients with in-flight tasks

### DIFF
--- a/src/scaler/scheduler/controllers/client_controller.py
+++ b/src/scaler/scheduler/controllers/client_controller.py
@@ -122,11 +122,25 @@ class VanillaClientController(ClientController, Looper, Reporter):
 
     async def __routine_cleanup_clients(self):
         now = time.time()
-        dead_clients = {
-            client
-            for client, (last_seen, info) in self._client_last_seen.items()
-            if now - last_seen > self._config_controller.get_config("client_timeout_seconds")
-        }
+        timeout = self._config_controller.get_config("client_timeout_seconds")
+        dead_clients = set()
+        for client, (last_seen, info) in self._client_last_seen.items():
+            if now - last_seen <= timeout:
+                continue
+            # Don't time out clients that still have tasks in flight. The
+            # heartbeat-based timeout is meant to detect clients whose
+            # network/process has gone away, but a client that is busy
+            # synchronously processing results (common in browser /
+            # emscripten clients running heavy Python user code) may
+            # legitimately fail to send heartbeats for extended periods
+            # while still being very much alive. The underlying transport
+            # (WebSocket / TCP) will report an actual connection close
+            # promptly, so it's safe to keep the client registered as long
+            # as it has outstanding work — the scheduler will see network
+            # close via the binder if the client really went away.
+            if self._client_to_task_ids.has_key(client) and len(self._client_to_task_ids.get_values(client)) > 0:
+                continue
+            dead_clients.add(client)
 
         for client in dead_clients:
             await self.__on_client_disconnect(client)

--- a/tests/scheduler/test_client_timeout_skips_busy_clients.py
+++ b/tests/scheduler/test_client_timeout_skips_busy_clients.py
@@ -1,0 +1,103 @@
+"""Unit test for the scheduler's heartbeat-timeout cleanup logic.
+
+Verifies the fix in ``VanillaClientController.__routine_cleanup_clients``: a
+client that is stale on heartbeats but still has outstanding tasks must NOT
+be disconnected. This is the exact failure mode hit by browser / Pyodide
+clients whose single asyncio event loop is starved by long synchronous user
+code and therefore can't send heartbeats while a workload runs.
+"""
+
+import asyncio
+import time
+import unittest
+from typing import Any
+
+from scaler.config.section.scheduler import SchedulerConfig
+from scaler.config.types.address import AddressConfig
+from scaler.protocol.capnp import ClientHeartbeat, Resource
+from scaler.scheduler.controllers.client_controller import VanillaClientController
+from scaler.scheduler.controllers.config_controller import VanillaConfigController
+from scaler.utility.identifiers import ClientID, TaskID
+
+
+class _StubObjectController:
+    def __init__(self) -> None:
+        self.cleaned: list = []
+
+    def clean_client(self, client_id: ClientID) -> None:
+        self.cleaned.append(client_id)
+
+
+class _StubTaskController:
+    def __init__(self) -> None:
+        self.canceled: list = []
+
+    async def on_task_cancel(self, client_id: ClientID, request: Any) -> None:
+        self.canceled.append((client_id, request))
+
+
+def _make_controller(timeout_seconds: int) -> VanillaClientController:
+    config = SchedulerConfig(
+        bind_address=AddressConfig.from_string("tcp://127.0.0.1:6378"),
+        object_storage_address=AddressConfig.from_string("tcp://127.0.0.1:6379"),
+        client_timeout_seconds=timeout_seconds,
+    )
+    controller = VanillaClientController(VanillaConfigController(config))
+    # The cleanup path may walk into disconnect → cancel-all-tasks → object
+    # cleanup. Stub just enough of those collaborators that the negative
+    # case (no in-flight tasks) cleanly exercises a full disconnect, and
+    # that a regression in the busy-client case surfaces as a clean
+    # ``assertIn`` failure rather than an ``AttributeError``.
+    controller._object_controller = _StubObjectController()  # type: ignore[assignment]
+    controller._task_controller = _StubTaskController()  # type: ignore[assignment]
+    return controller
+
+
+def _heartbeat() -> ClientHeartbeat:
+    return ClientHeartbeat(resource=Resource(cpu=0, rss=0), latencyUS=0)
+
+
+class TestClientTimeoutSkipsBusyClients(unittest.TestCase):
+    def test_stale_client_with_in_flight_task_is_not_disconnected(self):
+        """The scheduler must not time out a client that still owns tasks."""
+        timeout = 1
+        controller = _make_controller(timeout)
+        client = ClientID.generate_client_id("busy")
+        task = TaskID.generate_task_id()
+
+        # Heartbeat was a long time ago — well past client_timeout_seconds.
+        controller._client_last_seen[client] = (time.time() - (timeout + 10), _heartbeat())
+        controller.on_task_begin(client, task)
+
+        asyncio.new_event_loop().run_until_complete(controller.routine())
+
+        self.assertIn(client, controller._client_last_seen, "busy client must remain registered")
+        self.assertIn(task, controller.get_client_task_ids(client))
+
+    def test_stale_client_with_no_tasks_is_disconnected(self):
+        """The original timeout behaviour still applies to idle stale clients."""
+        timeout = 1
+        controller = _make_controller(timeout)
+        client = ClientID.generate_client_id("idle")
+
+        controller._client_last_seen[client] = (time.time() - (timeout + 10), _heartbeat())
+
+        asyncio.new_event_loop().run_until_complete(controller.routine())
+
+        self.assertNotIn(client, controller._client_last_seen, "idle stale client must be disconnected")
+
+    def test_fresh_client_is_not_disconnected(self):
+        """A client within the timeout window is never touched."""
+        timeout = 60
+        controller = _make_controller(timeout)
+        client = ClientID.generate_client_id("fresh")
+
+        controller._client_last_seen[client] = (time.time(), _heartbeat())
+
+        asyncio.new_event_loop().run_until_complete(controller.routine())
+
+        self.assertIn(client, controller._client_last_seen)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change was part of https://github.com/finos/opengris-scaler/pull/737

A client with in-flight tasks may legitimately fail to send heartbeats for extended periods while still being alive (e.g. clients running heavy synchronous Python user code). The transport layer (WebSocket/TCP) detects real connection loss promptly via the binder, so the heartbeat-based timeout should not race with long compute.

Generalizes the intent of test_death_timeout.py
test_no_timeout_if_suspended (clients running inside suspended processors must not be timed out) to any client with outstanding work.

Adds regression test verifying stale clients with in-flight tasks are not disconnected.