### PR TITLE
bump orb-py to 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ aws = [
     "botocore[crt]",
 ]
 orb = [
-    "orb-py~=1.6.0; python_version >= '3.10'",
+    "orb-py==1.7.0; python_version >= '3.10'",
     "boto3",
     "packaging",
     "botocore[crt]",


### PR DESCRIPTION
Pins `orb-py` to `==1.7.0`. Verified API compatibility — `ORBClient`, `create_request`, `get_request_status`, `create_return_request`, `create_template`, and `validate_template` are all present and signature-compatible with our usage.

The new `ACQUIRING` status added in 1.7.0 is non-terminal, so the polling loop in `ORBWorkerProvisioner.start_units` handles it correctly without changes.