### PR TITLE
fix: build OpenSSL static libs with -fPIC for the aarch64 wheel link

### DIFF
--- a/scripts/library_tool.sh
+++ b/scripts/library_tool.sh
@@ -258,7 +258,9 @@ elif [ "$1" == "openssl" ]; then
         extract_tar_gz "${OPENSSL_FOLDER_NAME}"
 
         cd "${THIRD_PARTY_COMPILED}/${OPENSSL_FOLDER_NAME}"
-        ./config --prefix="${PREFIX}" --libdir=lib no-tests no-shared
+        # -fPIC: the static libcrypto/libssl are linked into the _ymq.so shared module, so their objects
+        # (including OpenSSL's aarch64 asm) must be position-independent
+        ./config --prefix="${PREFIX}" --libdir=lib no-tests no-shared -fPIC
         make -j "${NUM_CORES}"
         echo "Compiled OpenSSL to ${THIRD_PARTY_COMPILED}/${OPENSSL_FOLDER_NAME}"
 


### PR DESCRIPTION
The static libcrypto/libssl are linked into the _ymq.so shared module, so their objects must be position-independent -- capnp and libuv are already built that way (CMAKE_POSITION_INDEPENDENT_CODE=ON), but OpenSSL's ./config was missing it. On x86_64 the link happened to succeed; on aarch64 it fails:

  ld: libcrypto.a(poly1305-armv8.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against
  symbol `poly1305_blocks_sve2' which may bind externally can not be used when
  making a shared object; recompile with -fPIC

Pass -fPIC to the OpenSSL build so its objects (including the aarch64 asm) are position-independent, matching the other two static dependencies.