### PR TITLE
Roll back oci to 2.177.0 and make Python 3.14 default in launchpad

### DIFF
--- a/docs/html_extra/launchpad/app.jsx
+++ b/docs/html_extra/launchpad/app.jsx
@@ -1383,7 +1383,7 @@ function App() {
   const [ociPrivateKey, setOciPrivateKey] = useState(() => IS_DEV ? (sessionStorage.getItem('launchpad-dev-oci-pk') || '') : '');
   const [transport, setTransport] = useState("ws");
   const [networkBackend, setNetBack] = useState("ymq");
-  const [pythonVersion, setPyVer] = useState("3.13");
+  const [pythonVersion, setPyVer] = useState("3.14");
   const [policy, setPolicy] = useState("simple");
   const [schedulerRequirements, setSchedulerReqs] = useState(
     "opengris-scaler[all]",

--- a/docs/html_extra/launchpad/provisioner.js
+++ b/docs/html_extra/launchpad/provisioner.js
@@ -404,7 +404,7 @@ function configFromToml(toml) {
     return base;
   });
 
-  var pyVer = "3.13";
+  var pyVer = "3.14";
   for (var j = 0; j < rawWms.length; j++) {
     if (rawWms[j].python_version) { pyVer = rawWms[j].python_version; break; }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ orb = [
     "botocore[crt]",
 ]
 oci = [
-    "oci",
+    "oci==2.177.0",
 ]
 all = [
     "opengris-scaler[aws]",


### PR DESCRIPTION
Pin the `oci` optional dependency to version 2.177.0 in `pyproject.toml`.

This is required to get Python 3.14 working again until https://github.com/oracle/oci-python-sdk/issues/874 is fixed.

Also changes the default Python version in the launchpad to 3.14.