### PR TITLE
Launchpad: policy panel, config load/save, WM reordering, OCI budget cap

### DIFF
--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -238,7 +238,7 @@ function WorkerManagerCard({
             value={wm.type}
             onChange={(v) => {
               if (v === "oci_raw") {
-                onChange({ ...wm, type: v, ociShape: "CI.Standard.A1.Flex", ociContainerImage: "ghcr.io/finos/scaler:latest-arm64" });
+                onChange({ ...wm, type: v, ociShape: "CI.Standard.A1.Flex", ociContainerImage: "ghcr.io/finos/scaler:latest-arm64", capMode: "instances", instanceCap: 4, budgetCap: 10 });
               } else {
                 set("type", v);
               }
@@ -522,6 +522,9 @@ function WorkerManagerCard({
         const ociShape = wm.ociShape || "CI.Standard.A1.Flex";
         const ociPricing = OCI_SHAPE_PRICING[ociShape] || OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
         const ociCostPerHr = ociPricing.ocpuPrice * (wm.ociOcpus || 4) + ociPricing.memPrice * (wm.ociMemoryGb || 30);
+        const derivedCount = wm.capMode === "instances"
+          ? Math.max(0, wm.instanceCap || 0)
+          : Math.max(0, Math.floor((wm.budgetCap || 0) / (ociCostPerHr || 1)));
         return (
           <>
             <div>
@@ -591,6 +594,45 @@ function WorkerManagerCard({
               </div>
             </div>
             <div>
+              <Label help="Maximum number of OCI container instances to run simultaneously. In budget mode, the cap is derived from your hourly USD budget divided by the per-instance cost.">Budget</Label>
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                {wm.capMode === "instances" ? (
+                  <NumericStepper
+                    value={wm.instanceCap || 1}
+                    onChange={(v) => set("instanceCap", v)}
+                    min={1}
+                    max={1000}
+                  />
+                ) : (
+                  <NumericStepper
+                    value={wm.budgetCap || 10}
+                    onChange={(v) => set("budgetCap", v)}
+                    min={0}
+                    step={0.5}
+                    width={64}
+                  />
+                )}
+                <select
+                  value={wm.capMode || "instances"}
+                  onChange={(e) => set("capMode", e.target.value)}
+                  style={{
+                    background: "var(--bg-surface)",
+                    border: "1px solid var(--border-accent)",
+                    borderRadius: 3,
+                    padding: "6px 8px",
+                    color: "var(--text-primary)",
+                    fontFamily: "inherit",
+                    fontSize: 11,
+                    outline: "none",
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="budget">USD/h cap</option>
+                  <option value="instances">instance cap</option>
+                </select>
+              </div>
+            </div>
+            <div>
               <Label help={"- Installed inside the container instance\n- opengris-scaler must be included"}>requirements.txt</Label>
               <textarea
                 value={wm.requirements || ""}
@@ -640,9 +682,9 @@ function WorkerManagerCard({
                 </span>
               </div>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderTop: "1px solid var(--border-success)", paddingTop: 4, marginTop: 2 }}>
-                <span style={{ fontSize: 10, color: "var(--text-muted)" }}>Total</span>
+                <span style={{ fontSize: 10, color: "var(--text-muted)" }}>Total ({derivedCount} instance{derivedCount !== 1 ? "s" : ""})</span>
                 <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-success)" }}>
-                  USD {ociCostPerHr.toFixed(2)}/h
+                  USD {(derivedCount * ociCostPerHr).toFixed(2)}/h
                 </span>
               </div>
             </div>
@@ -1345,7 +1387,7 @@ function App() {
       id: "wm-1",
       type: "orb_aws_ec2",
       instanceType: "t3.medium",
-      capMode: "budget",
+      capMode: "instances",
       instanceCap: 4,
       budgetCap: 10,
       requirements: "opengris-scaler[all]",
@@ -1469,7 +1511,11 @@ function App() {
     if (wm.type === "oci_raw") {
       const shape = wm.ociShape || "CI.Standard.A1.Flex";
       const pricing = OCI_SHAPE_PRICING[shape] || OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
-      return pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 30);
+      const costPerInstance = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 30);
+      const count = wm.capMode === "instances"
+        ? Math.max(0, wm.instanceCap || 0)
+        : Math.max(0, Math.floor((wm.budgetCap || 0) / (costPerInstance || 1)));
+      return count * costPerInstance;
     }
     return 0;
   });
@@ -1487,7 +1533,7 @@ function App() {
         id: newId,
         type: "orb_aws_ec2",
         instanceType: "t3.medium",
-        capMode: "budget",
+        capMode: "instances",
         instanceCap: 4,
         budgetCap: 10,
         requirements: "opengris-scaler[all]",
@@ -2825,14 +2871,17 @@ function App() {
                     const shape = wm.ociShape || "CI.Standard.A1.Flex";
                     const shapeName = shape === "CI.Standard.A1.Flex" ? "ARM - Ampere A1" : "x86 - Standard E4";
                     const pricing = OCI_SHAPE_PRICING[shape] || OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
-                    const cost = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 30);
+                    const costPerInstance = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 30);
+                    const count = wm.capMode === "instances"
+                      ? Math.max(0, wm.instanceCap || 0)
+                      : Math.max(0, Math.floor((wm.budgetCap || 0) / (costPerInstance || 1)));
                     return (
                       <div key={wm._uid} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
                         <span style={{ fontSize: 10, color: "var(--text-muted)" }}>
-                          {label} · {shapeName} · {wm.ociOcpus || 4} OCPU · {wm.ociMemoryGb || 30}GB
+                          {label} · {count}× {shapeName} · {wm.ociOcpus || 4} OCPU · {wm.ociMemoryGb || 30}GB
                         </span>
                         <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
-                          USD {cost.toFixed(2)}/h
+                          USD {(count * costPerInstance).toFixed(2)}/h
                         </span>
                       </div>
                     );

--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -2946,8 +2946,7 @@ function App() {
             </div>
           </div>
 
-          {phase === "idle" && (
-            <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
               <button
                 onClick={handleDownloadConfig}
                 style={{
@@ -2990,7 +2989,6 @@ function App() {
                 onChange={handleLoadConfig}
               />
             </div>
-          )}
         </div>
       </div>
 

--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -1321,6 +1321,7 @@ function App() {
   const [transport, setTransport] = useState("ws");
   const [networkBackend, setNetBack] = useState("ymq");
   const [pythonVersion, setPyVer] = useState("3.13");
+  const [policy, setPolicy] = useState("simple");
   const [schedulerRequirements, setSchedulerReqs] = useState(
     "opengris-scaler[all]",
   );
@@ -1337,6 +1338,7 @@ function App() {
   );
 
   const wmCounterRef = useRef(1);
+  const loadConfigInputRef = useRef(null);
   const [workerManagers, setWorkerManagers] = useState([
     {
       _uid: 1,
@@ -1350,6 +1352,8 @@ function App() {
     },
   ]);
   const [selectedWmId, setSelectedWmId] = useState("wm-1");
+  const [draggedWmId, setDraggedWmId] = useState(null);
+  const [dragOverWmId, setDragOverWmId] = useState(null);
 
   const [phase, setPhase] = useState(() => {
     try {
@@ -1505,7 +1509,6 @@ function App() {
       ),
     [],
   );
-
   const hasCredentials =
     accessKeyId.trim().length > 0 && secretKey.trim().length > 0;
 
@@ -1795,6 +1798,7 @@ function App() {
       schedulerPort,
       objectStoragePort,
       pythonVersion,
+      policy,
       workerManagers: workerManagers.map((wm) => ({
         ...wm,
         requirements: wm.requirements,
@@ -1808,8 +1812,36 @@ function App() {
     schedulerPort,
     objectStoragePort,
     pythonVersion,
+    policy,
     workerManagers,
   ]);
+
+  const handleLoadConfig = useCallback((e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    e.target.value = "";
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const toml = parseConfigToml(ev.target.result);
+        const cfg = configFromToml(toml);
+        if (cfg.transport) setTransport(cfg.transport);
+        if (cfg.schedulerPort) setSchedPort(cfg.schedulerPort);
+        if (cfg.objectStoragePort) setObjPort(cfg.objectStoragePort);
+        if (cfg.pythonVersion) setPyVer(cfg.pythonVersion);
+        if (cfg.region) setRegion(cfg.region);
+        if (cfg.policy) setPolicy(cfg.policy);
+        if (cfg.workerManagers && cfg.workerManagers.length) {
+          setWorkerManagers(cfg.workerManagers);
+          wmCounterRef.current = cfg.workerManagers.length;
+          setSelectedWmId(cfg.workerManagers[0].id);
+        }
+      } catch (err) {
+        window.alert("Failed to load config.toml: " + err.message);
+      }
+    };
+    reader.readAsText(file);
+  }, []);
 
   const handleReset = useCallback(() => {
     setLog([]);
@@ -2365,7 +2397,7 @@ function App() {
 
             {/* Column 2: Scheduler EC2 + Policy */}
             <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <PanelBox title="Scheduler">
+              <PanelBox title="Scheduler (AWS-only)">
                 <div>
                   <Label help="EC2 instance type for the scheduler. Compute-optimized (c5/c6i) works well for most deployments.">
                     Instance Type
@@ -2478,77 +2510,26 @@ function App() {
                 </div>
               </PanelBox>
 
-              {/* Policy panel — display only, not yet wired up */}
-              <div
-                style={{
-                  opacity: 0.45,
-                  pointerEvents: "none",
-                  userSelect: "none",
-                }}
-              >
-                <PanelBox title="Policy">
-                  {[
-                    {
-                      label: "Engine",
-                      help: "Policy engine that controls task allocation and worker scaling.",
-                      options: ["simple", "waterfall_v1"],
-                    },
-                    {
-                      label: "Allocate",
-                      help: "How tasks are assigned to workers. even_load distributes work evenly; capability routes tasks to workers that advertise matching capabilities.",
-                      options: ["even_load", "capability"],
-                    },
-                    {
-                      label: "Scaling",
-                      help: "How the scheduler scales worker counts up or down. vanilla uses a task-to-worker ratio; capability scales per-capability group; no disables autoscaling.",
-                      options: ["vanilla", "no", "capability"],
-                    },
-                  ].map(({ label, help, options }) => (
-                    <div key={label}>
-                      <Label help={help}>{label}</Label>
-                      <div style={{ position: "relative" }}>
-                        <select
-                          disabled
-                          style={{
-                            width: "100%",
-                            background: "var(--bg-surface)",
-                            border: "1px solid var(--border-accent)",
-                            borderRadius: 3,
-                            padding: "7px 28px 7px 10px",
-                            color: "var(--text-primary)",
-                            fontFamily: "inherit",
-                            fontSize: 12,
-                            outline: "none",
-                            appearance: "none",
-                            WebkitAppearance: "none",
-                          }}
-                        >
-                          {options.map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
-                        </select>
-                        <span
-                          style={{
-                            position: "absolute",
-                            right: 10,
-                            top: "50%",
-                            display: "block",
-                            width: 7,
-                            height: 7,
-                            borderRight: "1.5px solid var(--text-muted)",
-                            borderBottom: "1.5px solid var(--text-muted)",
-                            transform: "rotate(45deg)",
-                            marginTop: "-5px",
-                            pointerEvents: "none",
-                          }}
-                        />
-                      </div>
+              <PanelBox title="Policy">
+                <div>
+                  <Label help="Policy engine that controls task allocation and worker scaling.">
+                    Engine
+                  </Label>
+                  <PolicyDropdown value={policy} onChange={setPolicy} />
+                  {policy === "waterfall_v1" && (
+                    <div
+                      style={{
+                        marginTop: 8,
+                        fontSize: 10,
+                        color: "var(--text-dim)",
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      Priority is based on ordering in the Worker Managers pane. Drag to reorder.
                     </div>
-                  ))}
-                </PanelBox>
-              </div>
+                  )}
+                </div>
+              </PanelBox>
             </div>
 
             {/* Column 3: Worker Managers + Cost Summary */}
@@ -2578,29 +2559,104 @@ function App() {
                       alignSelf: "flex-start",
                     }}
                   >
-                    {workerManagers.map((wm) => (
+                    {workerManagers.map((wm, wmIdx) => (
                       <div
                         key={wm.id}
+                        onDragOver={(e) => {
+                          e.preventDefault();
+                          e.dataTransfer.dropEffect = "move";
+                          if (wm.id !== draggedWmId) setDragOverWmId(wm.id);
+                        }}
+                        onDragLeave={(e) => {
+                          if (!e.currentTarget.contains(e.relatedTarget))
+                            setDragOverWmId(null);
+                        }}
+                        onDrop={(e) => {
+                          e.preventDefault();
+                          if (draggedWmId && wm.id !== draggedWmId) {
+                            setWorkerManagers((prev) => {
+                              const from = prev.findIndex((w) => w.id === draggedWmId);
+                              const to = prev.findIndex((w) => w.id === wm.id);
+                              if (from === -1 || to === -1) return prev;
+                              const next = [...prev];
+                              const [item] = next.splice(from, 1);
+                              next.splice(to, 0, item);
+                              return next;
+                            });
+                          }
+                          setDraggedWmId(null);
+                          setDragOverWmId(null);
+                        }}
+                        onDragEnd={() => {
+                          setDraggedWmId(null);
+                          setDragOverWmId(null);
+                        }}
                         style={{
                           display: "flex",
                           alignItems: "stretch",
                           background:
-                            selectedWmId === wm.id
-                              ? "rgba(0,200,224,0.1)"
-                              : "transparent",
+                            dragOverWmId === wm.id
+                              ? "rgba(0,200,224,0.18)"
+                              : selectedWmId === wm.id
+                                ? "rgba(0,200,224,0.1)"
+                                : "transparent",
                           borderLeft:
                             selectedWmId === wm.id
                               ? "2px solid var(--tab-active)"
                               : "2px solid transparent",
                           borderBottom: "1px solid rgba(255,255,255,0.04)",
-                          transition: "background 0.12s",
+                          transition: "background 0.1s",
+                          opacity: draggedWmId === wm.id ? 0.4 : 1,
                         }}
                       >
+                        {workerManagers.length > 1 && (
+                          <div
+                            draggable={true}
+                            onDragStart={(e) => {
+                              setDraggedWmId(wm.id);
+                              e.dataTransfer.effectAllowed = "move";
+                              e.dataTransfer.setData("text/plain", wm.id);
+                            }}
+                            style={{
+                              cursor: "grab",
+                              display: "flex",
+                              alignItems: "center",
+                              padding: "0 3px 0 7px",
+                              flexShrink: 0,
+                              color: "var(--text-dim)",
+                              userSelect: "none",
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.color = "var(--text-muted)";
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.color = "var(--text-dim)";
+                            }}
+                          >
+                            <svg
+                              width="8"
+                              height="12"
+                              viewBox="0 0 8 12"
+                              fill="currentColor"
+                              style={{ display: "block" }}
+                            >
+                              <circle cx="2" cy="2" r="1.5" />
+                              <circle cx="6" cy="2" r="1.5" />
+                              <circle cx="2" cy="6" r="1.5" />
+                              <circle cx="6" cy="6" r="1.5" />
+                              <circle cx="2" cy="10" r="1.5" />
+                              <circle cx="6" cy="10" r="1.5" />
+                            </svg>
+                          </div>
+                        )}
                         <button
                           title={wm.id}
                           onClick={() => setSelectedWmId(wm.id)}
                           style={{
                             flex: 1,
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
                             background: "transparent",
                             border: "none",
                             color:
@@ -2609,18 +2665,40 @@ function App() {
                                 : "var(--text-muted)",
                             fontFamily: "inherit",
                             fontSize: 10,
-                            padding: "10px 6px 10px 10px",
+                            padding: workerManagers.length > 1 ? "10px 4px 10px 4px" : "10px 4px 10px 10px",
                             textAlign: "left",
                             cursor: "pointer",
                             letterSpacing: "0.05em",
                             transition: "color 0.12s",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
                             minWidth: 0,
+                            overflow: "hidden",
                           }}
                         >
-                          {wm.id}
+                          {policy === "waterfall_v1" && (
+                            <span
+                              style={{
+                                fontSize: 8,
+                                fontWeight: 700,
+                                lineHeight: 1,
+                                color: "var(--accent-cyan)",
+                                background: "rgba(0,200,224,0.12)",
+                                borderRadius: 2,
+                                padding: "2px 3px",
+                                flexShrink: 0,
+                              }}
+                            >
+                              {wmIdx + 1}
+                            </span>
+                          )}
+                          <span
+                            style={{
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {wm.id}
+                          </span>
                         </button>
                         {workerManagers.length > 1 && (
                           <button
@@ -2642,23 +2720,14 @@ function App() {
                               transition: "color 0.12s",
                             }}
                             onMouseEnter={(e) => {
-                              e.currentTarget.style.color =
-                                "var(--text-danger)";
-                              e.currentTarget.querySelector(
-                                "span",
-                              ).style.borderColor = "var(--border-danger)";
-                              e.currentTarget.querySelector(
-                                "span",
-                              ).style.background = "rgba(229,72,77,0.08)";
+                              e.currentTarget.style.color = "var(--text-danger)";
+                              e.currentTarget.querySelector("span").style.borderColor = "var(--border-danger)";
+                              e.currentTarget.querySelector("span").style.background = "rgba(229,72,77,0.08)";
                             }}
                             onMouseLeave={(e) => {
                               e.currentTarget.style.color = "var(--text-muted)";
-                              e.currentTarget.querySelector(
-                                "span",
-                              ).style.borderColor = "var(--border-accent)";
-                              e.currentTarget.querySelector(
-                                "span",
-                              ).style.background = "transparent";
+                              e.currentTarget.querySelector("span").style.borderColor = "var(--border-accent)";
+                              e.currentTarget.querySelector("span").style.background = "transparent";
                             }}
                           >
                             <span
@@ -2670,8 +2739,7 @@ function App() {
                                 height: 14,
                                 border: "1px solid var(--border-accent)",
                                 borderRadius: 2,
-                                transition:
-                                  "border-color 0.12s, background 0.12s",
+                                transition: "border-color 0.12s, background 0.12s",
                               }}
                             >
                               ✕
@@ -2848,6 +2916,30 @@ function App() {
               >
                 Download config.toml
               </button>
+              <button
+                onClick={() => loadConfigInputRef.current && loadConfigInputRef.current.click()}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--text-muted)",
+                  fontFamily: "inherit",
+                  fontSize: 10,
+                  padding: 0,
+                  letterSpacing: "0.06em",
+                  textDecoration: "underline",
+                  textDecorationColor: "var(--border-accent)",
+                }}
+              >
+                Load config.toml
+              </button>
+              <input
+                ref={loadConfigInputRef}
+                type="file"
+                accept=".toml"
+                style={{ display: "none" }}
+                onChange={handleLoadConfig}
+              />
             </div>
           )}
         </div>

--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -521,7 +521,7 @@ function WorkerManagerCard({
       {wm.type === "oci_raw" && (() => {
         const ociShape = wm.ociShape || "CI.Standard.A1.Flex";
         const ociPricing = OCI_SHAPE_PRICING[ociShape] || OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
-        const ociCostPerHr = ociPricing.ocpuPrice * (wm.ociOcpus || 4) + ociPricing.memPrice * (wm.ociMemoryGb || 30);
+        const ociCostPerHr = ociPricing.ocpuPrice * (wm.ociOcpus || 4) + ociPricing.memPrice * (wm.ociMemoryGb || 8);
         const derivedCount = wm.capMode === "instances"
           ? Math.max(0, wm.instanceCap || 0)
           : Math.max(0, Math.floor((wm.budgetCap || 0) / (ociCostPerHr || 1)));
@@ -586,7 +586,7 @@ function WorkerManagerCard({
               <div style={{ flex: 1 }}>
                 <Label help="Memory in GB for the container instance. Must satisfy OCI's minimum memory-per-OCPU ratio for your chosen shape.">Memory (GB)</Label>
                 <NumericStepper
-                  value={wm.ociMemoryGb || 30}
+                  value={wm.ociMemoryGb || 8}
                   onChange={(v) => set("ociMemoryGb", v)}
                   min={1}
                   max={512}
@@ -675,10 +675,10 @@ function WorkerManagerCard({
               </div>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
                 <span style={{ fontSize: 10, color: "var(--text-dim)" }}>
-                  {wm.ociMemoryGb || 30} GB × ${ociPricing.memPrice.toFixed(3)}/h
+                  {wm.ociMemoryGb || 8} GB × ${ociPricing.memPrice.toFixed(3)}/h
                 </span>
                 <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
-                  ${(ociPricing.memPrice * (wm.ociMemoryGb || 30)).toFixed(2)}/h
+                  ${(ociPricing.memPrice * (wm.ociMemoryGb || 8)).toFixed(2)}/h
                 </span>
               </div>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderTop: "1px solid var(--border-success)", paddingTop: 4, marginTop: 2 }}>
@@ -1511,7 +1511,7 @@ function App() {
     if (wm.type === "oci_raw") {
       const shape = wm.ociShape || "CI.Standard.A1.Flex";
       const pricing = OCI_SHAPE_PRICING[shape] || OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
-      const costPerInstance = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 30);
+      const costPerInstance = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 8);
       const count = wm.capMode === "instances"
         ? Math.max(0, wm.instanceCap || 0)
         : Math.max(0, Math.floor((wm.budgetCap || 0) / (costPerInstance || 1)));
@@ -2871,14 +2871,14 @@ function App() {
                     const shape = wm.ociShape || "CI.Standard.A1.Flex";
                     const shapeName = shape === "CI.Standard.A1.Flex" ? "ARM - Ampere A1" : "x86 - Standard E4";
                     const pricing = OCI_SHAPE_PRICING[shape] || OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
-                    const costPerInstance = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 30);
+                    const costPerInstance = pricing.ocpuPrice * (wm.ociOcpus || 4) + pricing.memPrice * (wm.ociMemoryGb || 8);
                     const count = wm.capMode === "instances"
                       ? Math.max(0, wm.instanceCap || 0)
                       : Math.max(0, Math.floor((wm.budgetCap || 0) / (costPerInstance || 1)));
                     return (
                       <div key={wm._uid} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
                         <span style={{ fontSize: 10, color: "var(--text-muted)" }}>
-                          {label} · {count}× {shapeName} · {wm.ociOcpus || 4} OCPU · {wm.ociMemoryGb || 30}GB
+                          {label} · {count}× {shapeName} · {wm.ociOcpus || 4} OCPU · {wm.ociMemoryGb || 8}GB
                         </span>
                         <span style={{ fontSize: 12, color: "var(--text-secondary)" }}>
                           USD {(count * costPerInstance).toFixed(2)}/h

--- a/docs/html_extra/launchpad/components.jsx
+++ b/docs/html_extra/launchpad/components.jsx
@@ -1627,7 +1627,7 @@ function SchedulerLogTerminal({ instanceId, region, credentials, isActive }) {
             DocumentName: "AWS-RunShellScript",
             Parameters: {
               commands: [
-                "tail -n 150 /var/log/scaler.log 2>/dev/null || echo '(log not yet available)'",
+                "cat /var/log/scaler.log 2>/dev/null || echo '(log not yet available)'",
               ],
             },
             TimeoutSeconds: 30,

--- a/docs/html_extra/launchpad/components.jsx
+++ b/docs/html_extra/launchpad/components.jsx
@@ -2119,6 +2119,157 @@ function WorkerManagerTypeSelect({ value, onChange }) {
   );
 }
 
+/* ── PolicyDropdown ── */
+const POLICY_OPTIONS = [
+  {
+    value: "simple",
+    label: "Load Balancer",
+    desc: "Distributes tasks evenly across all configured worker managers.",
+  },
+  {
+    value: "waterfall_v1",
+    label: "Waterfall",
+    desc: "Fills worker managers in priority order, spilling to the next only when the current is saturated.",
+  },
+  {
+    value: null,
+    label: "Lowest Cost (greedy)",
+    desc: "Routes tasks to the cheapest available worker manager. Not yet implemented.",
+    disabled: true,
+  },
+];
+
+function PolicyDropdown({ value, onChange }) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef(null);
+  const dropdownRef = useRef(null);
+  const [dropdownStyle, setDropdownStyle] = useState({});
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (
+        triggerRef.current && !triggerRef.current.contains(e.target) &&
+        dropdownRef.current && !dropdownRef.current.contains(e.target)
+      ) setOpen(false);
+    }
+    function handleScroll() { setOpen(false); }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("scroll", handleScroll, true);
+    };
+  }, []);
+
+  const openDropdown = () => {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setDropdownStyle({ position: "fixed", top: r.bottom + 4, left: r.left, width: r.width });
+    setOpen(true);
+  };
+
+  const selected = POLICY_OPTIONS.find((o) => o.value === value) || POLICY_OPTIONS[0];
+
+  return (
+    <div ref={triggerRef} style={{ position: "relative" }}>
+      <button
+        onClick={() => (open ? setOpen(false) : openDropdown())}
+        style={{
+          width: "100%",
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-accent)",
+          borderRadius: 3,
+          padding: "8px 10px",
+          color: "var(--text-primary)",
+          fontFamily: "inherit",
+          fontSize: 12,
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          textAlign: "left",
+          outline: "none",
+        }}
+      >
+        <span style={{ flex: 1, color: "var(--text-secondary)", fontWeight: 600 }}>
+          {selected.label}
+        </span>
+        <span
+          style={{
+            display: "inline-block",
+            width: 7,
+            height: 7,
+            borderRight: "1.5px solid var(--text-muted)",
+            borderBottom: "1.5px solid var(--text-muted)",
+            transform: open ? "rotate(225deg)" : "rotate(45deg)",
+            position: "relative",
+            top: open ? "2px" : "-2px",
+            flexShrink: 0,
+          }}
+        />
+      </button>
+      {open && ReactDOM.createPortal(
+        <div
+          ref={dropdownRef}
+          style={{
+            ...dropdownStyle,
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border-strong)",
+            borderRadius: 4,
+            zIndex: 9999,
+            boxShadow: "0 16px 48px rgba(0,0,0,0.7)",
+            overflow: "hidden",
+          }}
+        >
+          {POLICY_OPTIONS.map((opt) => (
+            <div
+              key={opt.label}
+              onClick={() => {
+                if (!opt.disabled) { onChange(opt.value); setOpen(false); }
+              }}
+              style={{
+                padding: "10px 12px",
+                cursor: opt.disabled ? "not-allowed" : "pointer",
+                background: opt.value === value ? "rgba(0,200,224,0.08)" : "transparent",
+                borderBottom: "1px solid rgba(255,255,255,0.04)",
+                opacity: opt.disabled ? 0.45 : 1,
+              }}
+              onMouseEnter={(e) => {
+                if (!opt.disabled && opt.value !== value)
+                  e.currentTarget.style.background = "var(--bg-surface)";
+              }}
+              onMouseLeave={(e) => {
+                if (!opt.disabled && opt.value !== value)
+                  e.currentTarget.style.background = "transparent";
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                <span style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: opt.value === value
+                    ? "var(--text-success)"
+                    : opt.disabled ? "var(--text-dim)" : "var(--text-primary)",
+                }}>
+                  {opt.label}
+                </span>
+                {opt.value === value && (
+                  <span style={{ color: "var(--text-success)", fontSize: 10, flexShrink: 0 }}>✓</span>
+                )}
+              </div>
+              <span style={{ display: "block", fontSize: 10, color: "var(--text-dim)", marginTop: 2 }}>
+                {opt.desc}
+              </span>
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}
+
 Object.assign(window, {
   SecretInput,
   RegionSelect,
@@ -2131,4 +2282,5 @@ Object.assign(window, {
   LiveTerminal,
   SchedulerLogTerminal,
   WorkerManagerTypeSelect,
+  PolicyDropdown,
 });

--- a/docs/html_extra/launchpad/index.html
+++ b/docs/html_extra/launchpad/index.html
@@ -26,6 +26,11 @@
     ></script>
     <!-- AWS SDK v2 for browser — pin this version for production -->
     <script src="https://unpkg.com/aws-sdk@2.1692.0/dist/aws-sdk.min.js"></script>
+    <script
+      src="https://unpkg.com/@ltd/j-toml@1.38.0/index.js"
+      integrity="sha384-rYNcgZhiOG0q5gH33zxhpG1RSdt3/O7tXexBvVR2dU1a6ExjDCxTUR6pTV7gKub9"
+      crossorigin="anonymous"
+    ></script>
     <script src="data.js"></script>
     <script type="text/babel" src="components.jsx"></script>
     <style>

--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -29,6 +29,11 @@ const _ORB_INLINE_POLICY = JSON.stringify({
   ],
 });
 
+const _OCI_SHAPE_PRICING = {
+  "CI.Standard.A1.Flex": { ocpuPrice: 0.013106, memPrice: 0.0019659 },
+  "CI.Standard.E4.Flex": { ocpuPrice: 0.032765, memPrice: 0.0019659 },
+};
+
 function randomSuffix(n) {
   n = n || 8;
   var chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -186,6 +191,11 @@ job_timeout_minutes = ${wm.jobTimeoutMinutes || 60}
 `;
       } else if (wm.type === "oci_raw") {
         var ociRawReq = (wm.requirements || "").trim();
+        var ociRawPricing = _OCI_SHAPE_PRICING[wm.ociShape || "CI.Standard.A1.Flex"] || _OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
+        var ociRawCostPerInstance = ociRawPricing.ocpuPrice * (wm.ociOcpus || 4) + ociRawPricing.memPrice * (wm.ociMemoryGb || 30);
+        var ociRawDerivedCount = wm.capMode === "instances"
+          ? Math.max(0, wm.instanceCap || 0)
+          : Math.max(0, Math.floor((wm.budgetCap || 0) / (ociRawCostPerInstance || 1)));
         block += `worker_scheduler_address = "${proto}://$PUBLIC_IP:${sp}${wsSlash}"
 oci_region = "${wm.ociRegion || "us-ashburn-1"}"
 `;
@@ -197,6 +207,7 @@ container_image = "${wm.ociContainerImage || ""}"
         block += `instance_shape = "${wm.ociShape || "CI.Standard.E4.Flex"}"
 instance_ocpus = ${wm.ociOcpus || 4}
 instance_memory_gb = ${wm.ociMemoryGb || 30}
+max_task_concurrency = ${ociRawDerivedCount * (wm.ociOcpus || 4)}
 python_version = "${cfg.pythonVersion}"
 requirements_txt = """
 ${ociRawReq}
@@ -288,7 +299,7 @@ function configFromToml(toml) {
     if (wm.type === "orb_aws_ec2") {
       return Object.assign(base, {
         instanceType: wm.instance_type || "t3.medium",
-        capMode: "budget",
+        capMode: "instances",
         instanceCap: 4,
         budgetCap: 10,
         requirements: wm.requirements_txt || "opengris-scaler[all]",
@@ -315,9 +326,13 @@ function configFromToml(toml) {
       });
     }
     if (wm.type === "oci_raw") {
+      var ociOcpus = wm.instance_ocpus || 4;
+      var ociInstanceCap = wm.max_task_concurrency != null
+        ? Math.max(1, Math.round(wm.max_task_concurrency / ociOcpus))
+        : 4;
       return Object.assign(base, {
         ociShape: wm.instance_shape || "CI.Standard.A1.Flex",
-        ociOcpus: wm.instance_ocpus || 4,
+        ociOcpus: ociOcpus,
         ociMemoryGb: wm.instance_memory_gb || 30,
         ociRegion: wm.oci_region || "",
         ociCompartmentId: wm.compartment_id || "",
@@ -325,6 +340,9 @@ function configFromToml(toml) {
         ociSubnetId: wm.subnet_id || "",
         ociContainerImage: wm.container_image || "",
         requirements: wm.requirements_txt || "",
+        capMode: "instances",
+        instanceCap: ociInstanceCap,
+        budgetCap: 10,
       });
     }
     if (wm.type === "oci_hpc") {
@@ -493,6 +511,11 @@ job_timeout_minutes = ${wm.jobTimeoutMinutes || 60}
 `;
       } else if (wm.type === "oci_raw") {
         var ociRawReq = (wm.requirements || "").trim();
+        var ociRawPricing = _OCI_SHAPE_PRICING[wm.ociShape || "CI.Standard.A1.Flex"] || _OCI_SHAPE_PRICING["CI.Standard.A1.Flex"];
+        var ociRawCostPerInstance = ociRawPricing.ocpuPrice * (wm.ociOcpus || 4) + ociRawPricing.memPrice * (wm.ociMemoryGb || 30);
+        var ociRawDerivedCount = wm.capMode === "instances"
+          ? Math.max(0, wm.instanceCap || 0)
+          : Math.max(0, Math.floor((wm.budgetCap || 0) / (ociRawCostPerInstance || 1)));
         block += `worker_scheduler_address = "${proto}://$PUBLIC_IP:${sp}${wsSlash}"
 oci_region = "${wm.ociRegion || "us-ashburn-1"}"
 `;
@@ -504,6 +527,7 @@ container_image = "${wm.ociContainerImage || ""}"
         block += `instance_shape = "${wm.ociShape || "CI.Standard.E4.Flex"}"
 instance_ocpus = ${wm.ociOcpus || 4}
 instance_memory_gb = ${wm.ociMemoryGb || 30}
+max_task_concurrency = ${ociRawDerivedCount * (wm.ociOcpus || 4)}
 python_version = "${cfg.pythonVersion}"
 requirements_txt = """
 ${ociRawReq}

--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -233,6 +233,15 @@ object_storage_address = "${proto}://127.0.0.1:${op}${wsSlash}"
     })
     .join("\n");
 
+  var policyEngineType = cfg.policy || "simple";
+  var policyContentLine = "";
+  if (policyEngineType === "waterfall_v1" && cfg.workerManagers && cfg.workerManagers.length > 0) {
+    var policyLines = cfg.workerManagers.map(function(wm, idx) {
+      return (idx + 1) + "," + wm.id;
+    }).join("\n");
+    policyContentLine = `policy_content = """\n${policyLines}\n"""\n`;
+  }
+
   return `[object_storage_server]
 bind_address = "${proto}://0.0.0.0:${op}${wsSlash}"
 
@@ -241,11 +250,146 @@ bind_address = "${proto}://0.0.0.0:${sp}${wsSlash}"
 object_storage_address = "${proto}://127.0.0.1:${op}${wsSlash}"
 advertised_object_storage_address = "${proto}://<PUBLIC_IP>:${op}${wsSlash}"
 
+[scheduler.policy]
+policy_engine_type = "${policyEngineType}"
+${policyContentLine}
 ${wmToml}
 [gui]
 monitor_address = "${proto}://127.0.0.1:${sp + 2}${wsSlash}"
 gui_address = "0.0.0.0:50001"
 `;
+}
+
+function parseConfigToml(text) {
+  return TOML.parse(text, 1, "\n");
+}
+
+function configFromToml(toml) {
+  var scheduler = toml.scheduler || {};
+  var schedBind = scheduler.bind_address || "";
+  var objBind = (toml.object_storage_server || {}).bind_address || "";
+
+  function extractPort(addr) {
+    var m = addr.match(/:(\d+)/);
+    return m ? parseInt(m[1], 10) : null;
+  }
+
+  var proto = schedBind.slice(0, 3) === "tcp" ? "tcp" : "ws";
+  var schedulerPort = extractPort(schedBind) || 6788;
+  var objectStoragePort = extractPort(objBind) || 6789;
+
+  var rawWms = toml.worker_manager || [];
+  var workerManagers = rawWms.map(function(wm, idx) {
+    var base = {
+      _uid: idx + 1,
+      id: wm.worker_manager_id || ("wm-" + (idx + 1)),
+      type: wm.type || "orb_aws_ec2",
+    };
+    if (wm.type === "orb_aws_ec2") {
+      return Object.assign(base, {
+        instanceType: wm.instance_type || "t3.medium",
+        capMode: "budget",
+        instanceCap: 4,
+        budgetCap: 10,
+        requirements: wm.requirements_txt || "opengris-scaler[all]",
+      });
+    }
+    if (wm.type === "aws_raw_ecs") {
+      return Object.assign(base, {
+        ecsCluster: wm.ecs_cluster || "",
+        ecsTaskImage: wm.ecs_task_image || "",
+        ecsSubnets: wm.ecs_subnets || "",
+        ecsTaskDefinition: wm.ecs_task_definition || "",
+        ecsTaskCpu: wm.ecs_task_cpu || 4,
+        ecsTaskMemory: wm.ecs_task_memory || 30,
+      });
+    }
+    if (wm.type === "aws_hpc") {
+      return Object.assign(base, {
+        jobQueue: wm.job_queue || "",
+        jobDefinition: wm.job_definition || "",
+        s3Bucket: wm.s3_bucket || "",
+        s3Prefix: wm.s3_prefix || "scaler-tasks",
+        maxConcurrentJobs: wm.max_concurrent_jobs || 100,
+        jobTimeoutMinutes: wm.job_timeout_minutes || 60,
+      });
+    }
+    if (wm.type === "oci_raw") {
+      return Object.assign(base, {
+        ociShape: wm.instance_shape || "CI.Standard.A1.Flex",
+        ociOcpus: wm.instance_ocpus || 4,
+        ociMemoryGb: wm.instance_memory_gb || 30,
+        ociRegion: wm.oci_region || "",
+        ociCompartmentId: wm.compartment_id || "",
+        ociAvailabilityDomain: wm.availability_domain || "",
+        ociSubnetId: wm.subnet_id || "",
+        ociContainerImage: wm.container_image || "",
+        requirements: wm.requirements_txt || "",
+      });
+    }
+    if (wm.type === "oci_hpc") {
+      return Object.assign(base, {
+        ociRegion: wm.oci_region || "",
+        ociCompartmentId: wm.compartment_id || "",
+        ociAvailabilityDomain: wm.availability_domain || "",
+        ociSubnetId: wm.subnet_id || "",
+        ociContainerImage: wm.container_image || "",
+        ociObjectStorageNamespace: wm.object_storage_namespace || "",
+        ociObjectStorageBucket: wm.object_storage_bucket || "",
+        ociObjectStoragePrefix: wm.object_storage_prefix || "scaler-tasks",
+        ociOcpus: wm.instance_ocpus || 1,
+        ociMemoryGb: wm.instance_memory_gb || 6,
+        ociMaxConcurrentJobs: wm.base_concurrency || 100,
+        ociJobTimeoutMinutes: Math.round((wm.job_timeout_seconds || 3600) / 60),
+      });
+    }
+    if (wm.type === "symphony") {
+      return Object.assign(base, { serviceName: wm.service_name || "" });
+    }
+    return base;
+  });
+
+  var pyVer = "3.13";
+  for (var j = 0; j < rawWms.length; j++) {
+    if (rawWms[j].python_version) { pyVer = rawWms[j].python_version; break; }
+  }
+
+  var region = "us-east-1";
+  for (var k = 0; k < rawWms.length; k++) {
+    if (rawWms[k].aws_region) { region = rawWms[k].aws_region; break; }
+  }
+
+  var policySection = scheduler.policy || {};
+  var policy = policySection.policy_engine_type || "simple";
+  var policyContent = policySection.policy_content || "";
+
+  if (policy === "waterfall_v1" && policyContent) {
+    var priorityMap = {};
+    policyContent.split("\n").forEach(function(line) {
+      line = line.split("#")[0].trim();
+      if (!line) return;
+      var parts = line.split(",");
+      if (parts.length >= 2) {
+        var pri = parseInt(parts[0].trim(), 10);
+        var wmId = parts[1].trim();
+        if (!isNaN(pri) && wmId) priorityMap[wmId] = pri;
+      }
+    });
+    workerManagers.sort(function(a, b) {
+      return (priorityMap[a.id] !== undefined ? priorityMap[a.id] : 999) -
+             (priorityMap[b.id] !== undefined ? priorityMap[b.id] : 999);
+    });
+  }
+
+  return {
+    transport: proto,
+    schedulerPort: schedulerPort,
+    objectStoragePort: objectStoragePort,
+    pythonVersion: pyVer,
+    region: region,
+    workerManagers: workerManagers.length ? workerManagers : null,
+    policy: policy,
+  };
 }
 
 function buildUserData(cfg, creds) {

--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -152,6 +152,10 @@ worker_manager_id = "${wm.id}"
 
       if (wm.type === "orb_aws_ec2") {
         var req = (wm.requirements || "").trim();
+        var inst = (window.SCALER_INSTANCES || []).find(function(i) { return i.type === wm.instanceType; }) || { price: 0 };
+        var orbDerivedCount = wm.capMode === "instances"
+          ? Math.max(0, wm.instanceCap || 0)
+          : Math.max(0, Math.floor((wm.budgetCap || 0) / (inst.price || 1)));
         block += `worker_scheduler_address = "${proto}://<PRIVATE_IP>:${sp}${wsSlash}"
 object_storage_address = "${proto}://<PRIVATE_IP>:${op}${wsSlash}"
 python_version = "${cfg.pythonVersion}"
@@ -159,6 +163,7 @@ requirements_txt = """
 ${req}
 """
 instance_type = "${wm.instanceType}"
+max_task_concurrency = ${orbDerivedCount}
 aws_region = "${cfg.region}"
 key_name = "scaler-key-${suffix}"
 subnet_id = "<SUBNET_ID>"
@@ -300,7 +305,7 @@ function configFromToml(toml) {
       return Object.assign(base, {
         instanceType: wm.instance_type || "t3.medium",
         capMode: "instances",
-        instanceCap: 4,
+        instanceCap: wm.max_task_concurrency != null ? wm.max_task_concurrency : 4,
         budgetCap: 10,
         requirements: wm.requirements_txt || "opengris-scaler[all]",
       });

--- a/src/protocol/message.capnp
+++ b/src/protocol/message.capnp
@@ -90,9 +90,10 @@ struct WorkerHeartbeatEcho {
 }
 
 struct WorkerManagerHeartbeat {
-    maxTaskConcurrency @0 :UInt32;
-    capabilities @1 :List(CommonType.TaskCapability);
-    workerManagerID @2 :Data;
+    maxTaskConcurrency    @0 :UInt32;
+    capabilities          @1 :List(CommonType.TaskCapability);
+    workerManagerID       @2 :Data;
+    currentDesiredWorkers @3 :UInt32;
 }
 
 struct WorkerManagerHeartbeatEcho {

--- a/src/scaler/protocol/capnp.pyi
+++ b/src/scaler/protocol/capnp.pyi
@@ -237,6 +237,7 @@ class WorkerManagerHeartbeat(BaseMessage):
     maxTaskConcurrency: int
     capabilities: Any
     workerManagerID: bytes
+    currentDesiredWorkers: int
 
 class WorkerManagerHeartbeatEcho(BaseMessage): ...
 

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
@@ -36,7 +36,7 @@ class CapabilityScalingPolicy(ScalingPolicy):
         tasks_by_capability = self._group_tasks_by_capability(information_snapshot)
         desired_per_capset = self._compute_desired_per_capset(tasks_by_capability, worker_manager_heartbeat)
         effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
-        if effective == len(managed_worker_ids):
+        if effective == worker_manager_heartbeat.currentDesiredWorkers:
             return []
         return [build_set_desired_command(desired_per_capset)]
 

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
@@ -32,7 +32,7 @@ class VanillaScalingPolicy(ScalingPolicy):
         desired = self._compute_desired_worker_count(information_snapshot, worker_manager_heartbeat, managed_worker_ids)
         desired_per_capset: List[Tuple[Dict[str, int], int]] = [({}, desired)]
         effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
-        if effective == len(managed_worker_ids):
+        if effective == worker_manager_heartbeat.currentDesiredWorkers:
             return []
         return [build_set_desired_command(desired_per_capset)]
 

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/types.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/types.py
@@ -1,10 +1,11 @@
 import dataclasses
+from typing import Optional
 
 
 @dataclasses.dataclass(frozen=True)
 class WaterfallRule:
-    """A single rule in the waterfall config, parsed from 'priority,worker_manager_id,max_task_concurrency'."""
+    """A single rule in the waterfall config, parsed from 'priority,worker_manager_id[,max_task_concurrency]'."""
 
     priority: int
     worker_manager_id: bytes
-    max_task_concurrency: int
+    max_task_concurrency: Optional[int]

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/utility.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/utility.py
@@ -8,9 +8,11 @@ def parse_waterfall_rules(policy_content: str) -> List[WaterfallRule]:
 
     Expected format (one rule per line, ``#`` comments supported)::
 
-        #priority,worker_manager_id,max_task_concurrency
-        1,native,10
+        #priority,worker_manager_id[,max_task_concurrency]
+        1,native
         2,ecs,20
+
+    When ``max_task_concurrency`` is omitted, the manager's heartbeat-reported capacity is used.
 
     Raises ``ValueError`` on malformed input.
     """
@@ -22,13 +24,14 @@ def parse_waterfall_rules(policy_content: str) -> List[WaterfallRule]:
             continue
 
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) != 3:
+        if len(parts) not in (2, 3):
             raise ValueError(
                 f"waterfall_v1 policy_content line {line_number}: "
-                f"expected 'priority,worker_manager_id,max_task_concurrency', got {raw_line.strip()!r}"
+                f"expected 'priority,worker_manager_id[,max_task_concurrency]', got {raw_line.strip()!r}"
             )
 
-        raw_priority, worker_manager_id, raw_max_task_concurrency = parts
+        raw_priority, worker_manager_id = parts[0], parts[1]
+        raw_max_task_concurrency = parts[2] if len(parts) == 3 else None
 
         if not worker_manager_id:
             raise ValueError(f"waterfall_v1 policy_content line {line_number}: worker_manager_id cannot be empty")
@@ -37,7 +40,7 @@ def parse_waterfall_rules(policy_content: str) -> List[WaterfallRule]:
             WaterfallRule(
                 priority=int(raw_priority),
                 worker_manager_id=worker_manager_id.encode(),
-                max_task_concurrency=int(raw_max_task_concurrency),
+                max_task_concurrency=int(raw_max_task_concurrency) if raw_max_task_concurrency is not None else None,
             )
         )
 

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -186,7 +186,11 @@ class WaterfallScalingPolicy(ScalingPolicy):
         snap = self._find_matching_snapshot(rule, snapshots)
         if snap is None:
             return None
-        return min(rule.max_task_concurrency, snap.max_task_concurrency) if rule.max_task_concurrency is not None else snap.max_task_concurrency
+        return (
+            min(rule.max_task_concurrency, snap.max_task_concurrency)
+            if rule.max_task_concurrency is not None
+            else snap.max_task_concurrency
+        )
 
     def _tasks_by_capability(self, information_snapshot: InformationSnapshot) -> Dict[FrozenSet[str], Dict[str, int]]:
         """Group tasks with non-empty capabilities, mapping capset keys to a representative dict."""

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -175,13 +175,18 @@ class WaterfallScalingPolicy(ScalingPolicy):
         current_heartbeat: WorkerManagerHeartbeat,
         snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> Optional[int]:
-        """Return min(rule cap, manager-reported max). Returns None if the manager is offline."""
+        """Return effective worker capacity for *rule*.
+
+        When the rule specifies a cap, returns min(cap, heartbeat max). When omitted, returns the
+        heartbeat-reported max directly. Returns None if the manager is offline.
+        """
         if rule.worker_manager_id == current_rule.worker_manager_id:
-            return min(rule.max_task_concurrency, current_heartbeat.maxTaskConcurrency)
+            reported = current_heartbeat.maxTaskConcurrency
+            return min(rule.max_task_concurrency, reported) if rule.max_task_concurrency is not None else reported
         snap = self._find_matching_snapshot(rule, snapshots)
         if snap is None:
             return None
-        return min(rule.max_task_concurrency, snap.max_task_concurrency)
+        return min(rule.max_task_concurrency, snap.max_task_concurrency) if rule.max_task_concurrency is not None else snap.max_task_concurrency
 
     def _tasks_by_capability(self, information_snapshot: InformationSnapshot) -> Dict[FrozenSet[str], Dict[str, int]]:
         """Group tasks with non-empty capabilities, mapping capset keys to a representative dict."""

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -52,7 +52,7 @@ class WaterfallScalingPolicy(ScalingPolicy):
             rule, information_snapshot, worker_manager_heartbeat, worker_manager_snapshots
         )
         effective = effective_desired_for_manager(desired_per_capset, worker_manager_heartbeat.capabilities)
-        if effective == len(managed_worker_ids):
+        if effective == worker_manager_heartbeat.currentDesiredWorkers:
             return []
         return [build_set_desired_command(desired_per_capset)]
 

--- a/src/scaler/worker_manager_adapter/aws_hpc/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/aws_hpc/worker_manager.py
@@ -32,6 +32,9 @@ class BatchWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/aws_raw/ecs.py
+++ b/src/scaler/worker_manager_adapter/aws_raw/ecs.py
@@ -137,6 +137,9 @@ class ECSWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -108,6 +108,9 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._workers)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def start_units(self, count: int) -> None:
         for _ in range(count):
             worker = self._create_worker()

--- a/src/scaler/worker_manager_adapter/capacity_coordinator.py
+++ b/src/scaler/worker_manager_adapter/capacity_coordinator.py
@@ -40,6 +40,10 @@ class CapacityCoordinator:
         self._reconcile_needed: asyncio.Event = asyncio.Event()
         self._stop: asyncio.Event = asyncio.Event()
 
+    @property
+    def desired_unit_count(self) -> int:
+        return self._desired_unit_count
+
     async def set_desired_unit_count(self, count: int) -> None:
         """Set the desired number of units and signal the reconcile task."""
         if count == self._desired_unit_count:

--- a/src/scaler/worker_manager_adapter/mixins.py
+++ b/src/scaler/worker_manager_adapter/mixins.py
@@ -77,6 +77,11 @@ class DeclarativeWorkerProvisioner(ABC):
         ...
 
     @abstractmethod
+    def desired_unit_count(self) -> int:
+        """Return the number of units currently desired by the coordinator."""
+        ...
+
+    @abstractmethod
     async def terminate(self) -> None:
         """Cancel the capacity coordinator and stop all running units."""
         ...

--- a/src/scaler/worker_manager_adapter/oci_hpc/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/oci_hpc/worker_manager.py
@@ -32,6 +32,9 @@ class OCIHPCWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/oci_raw/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/oci_raw/worker_manager.py
@@ -59,6 +59,9 @@ class OCIRawWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._instances)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
@@ -53,6 +53,9 @@ class ORBWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._units)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/symphony/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/symphony/worker_manager.py
@@ -42,6 +42,9 @@ class SymphonyWorkerProvisioner(DeclarativeWorkerProvisioner):
     def active_unit_count(self) -> int:
         return len(self._workers)
 
+    def desired_unit_count(self) -> int:
+        return self._capacity_coordinator.desired_unit_count
+
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]
     ) -> None:

--- a/src/scaler/worker_manager_adapter/worker_manager_runner.py
+++ b/src/scaler/worker_manager_adapter/worker_manager_runner.py
@@ -79,6 +79,8 @@ class WorkerManagerRunner:
                 maxTaskConcurrency=self._max_provisioner_units * self._workers_per_provisioner_unit,
                 capabilities=dict_to_capabilities(self._capabilities),
                 workerManagerID=self._worker_manager_id,
+                currentDesiredWorkers=self._worker_provisioner.desired_unit_count()
+                * self._workers_per_provisioner_unit,
             )
         )
 

--- a/tests/scheduler/test_scaling.py
+++ b/tests/scheduler/test_scaling.py
@@ -215,7 +215,7 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         }
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=3)
 
         request = self._single_request(snapshot, heartbeat, managed)
 
@@ -235,12 +235,12 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         self.assertEqual(request.taskConcurrency, 1)
 
     def test_balanced_ratio_skips_when_desired_equals_current(self):
-        """Task ratio in band keeps desired == current managed count -> no-op skip."""
+        """Task ratio in band keeps effective desired == currentDesiredWorkers -> no-op skip."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(15)}
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=5)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -252,19 +252,19 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         managed = [WorkerID(b"w0"), WorkerID(b"w1")]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=20) for wid in managed}
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=2)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=2, current_desired_workers=2)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
-        # Ratio would say desired=3, cap clamps to 2, which equals current=2 -> skip.
+        # Ratio would say desired=3, cap clamps to 2, which equals currentDesiredWorkers=2 -> skip.
         self.assertEqual(commands, [])
 
 
 class TestNoOpSkip(unittest.TestCase):
-    """A command whose effective desired count matches the manager's current connected
-    worker count is a no-op for the worker manager. The scheduler skips emission for
-    such commands so it doesn't waste network traffic on commands that cannot change
-    anything (notably: when the manager is already at its config-given max)."""
+    """A command whose effective desired count matches the manager's currentDesiredWorkers
+    (as reported in the heartbeat) is a no-op. The scheduler skips emission so it doesn't
+    waste network traffic on commands that cannot change anything (notably: when the manager
+    is already at its config-given max)."""
 
     def setUp(self):
         setup_logger()
@@ -276,7 +276,7 @@ class TestNoOpSkip(unittest.TestCase):
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=10) for wid in managed}
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, current_desired_workers=10)
 
         commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -298,16 +298,18 @@ class TestNoOpSkip(unittest.TestCase):
         self.assertEqual(requests[0].taskConcurrency, 2)
 
     def test_capability_at_cap_skips(self):
-        """Capability: ratio's per-capset desired equals current connected -> skip emission."""
+        """Capability: ratio's per-capset desired equals currentDesiredWorkers -> skip emission."""
         policy = CapabilityScalingPolicy()
-        # ceil(50/5) = 10 desired for gpu capset; clamp at cap=10; current connected = 10 -> no-op.
+        # ceil(50/5) = 10 desired for gpu capset; clamp at cap=10; currentDesiredWorkers=10 -> no-op.
         tasks = {}
         for _ in range(50):
             tid = TaskID.generate_task_id()
             tasks[tid] = _create_mock_task(tid, {"gpu": 1})
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, capabilities={"gpu": -1})
+        heartbeat = _create_worker_manager_heartbeat(
+            b"mgr", max_task_concurrency=10, capabilities={"gpu": -1}, current_desired_workers=10
+        )
 
         commands = policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -328,19 +330,19 @@ class TestNoOpSkip(unittest.TestCase):
         self.assertEqual(commands, [])
 
     def test_waterfall_at_cap_skips(self):
-        """Waterfall: when the manager is full per the priority chain and already has that
-        many workers connected, emission is skipped."""
+        """Waterfall: when the manager is full per the priority chain and its coordinator
+        already reflects that, emission is skipped."""
         from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
         from scaler.scheduler.controllers.policies.waterfall_v1.scaling.types import WaterfallRule
         from scaler.scheduler.controllers.policies.waterfall_v1.scaling.waterfall import WaterfallScalingPolicy
 
         rules = [WaterfallRule(priority=1, worker_manager_id=b"mgr", max_task_concurrency=10)]
         policy = WaterfallScalingPolicy(rules)
-        # ceil(100/10) = 10; cap=10; manager has 10 connected -> effective 10 == current 10 -> skip.
+        # ceil(100/10) = 10; cap=10; coordinator desired=10 -> effective 10 == currentDesiredWorkers=10 -> skip.
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
         snapshot = InformationSnapshot(tasks=tasks, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=10, current_desired_workers=10)
         manager_snapshots = {
             b"mgr": WorkerManagerSnapshot(
                 worker_manager_id=b"mgr", max_task_concurrency=10, worker_count=10, last_seen_s=0.0, capabilities={}
@@ -350,6 +352,23 @@ class TestNoOpSkip(unittest.TestCase):
         commands = policy.get_scaling_commands(snapshot, heartbeat, managed, manager_snapshots)
 
         self.assertEqual(commands, [])
+
+    def test_scale_down_not_suppressed_when_coordinator_desired_nonzero(self):
+        """Scale-down command must be emitted when the WM coordinator has desired>0 but
+        no workers have connected yet (e.g. EC2 instance still booting)."""
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=2)
+
+        vanilla_policy = VanillaScalingPolicy()
+        commands = vanilla_policy.get_scaling_commands(snapshot, heartbeat, [], {})
+        self.assertEqual(len(commands), 1)
+        requests = list(commands[0].setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 0)
+
+        capability_policy = CapabilityScalingPolicy()
+        commands_cap = capability_policy.get_scaling_commands(snapshot, heartbeat, [], {})
+        self.assertEqual(len(commands_cap), 1)
+        self.assertEqual(list(commands_cap[0].setDesiredTaskConcurrencyRequests), [])
 
 
 class TestCapabilityScalingPolicy(unittest.TestCase):
@@ -483,7 +502,7 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=0) for i in range(4)}
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks={}, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=4)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -515,7 +534,7 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
         managed = list(workers.keys())
         snapshot = InformationSnapshot(tasks=tasks, workers=workers)
-        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", current_desired_workers=5)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -539,11 +558,11 @@ class TestCapabilityDeclarativeEquivalents(unittest.TestCase):
 
     def test_drain_capset_when_no_tasks(self):
         """With 3 connected workers and no tasks, the policy emits setDesired with an
-        empty request list -- effective desired (0) differs from current (3) so the manager
-        is told to drain (via extract_desired_count returning 0 for the empty list)."""
+        empty request list -- effective desired (0) differs from currentDesiredWorkers (3) so
+        the manager is told to drain (via extract_desired_count returning 0 for the empty list)."""
         managed = [WorkerID(f"w{i}".encode()) for i in range(3)]
         snapshot = InformationSnapshot(tasks={}, workers={})
-        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", capabilities={"gpu": -1}, current_desired_workers=3)
 
         commands = self.policy.get_scaling_commands(snapshot, heartbeat, managed, {})
 
@@ -663,10 +682,16 @@ def _create_mock_worker_heartbeat(capabilities: dict, queued_tasks: int = 0) -> 
 
 
 def _create_worker_manager_heartbeat(
-    worker_manager_id: bytes, max_task_concurrency: int = 10, capabilities: Optional[Dict[str, int]] = None
+    worker_manager_id: bytes,
+    max_task_concurrency: int = 10,
+    capabilities: Optional[Dict[str, int]] = None,
+    current_desired_workers: int = 0,
 ) -> WorkerManagerHeartbeat:
     return WorkerManagerHeartbeat(
-        maxTaskConcurrency=max_task_concurrency, capabilities=capabilities or {}, workerManagerID=worker_manager_id
+        maxTaskConcurrency=max_task_concurrency,
+        capabilities=capabilities or {},
+        workerManagerID=worker_manager_id,
+        currentDesiredWorkers=current_desired_workers,
     )
 
 

--- a/tests/scheduler/test_waterfall_scaling.py
+++ b/tests/scheduler/test_waterfall_scaling.py
@@ -8,6 +8,7 @@ from scaler.protocol.helpers import capabilities_to_dict
 from scaler.scheduler.controllers.policies.library.utility import create_policy
 from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
 from scaler.scheduler.controllers.policies.waterfall_v1.scaling.types import WaterfallRule
+from scaler.scheduler.controllers.policies.waterfall_v1.scaling.utility import parse_waterfall_rules
 from scaler.scheduler.controllers.policies.waterfall_v1.scaling.waterfall import WaterfallScalingPolicy
 from scaler.scheduler.controllers.policies.waterfall_v1.waterfall_v1_policy import WaterfallV1Policy
 from scaler.utility.identifiers import ClientID, ObjectID, TaskID, WorkerID
@@ -497,7 +498,7 @@ class TestWaterfallV1Policy(unittest.TestCase):
         """Comments and blank lines should be ignored."""
         policy_content = "\n".join(
             [
-                "#priority,worker_manager_id,max_task_concurrency",
+                "#priority,worker_manager_id[,max_task_concurrency]",
                 "1,manager_a,10",
                 "",
                 "2,manager_b,20  # overflow tier",
@@ -505,6 +506,12 @@ class TestWaterfallV1Policy(unittest.TestCase):
         )
         policy = WaterfallV1Policy(policy_content)
         self.assertIsInstance(policy, WaterfallV1Policy)
+
+    def test_config_parsing_without_max_task_concurrency(self):
+        """max_task_concurrency may be omitted; the rule's field is then None."""
+        rules = parse_waterfall_rules("1,manager_a\n2,manager_b,20")
+        self.assertIsNone(rules[0].max_task_concurrency)
+        self.assertEqual(rules[1].max_task_concurrency, 20)
 
     def test_invalid_config_empty(self):
         """Empty policy content should raise ValueError."""
@@ -517,9 +524,11 @@ class TestWaterfallV1Policy(unittest.TestCase):
             WaterfallV1Policy("# just a comment\n# another comment")
 
     def test_invalid_config_wrong_field_count(self):
-        """Lines with wrong number of fields should raise ValueError."""
+        """Lines with too few or too many fields should raise ValueError."""
         with self.assertRaises(ValueError):
-            WaterfallV1Policy("1,manager_a")
+            WaterfallV1Policy("manager_a_only")
+        with self.assertRaises(ValueError):
+            WaterfallV1Policy("1,manager_a,10,extra")
 
     def test_invalid_config_non_integer_priority(self):
         """Non-integer priority should raise ValueError."""

--- a/tests/scheduler/test_waterfall_scaling.py
+++ b/tests/scheduler/test_waterfall_scaling.py
@@ -173,14 +173,14 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
 
         # manager_b (lower priority) is told to drain to 0
         managed_b = [WorkerID(b"worker-3"), WorkerID(b"worker-4")]
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20, current_desired_workers=2)
         commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, managed_b, manager_snapshots)
         self.assertEqual(len(commands_b), 1)
         self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 0)
 
-        # manager_a (higher priority) is NOT told to drain yet -- desired matches its current count
+        # manager_a (higher priority) is NOT told to drain yet -- desired matches currentDesiredWorkers
         managed_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10, current_desired_workers=3)
         commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, managed_a, manager_snapshots)
         self.assertEqual(commands_a, [])
 
@@ -198,7 +198,7 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
         }
 
         managed_a = [WorkerID(b"worker-0"), WorkerID(b"worker-1"), WorkerID(b"worker-2")]
-        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10)
+        heartbeat_a = _create_worker_manager_heartbeat(b"manager_a", max_task_concurrency=10, current_desired_workers=3)
         commands_a = policy.get_scaling_commands(snapshot, heartbeat_a, managed_a, manager_snapshots)
 
         # No lower-priority manager to wait on -- emit setDesired(0) to drain.
@@ -304,13 +304,27 @@ class TestWaterfallScalingPolicy(unittest.TestCase):
         }
 
         managed_b = [WorkerID(b"w0"), WorkerID(b"w1")]
-        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20)
+        heartbeat_b = _create_worker_manager_heartbeat(b"manager_b", max_task_concurrency=20, current_desired_workers=2)
         commands_b = policy.get_scaling_commands(snapshot, heartbeat_b, managed_b, manager_snapshots)
 
         # 5 tasks -> total_desired=1, absorbed by manager_a entirely -> manager_b's share=0;
         # but manager_b has 2 connected workers, so the command is not a no-op.
         self.assertEqual(len(commands_b), 1)
         self.assertEqual(_generic_request(commands_b[0]).taskConcurrency, 0)
+
+    def test_scale_down_not_suppressed_when_coordinator_desired_nonzero(self):
+        """Scale-down command must be emitted when the WM coordinator has desired>0 but
+        no workers have connected yet (e.g. EC2 instance still booting)."""
+        rules = [WaterfallRule(priority=1, worker_manager_id=b"manager_a", max_task_concurrency=10)]
+        policy = WaterfallScalingPolicy(rules)
+        snapshot = InformationSnapshot(tasks={}, workers={})
+        manager_snapshots = {b"manager_a": _create_manager_snapshot(b"manager_a")}
+        heartbeat = _create_worker_manager_heartbeat(b"manager_a", current_desired_workers=2)
+
+        commands = policy.get_scaling_commands(snapshot, heartbeat, [], manager_snapshots)
+
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(_generic_request(commands[0]).taskConcurrency, 0)
 
 
 class TestWaterfallCapabilities(unittest.TestCase):
@@ -670,10 +684,16 @@ def _create_mock_worker_heartbeat(
 
 
 def _create_worker_manager_heartbeat(
-    worker_manager_id: bytes, max_task_concurrency: int = 10, capabilities: Optional[Dict[str, int]] = None
+    worker_manager_id: bytes,
+    max_task_concurrency: int = 10,
+    capabilities: Optional[Dict[str, int]] = None,
+    current_desired_workers: int = 0,
 ) -> WorkerManagerHeartbeat:
     return WorkerManagerHeartbeat(
-        maxTaskConcurrency=max_task_concurrency, capabilities=capabilities or {}, workerManagerID=worker_manager_id
+        maxTaskConcurrency=max_task_concurrency,
+        capabilities=capabilities or {},
+        workerManagerID=worker_manager_id,
+        currentDesiredWorkers=current_desired_workers,
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a policy configuration panel to the Launchpad UI with load/save support
- Enables drag-and-drop reordering of worker managers in the Launchpad UI
- Adds budget and instance cap controls for the OCI raw worker manager
- Adds **Load config.toml** button to restore a full Launchpad configuration from a previously downloaded TOML file
- Makes `max_task_concurrency` optional in waterfall policy rule format (with a sensible default)
- Reduces OCI raw worker manager default memory from 30 GB to 8 GB (2 GB/OCPU with the default 4 OCPUs — still above OCI's 1 GB/OCPU minimum)
- Download/Load config.toml buttons are now always visible, not hidden during active deployments
- Fixes ORB EC2 worker manager reporting incorrect max concurrency: `max_task_concurrency` was missing from the generated TOML, so it defaulted to `os.cpu_count()` on the Launchpad host; the Launchpad now writes the configured instance count as `max_task_concurrency`, which the worker manager rounds up to whole instances (e.g. `mtc=3` on t3.medium → 2 instances → 4 max concurrency)
- Scheduler Logs tab now fetches the full `/var/log/scaler.log` via `cat` instead of `tail -n 150`, allowing full scroll-back through the log history. Note: SSM `GetCommandInvocation` caps `StandardOutputContent` at 48,000 characters, so very large log files will still be truncated at that limit.