### PR TITLE
Fix bug ref count leak in Pymod

### DIFF
--- a/src/cpp/scaler/protocol/pymod/utility.cpp
+++ b/src/cpp/scaler/protocol/pymod/utility.cpp
@@ -683,7 +683,10 @@ OwnedPyObject<> capnp_union_init_method(PyObject* self, PyObject* args, PyObject
         PyErr_SetString(PyExc_ValueError, "requires exactly one active union field");
         return {};
     }
-    if (PyObject_SetAttrString(self, "_variant_name", PyUnicode_FromString(active_field)) < 0)
+    OwnedPyObject<> variant_name {PyUnicode_FromString(active_field)};
+    if (!variant_name)
+        return {};
+    if (PyObject_SetAttrString(self, "_variant_name", variant_name.get()) < 0)
         return {};
     if (capnp_struct_init(self, args, kwargs) < 0)
         return {};

--- a/tests/protocol/test_capnp.py
+++ b/tests/protocol/test_capnp.py
@@ -92,7 +92,8 @@ class TestCapnp(unittest.TestCase):
         # live references to the string are the instance dict and the temporary
         # created for the getrefcount() call, so a correct implementation reads 2.
         msg = Message(stateTask=StateTask(state=TaskState.success, taskId=b"t", functionName=b"f", worker=b"w"))
-        self.assertEqual(sys.getrefcount(msg._variant_name), 2)
+        # _variant_name is an internal runtime attribute (not in the type stub).
+        self.assertEqual(sys.getrefcount(getattr(msg, "_variant_name")), 2)
 
 
 if __name__ == "__main__":

--- a/tests/protocol/test_capnp.py
+++ b/tests/protocol/test_capnp.py
@@ -2,6 +2,7 @@
 semantics, union variant resolution, and error paths."""
 
 import gc
+import sys
 import unittest
 
 from scaler.io.utility import deserialize, serialize
@@ -81,6 +82,17 @@ class TestCapnp(unittest.TestCase):
         msg = Message.from_bytes(serialize(original))
         self.assertEqual(msg.stateTask.taskId, b"task")
         self.assertEqual(msg.stateTask.functionName, b"func")
+
+    def test_union_init_does_not_leak_variant_name(self):
+        # Constructing a union struct stamps _variant_name on the instance. The
+        # string returned by PyUnicode_FromString must be handed to SetAttrString
+        # without an extra reference: SetAttrString increfs (it does not steal), so
+        # passing the freshly-created reference straight in leaks one ref of the
+        # variant name on every construction (i.e. on every serialize()). The only
+        # live references to the string are the instance dict and the temporary
+        # created for the getrefcount() call, so a correct implementation reads 2.
+        msg = Message(stateTask=StateTask(state=TaskState.success, taskId=b"t", functionName=b"f", worker=b"w"))
+        self.assertEqual(sys.getrefcount(msg._variant_name), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# READY FOR REVIEW.

`PyUnicode_FromString`:
> Return value: New reference. Part of the [Stable ABI](https://docs.python.org/3/c-api/stable.html#stable).


