### PR TITLE
fix macOS ARM wheel build: pin runner to macos-15

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -20,7 +20,7 @@ jobs:
             cibw_archs: aarch64
           - os: windows-latest
             cibw_archs: AMD64
-          - os: macos-latest
+          - os: macos-15
             cibw_archs: native
           - os: macos-15-intel
             cibw_archs: native


### PR DESCRIPTION
## Summary

- `macos-latest` was recently promoted to `macos-26-arm64` (macOS 26.4). The ARM wheel build uses this runner and installs Homebrew's LLVM@21, whose precompiled bottle on macOS 26 has `MACOSX_DEPLOYMENT_TARGET=26.0` for its runtime libraries (`libc++`, `libc++abi`, `libunwind`).
- `delocate-wheel` bundles these dylibs into the wheel but rejects them because the wheel declares `MACOSX_DEPLOYMENT_TARGET=15.0` — a conflict it refuses to produce.
- The Intel runner (`macos-15-intel`) was unaffected because it runs macOS 15, where the LLVM@21 bottle targets macOS 15.
- Fix: pin the ARM matrix entry to `macos-15` (explicit Sequoia ARM runner) so the LLVM@21 bottle matches our deployment target.