### PR TITLE
fix Windows wheel build failing with VS 2026 runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,4 +267,4 @@ set -ex && \
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
 before-all = "pwsh -File ./scripts/cibuildwheel_before_all_windows.ps1"
-environment = { CMAKE_C_COMPILER = "cl", CMAKE_CXX_COMPILER = "cl", CMAKE_GENERATOR = "Visual Studio 17 2022", CMAKE_GENERATOR_PLATFORM = "x64", CMAKE_CONFIGURATION_TYPES = "Release", CMAKE_PREFIX_PATH = "$TEMP/opengris-thirdparties" }
+environment = { CMAKE_C_COMPILER = "cl", CMAKE_CXX_COMPILER = "cl", CMAKE_GENERATOR = "Visual Studio 18 2026", CMAKE_GENERATOR_PLATFORM = "x64", CMAKE_CONFIGURATION_TYPES = "Release", CMAKE_PREFIX_PATH = "$TEMP/opengris-thirdparties" }


### PR DESCRIPTION
## Summary

- The `windows-latest` runner now ships VS 18 (Visual Studio 2026) instead of VS 2022.
- PR #831 updated `scripts/library_tool.ps1` to detect VS 18 and select `"Visual Studio 18 2026"` as the CMake generator, but the same generator string was not updated in `pyproject.toml`.
- As a result, cibuildwheel's `python -m build` invocation inherited `CMAKE_GENERATOR=Visual Studio 17 2022` from the cibuildwheel environment config and CMake failed with "could not find any instance of Visual Studio", taking down the ubuntu and macOS Intel jobs via strategy cancellation.

Failed workflow: https://github.com/finos/opengris-scaler/actions/runs/28393412632/job/84125936660

## Change

`pyproject.toml` `[tool.cibuildwheel.windows]` environment: `CMAKE_GENERATOR` updated from `"Visual Studio 17 2022"` to `"Visual Studio 18 2026"`.