### PR TITLE
orb worker manager: pass configured worker_manager_id to EC2 workers

### DIFF
--- a/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
@@ -426,11 +426,11 @@ set +e
         # --max-task-concurrency is not passed: scaler_worker_manager defaults to cpu_count - 1 workers,
         # where cpu_count is determined by the machine type the user configured in the ORB template.
         backend_prefix = f"SCALER_NETWORK_BACKEND={self._config.network_backend.name} "
-        script += f"""INSTANCE_ID=$(ec2-metadata --instance-id --quiet)
-{backend_prefix}nohup scaler_worker_manager baremetal_native {self._worker_scheduler_address!r} \\
+        wm_id = shlex.quote(worker_manager_config.worker_manager_id)
+        script += f"""{backend_prefix}nohup scaler_worker_manager baremetal_native {self._worker_scheduler_address!r} \\
     --mode fixed \\
     --worker-type ORB \\
-    --worker-manager-id "${{INSTANCE_ID}}" \\
+    --worker-manager-id {wm_id} \\
     --per-worker-task-queue-size {worker_config.per_worker_task_queue_size} \\
     --heartbeat-interval-seconds {worker_config.heartbeat_interval_seconds} \\
     --task-timeout-seconds {worker_config.task_timeout_seconds} \\


### PR DESCRIPTION
## Summary

Workers launched by the ORB provisioner used the EC2 instance ID (`$INSTANCE_ID` from `ec2-metadata`) as their `--worker-manager-id`. The `WorkerManagerRunner` on those instances heartbeated to the scheduler using the configured ID (e.g. `wm-1`). Because the two IDs never matched, the scheduler's `get_workers_by_manager_id` always returned an empty list for the manager, so scaling commands computed a desired worker count against zero connected workers and had no effect.

Fixed by passing `shlex.quote(worker_manager_config.worker_manager_id)` directly into the user-data script instead of reading `$INSTANCE_ID` from instance metadata at boot time.