### PR TITLE
Rename 'Launch Cluster' to 'Launch Scheduler' in launchpad

### DIFF
--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -1612,7 +1612,7 @@ function App() {
           flexShrink: 0,
         }}
       >
-        Launch Cluster
+        Launch Scheduler
       </button>
     );
   } else if (phase === "ready") {


### PR DESCRIPTION
## Summary

- Renames the 'Launch Cluster' button to 'Launch Scheduler' in the launchpad UI