### PR TITLE
Ensure SocketStopRequested is handled when thrown

### DIFF
--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -270,6 +270,12 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
         except ymq.YMQException as e:
             if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
                 pass
+            elif e.code == ymq.ErrorCode.SocketStopRequested:
+                # A YMQ socket (e.g. the internal binder) was shut down via `disconnect`/teardown
+                # while a send or recv driven by one of the loops above was still in flight. Like
+                # ConnectorSocketClosedByRemoteEnd, this is an expected teardown condition that is
+                # out of our control: log it, but never let it surface as a crash.
+                logger.info(f"{self.identity!r}: a YMQ socket was shut down during teardown: {e}")
             else:
                 logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
         except (ClientShutdownException, TimeoutError) as e:

--- a/tests/io/test_ymq_async_binder.py
+++ b/tests/io/test_ymq_async_binder.py
@@ -1,0 +1,71 @@
+"""io-layer contract tests for ``YMQAsyncBinder``.
+
+These document the origin of the ``jne-fix-ymq`` failure: a binder send surfaces
+``SocketStopRequested`` when its own socket is shut down (``disconnect``/teardown) while a send is
+in flight. The io layer deliberately does NOT swallow this in ``send()`` - it fails fast so the
+error is visible during development. The graceful, "log not crash" handling lives at the worker's
+loop boundary; see ``tests/worker/test_worker.py``.
+"""
+
+import asyncio
+import unittest
+from typing import List, Tuple
+
+from scaler.config.types.address import AddressConfig
+from scaler.io.utility import deserialize
+from scaler.io.ymq import ConnectorSocket, IOContext, SocketStopRequestedError
+from scaler.io.ymq_async_binder import YMQAsyncBinder
+from scaler.protocol.capnp import BaseMessage, DisconnectRequest
+from scaler.utility.identifiers import WorkerID
+
+
+class TestYMQAsyncBinderSend(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self._received: List[Tuple[bytes, BaseMessage]] = []
+
+        self._context = IOContext()
+        self._binder = YMQAsyncBinder(self._context, identity=b"binder-under-test", callback=self._on_receive)
+        await self._binder.bind(AddressConfig.from_string("tcp://127.0.0.1:0"))
+
+    async def _on_receive(self, address: bytes, message: BaseMessage) -> None:
+        self._received.append((address, message))
+
+    @staticmethod
+    def _make_message() -> DisconnectRequest:
+        return DisconnectRequest(worker=WorkerID.generate_worker_id("nobody"))
+
+    async def test_send_propagates_socket_stop_requested_when_socket_shut_down(self) -> None:
+        """binder.send surfaces SocketStopRequested when its own socket is shut down mid-send.
+
+        The send is queued inside the C++ binder (the peer never connects), then the binder is
+        destroyed. The native socket fails the pending send with ``SocketStopRequested``, which the
+        io layer propagates as-is (fail fast). This is the exception the worker boundary must handle.
+        """
+        send_task = asyncio.ensure_future(self._binder.send(b"peer-that-never-connects", self._make_message()))
+
+        # Let the send reach the binder's event-loop thread and park in its pending-send queue.
+        await asyncio.sleep(0.2)
+        self.assertFalse(send_task.done(), "send should still be pending (peer never connected)")
+
+        # Shut the binder down while the send is in flight (mirrors worker teardown / `disconnect`).
+        self._binder.destroy()
+
+        with self.assertRaises(SocketStopRequestedError):
+            await asyncio.wait_for(send_task, timeout=5.0)
+
+    async def test_normal_send_still_delivers(self) -> None:
+        """A normal send still reaches a connected peer (happy path is unaffected)."""
+        connector = ConnectorSocket.connect(self._context, "peer", repr(self._binder.address))
+
+        message = self._make_message()
+        await self._binder.send(b"peer", message)  # completes once the peer identifies itself
+
+        ymq_msg = await asyncio.wait_for(connector.recv_message(), timeout=5.0)
+        received = deserialize(ymq_msg.payload.data)
+
+        assert isinstance(received, DisconnectRequest)
+        self.assertEqual(received.worker, message.worker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -1,0 +1,134 @@
+"""Regression tests for the worker's top-level YMQ error handling (``Worker.__get_loops``).
+
+The ``jne-fix-ymq`` failure: a worker's internal YMQ binder is shut down (``disconnect``/teardown)
+while a ``binder.send`` driven by one of the worker's loops is still in flight. The send surfaces
+``SocketStopRequested`` (see ``tests/io/test_ymq_async_binder.py``), which propagates through
+``asyncio.gather`` into ``Worker.__get_loops``. Before the fix the handler logged it as a "failed
+with unhandled exception" crash; it must instead be treated like ``ConnectorSocketClosedByRemoteEnd``
+- an expected teardown condition that is logged, never surfaced as a crash.
+"""
+
+import asyncio
+import unittest
+from typing import Any, Awaitable, Callable
+from unittest import mock
+
+import scaler.worker.worker as worker_module
+from scaler.config.types.address import AddressConfig
+from scaler.io import ymq
+from scaler.io.ymq import SocketStopRequestedError, SysCallError
+from scaler.worker.worker import Worker
+
+
+async def _hang() -> None:
+    await asyncio.Event().wait()
+
+
+class _StubCollaborator:
+    """Minimal stand-in for a worker collaborator, exposing the hooks ``__get_loops`` touches."""
+
+    def __init__(self, routine_behavior: Callable[[], Awaitable[None]] = _hang) -> None:
+        self._routine_behavior = routine_behavior
+        self.destroyed = False
+
+    async def routine(self) -> None:
+        await self._routine_behavior()
+
+    async def connect(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    async def bind(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    async def initialize(self, *args: object, **kwargs: object) -> None:
+        await _hang()
+
+    def destroy(self, *args: object) -> None:
+        self.destroyed = True
+
+
+class WorkerTeardownYMQErrorTest(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _build_worker(task_routine_error: ymq.YMQException) -> Any:
+        # Typed as Any: the test deliberately injects duck-typed stubs into the worker's typed
+        # collaborator slots and reaches a name-mangled private loop, which the type system rejects.
+        worker: Any = Worker(
+            event_loop="builtin",
+            name="test-worker",
+            address=AddressConfig.from_string("tcp://127.0.0.1:2345"),
+            object_storage_address=None,
+            preload=None,
+            capabilities={},
+            io_threads=1,
+            task_queue_size=10,
+            heartbeat_interval_seconds=1,
+            garbage_collect_interval_seconds=1,
+            trim_memory_threshold_bytes=0,
+            task_timeout_seconds=10,
+            death_timeout_seconds=10,
+            hard_processor_suspend=False,
+            logging_paths=(),
+            logging_level="INFO",
+            worker_manager_id=b"wm",
+        )
+
+        worker._backend = None  # not a ZMQ backend -> no graceful-shutdown handshake on teardown
+        worker._address_internal = AddressConfig.from_string("tcp://127.0.0.1:2346")  # tcp -> no ipc unlink
+
+        async def _raise() -> None:
+            raise task_routine_error
+
+        worker._connector_external = _StubCollaborator()
+        worker._connector_storage = _StubCollaborator()
+        worker._binder_internal = _StubCollaborator()
+        worker._heartbeat_manager = _StubCollaborator()
+        worker._timeout_manager = _StubCollaborator()
+        worker._profiling_manager = _StubCollaborator()
+        worker._processor_manager = _StubCollaborator()
+        # The task loop is what drives processor_manager.on_task -> binder_internal.send; model that
+        # send raising the YMQ error by having the task routine raise it directly into the gather.
+        worker._task_manager = _StubCollaborator(_raise)
+
+        return worker
+
+    async def _drain_pending_tasks(self) -> None:
+        # The sibling loop coroutines created by __get_loops's gather keep running after the gather
+        # propagates the first exception; cancel them so the test loop tears down cleanly.
+        pending = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _run_get_loops(self, task_routine_error: ymq.YMQException) -> mock.MagicMock:
+        worker = self._build_worker(task_routine_error)
+        with mock.patch.object(worker_module, "logger") as mock_logger:
+            await worker._Worker__get_loops()  # name-mangled private method
+        await self._drain_pending_tasks()
+
+        # Regardless of the error, the worker must always reach clean teardown.
+        self.assertTrue(worker._binder_internal.destroyed, "worker did not reach teardown / destroy")
+        return mock_logger
+
+    async def test_socket_stop_requested_during_teardown_is_logged_not_crashed(self) -> None:
+        error = SocketStopRequestedError(ymq.ErrorCode.SocketStopRequested, "binder socket shut down mid-send")
+        mock_logger = await self._run_get_loops(error)
+
+        unhandled = [c for c in mock_logger.exception.call_args_list if "failed with unhandled exception" in str(c)]
+        self.assertEqual(unhandled, [], "SocketStopRequested surfaced as an unhandled-exception crash")
+
+        handled = [c for c in mock_logger.info.call_args_list if "shut down during teardown" in str(c)]
+        self.assertTrue(handled, "SocketStopRequested was not logged as an expected teardown condition")
+
+    async def test_unexpected_ymq_error_still_surfaces_as_unhandled(self) -> None:
+        # A YMQ error that is NOT an expected teardown condition must still be logged loudly, so real
+        # bugs continue to fail fast during development rather than being blanket-swallowed.
+        error = SysCallError(ymq.ErrorCode.SysCallError, "something genuinely broke")
+        mock_logger = await self._run_get_loops(error)
+
+        unhandled = [c for c in mock_logger.exception.call_args_list if "failed with unhandled exception" in str(c)]
+        self.assertTrue(unhandled, "an unexpected YMQ error should still be logged as an unhandled exception")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# READY FOR REVIEW.

This is to ensure the `YMQ.SocketStopRequested` is not surface out of `opengris-scaler`. This race condition happens typically when another thread calls `destroy()` and some pending `recv` is still in the event loop. 