### PR TITLE
Launchpad: emit max_task_concurrency for ORB EC2 worker manager

### DIFF
--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -147,6 +147,10 @@ worker_manager_id = "${wm.id}"
 
       if (wm.type === "orb_aws_ec2") {
         var req = (wm.requirements || "").trim();
+        var inst = (window.SCALER_INSTANCES || []).find(function(i) { return i.type === wm.instanceType; }) || { price: 0 };
+        var orbDerivedCount = wm.capMode === "instances"
+          ? Math.max(0, wm.instanceCap || 0)
+          : Math.max(0, Math.floor((wm.budgetCap || 0) / (inst.price || 1)));
         block += `worker_scheduler_address = "${proto}://<PRIVATE_IP>:${sp}${wsSlash}"
 object_storage_address = "${proto}://<PRIVATE_IP>:${op}${wsSlash}"
 python_version = "${cfg.pythonVersion}"
@@ -154,6 +158,7 @@ requirements_txt = """
 ${req}
 """
 instance_type = "${wm.instanceType}"
+max_task_concurrency = ${orbDerivedCount}
 aws_region = "${cfg.region}"
 key_name = "scaler-key-${suffix}"
 subnet_id = "<SUBNET_ID>"

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/types.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/types.py
@@ -1,10 +1,11 @@
 import dataclasses
+from typing import Optional
 
 
 @dataclasses.dataclass(frozen=True)
 class WaterfallRule:
-    """A single rule in the waterfall config, parsed from 'priority,worker_manager_id,max_task_concurrency'."""
+    """A single rule in the waterfall config, parsed from 'priority,worker_manager_id[,max_task_concurrency]'."""
 
     priority: int
     worker_manager_id: bytes
-    max_task_concurrency: int
+    max_task_concurrency: Optional[int]

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/utility.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/utility.py
@@ -8,9 +8,11 @@ def parse_waterfall_rules(policy_content: str) -> List[WaterfallRule]:
 
     Expected format (one rule per line, ``#`` comments supported)::
 
-        #priority,worker_manager_id,max_task_concurrency
-        1,native,10
+        #priority,worker_manager_id[,max_task_concurrency]
+        1,native
         2,ecs,20
+
+    When ``max_task_concurrency`` is omitted, the manager's heartbeat-reported capacity is used.
 
     Raises ``ValueError`` on malformed input.
     """
@@ -22,13 +24,14 @@ def parse_waterfall_rules(policy_content: str) -> List[WaterfallRule]:
             continue
 
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) != 3:
+        if len(parts) not in (2, 3):
             raise ValueError(
                 f"waterfall_v1 policy_content line {line_number}: "
-                f"expected 'priority,worker_manager_id,max_task_concurrency', got {raw_line.strip()!r}"
+                f"expected 'priority,worker_manager_id[,max_task_concurrency]', got {raw_line.strip()!r}"
             )
 
-        raw_priority, worker_manager_id, raw_max_task_concurrency = parts
+        raw_priority, worker_manager_id = parts[0], parts[1]
+        raw_max_task_concurrency = parts[2] if len(parts) == 3 else None
 
         if not worker_manager_id:
             raise ValueError(f"waterfall_v1 policy_content line {line_number}: worker_manager_id cannot be empty")
@@ -37,7 +40,7 @@ def parse_waterfall_rules(policy_content: str) -> List[WaterfallRule]:
             WaterfallRule(
                 priority=int(raw_priority),
                 worker_manager_id=worker_manager_id.encode(),
-                max_task_concurrency=int(raw_max_task_concurrency),
+                max_task_concurrency=int(raw_max_task_concurrency) if raw_max_task_concurrency is not None else None,
             )
         )
 

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -186,7 +186,11 @@ class WaterfallScalingPolicy(ScalingPolicy):
         snap = self._find_matching_snapshot(rule, snapshots)
         if snap is None:
             return None
-        return min(rule.max_task_concurrency, snap.max_task_concurrency) if rule.max_task_concurrency is not None else snap.max_task_concurrency
+        return (
+            min(rule.max_task_concurrency, snap.max_task_concurrency)
+            if rule.max_task_concurrency is not None
+            else snap.max_task_concurrency
+        )
 
     def _tasks_by_capability(self, information_snapshot: InformationSnapshot) -> Dict[FrozenSet[str], Dict[str, int]]:
         """Group tasks with non-empty capabilities, mapping capset keys to a representative dict."""

--- a/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
+++ b/src/scaler/scheduler/controllers/policies/waterfall_v1/scaling/waterfall.py
@@ -175,13 +175,18 @@ class WaterfallScalingPolicy(ScalingPolicy):
         current_heartbeat: WorkerManagerHeartbeat,
         snapshots: Dict[bytes, WorkerManagerSnapshot],
     ) -> Optional[int]:
-        """Return min(rule cap, manager-reported max). Returns None if the manager is offline."""
+        """Return effective worker capacity for *rule*.
+
+        When the rule specifies a cap, returns min(cap, heartbeat max). When omitted, returns the
+        heartbeat-reported max directly. Returns None if the manager is offline.
+        """
         if rule.worker_manager_id == current_rule.worker_manager_id:
-            return min(rule.max_task_concurrency, current_heartbeat.maxTaskConcurrency)
+            reported = current_heartbeat.maxTaskConcurrency
+            return min(rule.max_task_concurrency, reported) if rule.max_task_concurrency is not None else reported
         snap = self._find_matching_snapshot(rule, snapshots)
         if snap is None:
             return None
-        return min(rule.max_task_concurrency, snap.max_task_concurrency)
+        return min(rule.max_task_concurrency, snap.max_task_concurrency) if rule.max_task_concurrency is not None else snap.max_task_concurrency
 
     def _tasks_by_capability(self, information_snapshot: InformationSnapshot) -> Dict[FrozenSet[str], Dict[str, int]]:
         """Group tasks with non-empty capabilities, mapping capset keys to a representative dict."""

--- a/tests/scheduler/test_waterfall_scaling.py
+++ b/tests/scheduler/test_waterfall_scaling.py
@@ -8,6 +8,7 @@ from scaler.protocol.helpers import capabilities_to_dict
 from scaler.scheduler.controllers.policies.library.utility import create_policy
 from scaler.scheduler.controllers.policies.simple_policy.scaling.types import WorkerManagerSnapshot
 from scaler.scheduler.controllers.policies.waterfall_v1.scaling.types import WaterfallRule
+from scaler.scheduler.controllers.policies.waterfall_v1.scaling.utility import parse_waterfall_rules
 from scaler.scheduler.controllers.policies.waterfall_v1.scaling.waterfall import WaterfallScalingPolicy
 from scaler.scheduler.controllers.policies.waterfall_v1.waterfall_v1_policy import WaterfallV1Policy
 from scaler.utility.identifiers import ClientID, ObjectID, TaskID, WorkerID
@@ -497,7 +498,7 @@ class TestWaterfallV1Policy(unittest.TestCase):
         """Comments and blank lines should be ignored."""
         policy_content = "\n".join(
             [
-                "#priority,worker_manager_id,max_task_concurrency",
+                "#priority,worker_manager_id[,max_task_concurrency]",
                 "1,manager_a,10",
                 "",
                 "2,manager_b,20  # overflow tier",
@@ -505,6 +506,12 @@ class TestWaterfallV1Policy(unittest.TestCase):
         )
         policy = WaterfallV1Policy(policy_content)
         self.assertIsInstance(policy, WaterfallV1Policy)
+
+    def test_config_parsing_without_max_task_concurrency(self):
+        """max_task_concurrency may be omitted; the rule's field is then None."""
+        rules = parse_waterfall_rules("1,manager_a\n2,manager_b,20")
+        self.assertIsNone(rules[0].max_task_concurrency)
+        self.assertEqual(rules[1].max_task_concurrency, 20)
 
     def test_invalid_config_empty(self):
         """Empty policy content should raise ValueError."""
@@ -517,9 +524,11 @@ class TestWaterfallV1Policy(unittest.TestCase):
             WaterfallV1Policy("# just a comment\n# another comment")
 
     def test_invalid_config_wrong_field_count(self):
-        """Lines with wrong number of fields should raise ValueError."""
+        """Lines with too few or too many fields should raise ValueError."""
         with self.assertRaises(ValueError):
-            WaterfallV1Policy("1,manager_a")
+            WaterfallV1Policy("manager_a_only")
+        with self.assertRaises(ValueError):
+            WaterfallV1Policy("1,manager_a,10,extra")
 
     def test_invalid_config_non_integer_priority(self):
         """Non-integer priority should raise ValueError."""


### PR DESCRIPTION
## Summary

- Fixes the Launchpad config generator for ORB EC2: without this, `max_task_concurrency` was not emitted, causing the worker manager to default to `os.cpu_count()` on the Launchpad host — spinning up more instances than configured.
- Derives the count from the cap mode: instance cap directly, or budget divided by instance price.
- Also fixes `configFromToml` round-trip: when loading an existing config, the ORB EC2 `max_task_concurrency` value is now used to populate `instanceCap` instead of defaulting to 4.

Depends on: #833 (waterfall optional max_task_concurrency)

## Test plan

- [ ] Generate an ORB EC2 config in the Launchpad and verify `max_task_concurrency` appears with the correct value
- [ ] Load an existing config with `max_task_concurrency` set and verify `instanceCap` round-trips correctly