### PR TITLE
fix: Postpone graphtask submission after future registration

### DIFF
--- a/src/scaler/client/client.py
+++ b/src/scaler/client/client.py
@@ -429,9 +429,8 @@ class Client:
         graph_task, compute_futures, finished_futures = self.__construct_graph(
             node_name_to_argument, call_graph, keys, block, capabilities
         )
-        self._object_buffer.commit_send_objects()
-        self._connector_agent.send(graph_task)
 
+        # future needs to be added first to avoid having task completes too early
         self._future_manager.add_future(
             self._future_factory(
                 task=Task(
@@ -448,6 +447,9 @@ class Client:
         )
         for future in compute_futures.values():
             self._future_manager.add_future(future)
+
+        self._object_buffer.commit_send_objects()
+        self._connector_agent.send(graph_task)
 
         # preserve the future insertion order based on inputted keys
         futures = {}


### PR DESCRIPTION
# READY TO REVIEW.

We need to postpone graph task submission after future registration. This is because if you have graph task result returned to the client without future being registered, then you will have early return and some task may be lost.

This changes only `get()` because `submit()` was already postponing graph task submission.

Note that it's hard to add test case for this one. Because we don't have hook to system internal.