### PR TITLE
DO NOT MERGE: diagnose windows CI hang in test_scheduler_disconnect_raises_disconnected_error

### DIFF
--- a/src/scaler/client/agent/client_agent.py
+++ b/src/scaler/client/agent/client_agent.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import sys
 import threading
+import time
 from concurrent.futures import Future
 from typing import Callable, Optional
 
@@ -193,6 +194,7 @@ class ClientAgent(threading.Thread):
                 create_async_loop_routine(self._connector_external.routine, 0),
                 create_async_loop_routine(self._connector_internal.routine, 0),
                 create_async_loop_routine(self._heartbeat_manager.routine, self._heartbeat_interval_seconds),
+                self.__diagnostic_canary(),  # DIAGNOSTIC: do not merge
             ]
 
             await asyncio.gather(*loops)
@@ -253,3 +255,15 @@ class ClientAgent(threading.Thread):
             (asyncio.CancelledError, ClientQuitException, ClientShutdownException, TimeoutError, YMQException),
         ):
             raise exception
+
+    async def __diagnostic_canary(self):
+        # DIAGNOSTIC: temporary instrumentation to determine whether the client agent's event loop
+        # keeps ticking on windows-latest after the scheduler is killed, or whether something stalls
+        # it outright (in which case neither the YMQException nor the heartbeat TimeoutError path
+        # would ever get a chance to run). Not for merge -- see PR discussion.
+        tick = 0
+        start = time.monotonic()
+        while True:
+            logger.error(f"DIAGNOSTIC canary: tick={tick} elapsed={time.monotonic() - start:.2f}s")
+            tick += 1
+            await asyncio.sleep(0.5)

--- a/src/scaler/client/agent/heartbeat_manager.py
+++ b/src/scaler/client/agent/heartbeat_manager.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 from concurrent.futures import Future
@@ -15,6 +16,8 @@ from scaler.config.types.address import AddressConfig, SocketType
 from scaler.io.mixins import AsyncConnector
 from scaler.protocol.capnp import ClientHeartbeat, ClientHeartbeatEcho, Resource
 from scaler.utility.mixins import Looper
+
+logger = logging.getLogger(__name__)
 
 
 class ClientHeartbeatManager(Looper, HeartbeatManager):
@@ -78,7 +81,12 @@ class ClientHeartbeatManager(Looper, HeartbeatManager):
         # its own dead-client cleanup over the WebSocket, and the user can
         # interrupt the kernel manually, so skip the local check in browser.
         if sys.platform != "emscripten":
-            if time.time() - self._last_scheduler_contact > self._death_timeout_seconds:
+            elapsed_since_contact = time.time() - self._last_scheduler_contact
+            logger.error(  # DIAGNOSTIC: do not merge
+                f"DIAGNOSTIC heartbeat routine tick: elapsed_since_contact={elapsed_since_contact:.2f}s "
+                f"death_timeout={self._death_timeout_seconds}s"
+            )
+            if elapsed_since_contact > self._death_timeout_seconds:
                 raise TimeoutError(
                     f"Timeout when connecting to scheduler {self._connector_external.address} "
                     f"in {self._death_timeout_seconds} seconds"

--- a/src/scaler/cluster/combo.py
+++ b/src/scaler/cluster/combo.py
@@ -34,11 +34,21 @@ from scaler.config.section.scheduler import PolicyConfig
 from scaler.config.types.address import AddressConfig, SocketType
 from scaler.config.types.worker import WorkerCapabilities
 from scaler.utility.network_util import get_available_tcp_port
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.worker_manager_adapter.baremetal.native import NativeWorkerManager
 
 logger = logging.getLogger(__name__)
 
 SCHEDULER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 10
+
+
+def _run_native_worker_manager(worker_manager: NativeWorkerManager) -> None:
+    # This process is spawned directly, so it must bootstrap its own logging/faulthandler.
+    logging_config = worker_manager.config.logging_config
+    bootstrap_process(
+        logging_config.paths, logging_config.config_file, logging_config.level, process_name="worker_manager_native"
+    )
+    worker_manager.run()
 
 
 class SchedulerClusterCombo:
@@ -130,7 +140,9 @@ class SchedulerClusterCombo:
             )
         )
 
-        self._worker_manager_process = multiprocessing.get_context("spawn").Process(target=self._worker_manager.run)
+        self._worker_manager_process = multiprocessing.get_context("spawn").Process(
+            target=_run_native_worker_manager, args=(self._worker_manager,)
+        )
 
         # Synthesized signal-disposition for the scheduler. multiprocessing.Process.terminate() is
         # TerminateProcess on Windows, which never runs Python signal handlers, so the scheduler would

--- a/src/scaler/cluster/object_storage_server.py
+++ b/src/scaler/cluster/object_storage_server.py
@@ -10,7 +10,8 @@ from scaler.io.ymq import YMQException
 from scaler.object_storage.object_storage_server import ObjectStorageServer
 from scaler.utility.exceptions import ObjectStorageException
 from scaler.utility.identifiers import ClientID, ObjectID
-from scaler.utility.logging.utility import get_logger_info, setup_logger
+from scaler.utility.logging.utility import get_logger_info
+from scaler.utility.process_bootstrap import bootstrap_process
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ class ObjectStorageServerProcess(multiprocessing.get_context("spawn").Process): 
         raise TimeoutError(f"ObjectStorageServer at {self._bind_address!r} failed to start within 30 seconds")
 
     def run(self) -> None:
-        setup_logger(
+        bootstrap_process(
             self._logging_paths, self._logging_config_file, self._logging_level, process_name="object_storage_server"
         )
         logger.info(f"ObjectStorageServer: start and listen to {self._bind_address!r}")

--- a/src/scaler/cluster/scheduler.py
+++ b/src/scaler/cluster/scheduler.py
@@ -7,7 +7,7 @@ from scaler.config.section.scheduler import PolicyConfig, SchedulerConfig
 from scaler.config.types.address import AddressConfig
 from scaler.scheduler.scheduler import Scheduler
 from scaler.utility.event_loop import register_event_loop, run_task_forever
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.utility.signal_handler import install_async_shutdown_handler
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ def run_scheduler(
     loop = asyncio.new_event_loop()
 
     async def _run() -> None:
-        setup_logger(logging_paths, logging_config_file, logging_level)
+        bootstrap_process(logging_paths, logging_config_file, logging_level)
         register_event_loop(scheduler_config.event_loop)
 
         scheduler = Scheduler(scheduler_config)

--- a/src/scaler/entry_points/object_storage_server.py
+++ b/src/scaler/entry_points/object_storage_server.py
@@ -4,13 +4,14 @@ import sys
 
 from scaler.config.section.object_storage_server import ObjectStorageServerConfig
 from scaler.object_storage.object_storage_server import ObjectStorageServer
-from scaler.utility.logging.utility import get_logger_info, setup_logger
+from scaler.utility.logging.utility import get_logger_info
+from scaler.utility.process_bootstrap import bootstrap_process
 
 
 def main():
     oss_config = ObjectStorageServerConfig.parse("Scaler Object Storage Server", "object_storage_server")
 
-    setup_logger(
+    bootstrap_process(
         oss_config.logging_config.paths,
         oss_config.logging_config.config_file,
         oss_config.logging_config.level,

--- a/src/scaler/entry_points/scaler.py
+++ b/src/scaler/entry_points/scaler.py
@@ -23,7 +23,7 @@ from scaler.config.section.symphony_worker_manager import SymphonyWorkerManagerC
 from scaler.config.section.webgui import WebGUIConfig
 from scaler.config.section.worker_manager_union import WorkerManagerUnion
 from scaler.utility.event_loop import register_event_loop
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 
 
 @dataclasses.dataclass
@@ -50,7 +50,7 @@ def _run_scheduler(config: SchedulerConfig) -> None:
 
 
 def _run_worker_manager(config: WorkerManagerUnion) -> None:
-    setup_logger(
+    bootstrap_process(
         config.logging_config.paths,
         config.logging_config.config_file,
         config.logging_config.level,

--- a/src/scaler/entry_points/worker_manager.py
+++ b/src/scaler/entry_points/worker_manager.py
@@ -15,7 +15,7 @@ from scaler.config.section.oci_raw_worker_manager import OCIRawWorkerManagerConf
 from scaler.config.section.orb_aws_ec2_worker_manager import ORBAWSEC2WorkerManagerConfig
 from scaler.config.section.symphony_worker_manager import SymphonyWorkerManagerConfig
 from scaler.utility.event_loop import register_event_loop
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 
 _AnyWorkerManagerConfig = Union[
     NativeWorkerManagerConfig,
@@ -90,7 +90,7 @@ def main() -> None:
         config_cls.parse_with_section("scaler_worker_manager", section_data, argv=remaining_argv),
     )
 
-    setup_logger(
+    bootstrap_process(
         wm_config.logging_config.paths,
         wm_config.logging_config.config_file,
         wm_config.logging_config.level,

--- a/src/scaler/ui/webgui.py
+++ b/src/scaler/ui/webgui.py
@@ -4,13 +4,13 @@ import uvicorn  # pyright: ignore[reportMissingImports]
 
 from scaler.config.section.webgui import WebGUIConfig
 from scaler.ui.app import create_app
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 
 logger = logging.getLogger(__name__)
 
 
 def start_webgui(config: WebGUIConfig) -> None:
-    setup_logger(
+    bootstrap_process(
         config.logging_config.paths, config.logging_config.config_file, config.logging_config.level, process_name="gui"
     )
 

--- a/src/scaler/utility/event_loop.py
+++ b/src/scaler/utility/event_loop.py
@@ -1,9 +1,11 @@
 import asyncio
 import enum
 import logging
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 class EventLoopType(enum.Enum):
@@ -61,8 +63,8 @@ def create_async_loop_routine(routine: Callable[[], Awaitable], seconds: int):
 
 
 def run_task_forever(
-    loop: asyncio.AbstractEventLoop, task: Awaitable[None], cleanup_callback: Optional[Callable[[], None]] = None
-) -> None:
+    loop: asyncio.AbstractEventLoop, task: Awaitable[T], cleanup_callback: Optional[Callable[[], None]] = None
+) -> T:
     """
     run task until completion and close the loop
 
@@ -72,7 +74,7 @@ def run_task_forever(
     """
 
     try:
-        loop.run_until_complete(task)
+        return loop.run_until_complete(task)
     finally:
         pending = asyncio.all_tasks(loop)
         for pending_task in pending:

--- a/src/scaler/utility/logging/utility.py
+++ b/src/scaler/utility/logging/utility.py
@@ -48,12 +48,13 @@ def setup_logger(
         logging.config.fileConfig(logging_config_file, disable_existing_loggers=True)
         return
 
-    resolved_log_paths = [LogPath(log_type=__detect_log_types(file_name), path=file_name) for file_name in log_paths]
+    resolved_log_paths = [LogPath(log_type=detect_log_type(file_name), path=file_name) for file_name in log_paths]
     __logging_config(log_paths=resolved_log_paths, logging_level=logging_level, process_name=process_name)
     logger.info(f"logging to {log_paths}")
 
 
-def __detect_log_types(file_name: str) -> LogType:
+def detect_log_type(file_name: str) -> LogType:
+    """Classify a configured log path: "-" and "/dev/stdout" mean write to stdout, anything else is a file."""
     if file_name in {"-", "/dev/stdout"}:
         return LogType.Screen
 

--- a/src/scaler/utility/process_bootstrap.py
+++ b/src/scaler/utility/process_bootstrap.py
@@ -1,0 +1,39 @@
+import faulthandler
+import logging
+import os
+import typing
+
+from scaler.config.defaults import DEFAULT_LOGGING_PATHS
+from scaler.utility.logging.utility import LoggingLevel, setup_logger
+
+logger = logging.getLogger(__name__)
+
+_faulthandler_file: typing.Optional[typing.IO] = None
+
+
+def bootstrap_process(
+    log_paths: typing.Tuple[str, ...] = DEFAULT_LOGGING_PATHS,
+    logging_config_file: typing.Optional[str] = None,
+    logging_level: str = LoggingLevel.INFO.name,
+    process_name: str = "scaler",
+) -> None:
+    """Configure logging and enable a fatal-signal crash-dump handler for this process."""
+    setup_logger(log_paths, logging_config_file, logging_level, process_name)
+    __enable_faulthandler(log_paths[0] if log_paths else None)
+
+
+def __enable_faulthandler(log_path: typing.Optional[str]) -> None:
+    global _faulthandler_file
+
+    if log_path is None:
+        faulthandler.enable(all_threads=True)
+        logger.info("fatal signal crash dumps will be written to stderr")
+        return
+
+    try:
+        _faulthandler_file = open(os.path.expandvars(os.path.expanduser(log_path)), "a")
+        faulthandler.enable(file=_faulthandler_file, all_threads=True)
+        logger.info(f"fatal signal crash dumps will be written to {log_path!r}")
+    except OSError:
+        faulthandler.enable(all_threads=True)
+        logger.info(f"fatal signal crash dumps will be written to stderr (failed to open {log_path!r})")

--- a/src/scaler/utility/process_bootstrap.py
+++ b/src/scaler/utility/process_bootstrap.py
@@ -1,6 +1,5 @@
 import faulthandler
 import logging
-import os
 import sys
 import typing
 
@@ -37,7 +36,7 @@ def __enable_faulthandler(log_path: str) -> None:
         return
 
     try:
-        _faulthandler_file = open(os.path.expandvars(os.path.expanduser(log_path)), "a")
+        _faulthandler_file = open(log_path, "a")
         faulthandler.enable(file=_faulthandler_file, all_threads=True)
         logger.info(f"fatal signal crash dumps will be written to {log_path!r}")
     except OSError:

--- a/src/scaler/utility/process_bootstrap.py
+++ b/src/scaler/utility/process_bootstrap.py
@@ -1,10 +1,11 @@
 import faulthandler
 import logging
 import os
+import sys
 import typing
 
 from scaler.config.defaults import DEFAULT_LOGGING_PATHS
-from scaler.utility.logging.utility import LoggingLevel, setup_logger
+from scaler.utility.logging.utility import LoggingLevel, LogType, detect_log_type, setup_logger
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,11 @@ def __enable_faulthandler(log_path: typing.Optional[str]) -> None:
     if log_path is None:
         faulthandler.enable(all_threads=True)
         logger.info("fatal signal crash dumps will be written to stderr")
+        return
+
+    if detect_log_type(log_path) == LogType.Screen:
+        faulthandler.enable(file=sys.stdout, all_threads=True)
+        logger.info("fatal signal crash dumps will be written to stdout")
         return
 
     try:

--- a/src/scaler/utility/process_bootstrap.py
+++ b/src/scaler/utility/process_bootstrap.py
@@ -5,7 +5,7 @@ import sys
 import typing
 
 from scaler.config.defaults import DEFAULT_LOGGING_PATHS
-from scaler.utility.logging.utility import LoggingLevel, LogType, detect_log_type, setup_logger
+from scaler.utility.logging.utility import LoggingLevel, LogType, detect_log_type, get_logger_info, setup_logger
 
 logger = logging.getLogger(__name__)
 
@@ -20,16 +20,16 @@ def bootstrap_process(
 ) -> None:
     """Configure logging and enable a fatal-signal crash-dump handler for this process."""
     setup_logger(log_paths, logging_config_file, logging_level, process_name)
-    __enable_faulthandler(log_paths[0] if log_paths else None)
+
+    # Read the primary logging location back off the logger itself, rather than off log_paths:
+    # setup_logger ignores log_paths in favor of logging_config_file when one is given, so log_paths
+    # is not a reliable source of truth for where logging actually ended up.
+    _, _, resolved_log_paths = get_logger_info(logging.getLogger("scaler"))
+    __enable_faulthandler(resolved_log_paths[0])
 
 
-def __enable_faulthandler(log_path: typing.Optional[str]) -> None:
+def __enable_faulthandler(log_path: str) -> None:
     global _faulthandler_file
-
-    if log_path is None:
-        faulthandler.enable(all_threads=True)
-        logger.info("fatal signal crash dumps will be written to stderr")
-        return
 
     if detect_log_type(log_path) == LogType.Screen:
         faulthandler.enable(file=sys.stdout, all_threads=True)

--- a/src/scaler/worker/agent/processor/processor.py
+++ b/src/scaler/worker/agent/processor/processor.py
@@ -30,8 +30,8 @@ from scaler.protocol.capnp import (
 )
 from scaler.utility.exceptions import ObjectStorageException
 from scaler.utility.identifiers import ClientID, ObjectID, TaskID
-from scaler.utility.logging.utility import setup_logger
 from scaler.utility.metadata.task_flags import retrieve_task_flags_from_task
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.utility.serialization import serialize_failure
 from scaler.worker.agent.processor.object_cache import ObjectCache
 from scaler.worker.agent.processor.streaming_buffer import StreamingBuffer
@@ -115,7 +115,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
         if "/dev/stdout" in self._logging_paths:
             logging_paths.append("/dev/stdout")
 
-        setup_logger(log_paths=tuple(logging_paths), logging_level=self._logging_level)
+        bootstrap_process(log_paths=tuple(logging_paths), logging_level=self._logging_level)
         tblib.pickling_support.install()
 
         self._backend = get_network_backend_from_env()

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -129,7 +129,7 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
         except asyncio.CancelledError:
             logger.info(f"{self.identity!r}: cancelled, shutting down")
         except ObjectStorageException as e:
-            logger.info(f"{self.identity!r}: object storage exception during shutdown: {e}")
+            logger.info(f"{self.identity!r}: object storage exception: {e}")
         except ymq.YMQException as e:
             if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
                 logger.info(f"{self.identity!r}: connector socket closed by remote end: {e}")

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -129,7 +129,10 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
         except asyncio.CancelledError:
             logger.info(f"{self.identity!r}: cancelled, shutting down")
         except ObjectStorageException as e:
-            logger.info(f"{self.identity!r}: object storage exception: {e}")
+            # Nobody asked this worker to stop; it gave up because it could not reach a
+            # dependency it needs to do its job, so this is an anomaly worth a nonzero exit.
+            logger.warning(f"{self.identity!r}: object storage exception: {e}")
+            exit_code = 1
         except ymq.YMQException as e:
             if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
                 logger.info(f"{self.identity!r}: connector socket closed by remote end: {e}")
@@ -142,8 +145,14 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
             else:
                 logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
                 exit_code = 1
-        except (ClientShutdownException, TimeoutError) as e:
+        except ClientShutdownException as e:
             logger.info(f"{self.identity!r}: {str(e)}")
+        except TimeoutError as e:
+            # The worker decided on its own that it is orphaned (no heartbeat from the scheduler
+            # within death_timeout_seconds), not that anyone asked it to stop: an anomaly worth a
+            # nonzero exit.
+            logger.warning(f"{self.identity!r}: {str(e)}")
+            exit_code = 1
         except Exception as e:
             logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
             exit_code = 1

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -34,7 +34,7 @@ from scaler.protocol.capnp import (
 from scaler.utility.event_loop import create_async_loop_routine, register_event_loop, run_task_forever
 from scaler.utility.exceptions import ClientShutdownException, ObjectStorageException
 from scaler.utility.identifiers import ProcessorID, WorkerID
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.utility.signal_handler import install_async_shutdown_handler
 from scaler.worker.agent.heartbeat_manager import VanillaHeartbeatManager
 from scaler.worker.agent.processor_manager import VanillaProcessorManager
@@ -160,7 +160,7 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
             self._connector_storage.destroy()
 
     def __initialize(self):
-        setup_logger()
+        bootstrap_process()
         register_event_loop(self._event_loop)
 
         self._backend = get_network_backend_from_env(io_threads=self._io_threads)

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import multiprocessing
 import pathlib
+import sys
 import uuid
 from typing import Dict, Optional, Tuple
 
@@ -113,14 +114,44 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
 
     def run(self) -> None:
         self._loop = asyncio.new_event_loop()
-        run_task_forever(self._loop, self._run(), cleanup_callback=self._cleanup)
+        exit_code = run_task_forever(self._loop, self._run(), cleanup_callback=self._cleanup)
+        if exit_code:
+            sys.exit(exit_code)
 
-    async def _run(self) -> None:
-        self.__initialize()
+    async def _run(self) -> int:
+        exit_code = 0
+        try:
+            self.__initialize()
 
-        self._task = self._loop.create_task(self.__get_loops())
-        self.__register_signal()
-        await self._task
+            self._task = self._loop.create_task(self.__main_loop())
+            self.__register_signal()
+            await self._task
+        except asyncio.CancelledError:
+            logger.info(f"{self.identity!r}: cancelled, shutting down")
+        except ObjectStorageException as e:
+            logger.info(f"{self.identity!r}: object storage exception during shutdown: {e}")
+        except ymq.YMQException as e:
+            if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
+                logger.info(f"{self.identity!r}: connector socket closed by remote end: {e}")
+            elif e.code == ymq.ErrorCode.SocketStopRequested:
+                # A YMQ socket (e.g. the internal binder) was shut down via `disconnect`/teardown
+                # while a send or recv driven by one of the loops above was still in flight. Like
+                # ConnectorSocketClosedByRemoteEnd, this is an expected teardown condition that is
+                # out of our control.
+                logger.info(f"{self.identity!r}: a YMQ socket was shut down during teardown: {e}")
+            else:
+                logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+                exit_code = 1
+        except (ClientShutdownException, TimeoutError) as e:
+            logger.info(f"{self.identity!r}: {str(e)}")
+        except Exception as e:
+            logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+            exit_code = 1
+        finally:
+            await self.__teardown()
+
+        logger.info(f"{self.identity!r}: quit")
+        return exit_code
 
     def _cleanup(self):
         # the storage connector has asyncio resources that need to be cleaned up
@@ -242,71 +273,49 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
 
         raise TypeError(f"Unknown message from {processor_id!r}: {message}")
 
-    async def __get_loops(self):
-        try:
-            # Connection setup lives inside the try so a connection-level failure here (e.g. the scheduler is
-            # never reachable, which surfaces as ConnectorSocketClosedByRemoteEnd once the connector exhausts its
-            # retries) is absorbed by the YMQException handler below and shuts the worker down cleanly, instead of
-            # escaping __get_loops as an unhandled exception that crashes the worker process.
-            await self._connector_external.connect(
-                self._address, ConnectorRemoteType.Binder, security_config=self._security_config
-            )
-            await self._binder_internal.bind(self._address_internal)
+    async def __main_loop(self) -> None:
+        await self._connector_external.connect(
+            self._address, ConnectorRemoteType.Binder, security_config=self._security_config
+        )
+        await self._binder_internal.bind(self._address_internal)
 
-            if self._object_storage_address is not None:
-                # With a manually set storage address, immediately connect to the object storage server.
-                await self._connector_storage.connect(
-                    self._object_storage_address, security_config=self._security_config
-                )
+        if self._object_storage_address is not None:
+            # With a manually set storage address, immediately connect to the object storage server.
+            await self._connector_storage.connect(self._object_storage_address, security_config=self._security_config)
 
-            await asyncio.gather(
-                self._processor_manager.initialize(),
-                create_async_loop_routine(self._connector_external.routine, 0),
-                create_async_loop_routine(self._connector_storage.routine, 0),
-                create_async_loop_routine(self._binder_internal.routine, 0),
-                create_async_loop_routine(self._heartbeat_manager.routine, self._heartbeat_interval_seconds),
-                create_async_loop_routine(self._timeout_manager.routine, 1),
-                create_async_loop_routine(self._task_manager.routine, 0),
-                create_async_loop_routine(self._profiling_manager.routine, PROFILING_INTERVAL_SECONDS),
-            )
-        except asyncio.CancelledError:
-            pass
+        await asyncio.gather(
+            self._processor_manager.initialize(),
+            create_async_loop_routine(self._connector_external.routine, 0),
+            create_async_loop_routine(self._connector_storage.routine, 0),
+            create_async_loop_routine(self._binder_internal.routine, 0),
+            create_async_loop_routine(self._heartbeat_manager.routine, self._heartbeat_interval_seconds),
+            create_async_loop_routine(self._timeout_manager.routine, 1),
+            create_async_loop_routine(self._task_manager.routine, 0),
+            create_async_loop_routine(self._profiling_manager.routine, PROFILING_INTERVAL_SECONDS),
+        )
 
-        except ObjectStorageException:
-            pass
-
-        # TODO: Should the object storage connector catch this error?
-        except ymq.YMQException as e:
-            if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
-                pass
-            elif e.code == ymq.ErrorCode.SocketStopRequested:
-                # A YMQ socket (e.g. the internal binder) was shut down via `disconnect`/teardown
-                # while a send or recv driven by one of the loops above was still in flight. Like
-                # ConnectorSocketClosedByRemoteEnd, this is an expected teardown condition that is
-                # out of our control: log it, but never let it surface as a crash.
-                logger.info(f"{self.identity!r}: a YMQ socket was shut down during teardown: {e}")
-            else:
-                logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
-        except (ClientShutdownException, TimeoutError) as e:
-            logger.info(f"{self.identity!r}: {str(e)}")
-        except Exception as e:
-            logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
-
+    async def __teardown(self) -> None:
+        # Guarded with `is not None` throughout: this runs even when __initialize failed partway
+        # through, so some of these may never have been created.
         if isinstance(self._backend, ZMQNetworkBackend):
             await self.__graceful_shutdown()
 
-        self._connector_external.destroy()
-        self._processor_manager.destroy("quit")
-        self._binder_internal.destroy()
-        self._connector_storage.destroy()
+        if self._connector_external is not None:
+            self._connector_external.destroy()
+        if self._processor_manager is not None:
+            self._processor_manager.destroy("quit")
+        if self._binder_internal is not None:
+            self._binder_internal.destroy()
+        if self._connector_storage is not None:
+            self._connector_storage.destroy()
 
-        if self._address_internal.type == SocketType.ipc and not self._address_internal.host.startswith(
-            "\\\\.\\pipe\\"
+        if (
+            self._address_internal is not None
+            and self._address_internal.type == SocketType.ipc
+            and not self._address_internal.host.startswith("\\\\.\\pipe\\")
         ):
             # Windows named pipes have no filesystem entry to remove; only unlink Unix-domain-socket paths.
             pathlib.Path(self._address_internal.host).unlink(missing_ok=True)
-
-        logger.info(f"{self.identity!r}: quit")
 
     def __register_signal(self):
         if isinstance(self._backend, ZMQNetworkBackend):
@@ -318,6 +327,9 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
         asyncio.ensure_future(self.__graceful_shutdown())
 
     async def __graceful_shutdown(self):
+        if self._connector_external is None:
+            return
+
         try:
             await self._connector_external.send(DisconnectRequest(worker=self.identity))
         except ymq.YMQException:

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, List, Optional
 import psutil
 
 from scaler.config.section.native_worker_manager import NativeWorkerManagerConfig, NativeWorkerManagerMode
-from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.worker.worker import Worker
 from scaler.worker_manager_adapter.capacity_coordinator import CapacityCoordinator
 from scaler.worker_manager_adapter.common import extract_desired_count
@@ -52,7 +51,6 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
         self._preload = config.worker_config.preload
         self._logging_paths = config.logging_config.paths
         self._logging_level = config.logging_config.level
-        self._logging_config_file = config.logging_config.config_file
         self._security_config = config.security
 
         if config.worker_type is not None:
@@ -95,25 +93,20 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
         )
 
     def run_fixed(self) -> None:
-        bootstrap_process(
-            self._logging_paths, self._logging_config_file, self._logging_level, process_name="worker_manager_native"
-        )
-
         workers: List[Worker] = []
         for _ in range(self._max_task_concurrency):
             worker = self._create_worker()
             worker.start()
             workers.append(worker)
 
-        shutting_down = False
+        terminated_by_us: set[Worker] = set()
 
         def _on_signal(sig: int, frame: object) -> None:
-            nonlocal shutting_down
-            shutting_down = True
             logger.info("NativeWorkerProvisioner (FIXED): received signal %d, terminating workers", sig)
             for worker in workers:
                 if worker.is_alive():
                     worker.terminate()
+                    terminated_by_us.add(worker)
 
         signal.signal(signal.SIGTERM, _on_signal)
         signal.signal(signal.SIGINT, _on_signal)
@@ -124,7 +117,7 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
                 worker = workers_by_sentinel.pop(sentinel)
                 worker.join()
 
-                if shutting_down:
+                if worker in terminated_by_us:
                     logger.info(
                         f"native worker {worker.identity!r} stopped (exitcode={_describe_exitcode(worker.exitcode)})"
                     )

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, List, Optional
 import psutil
 
 from scaler.config.section.native_worker_manager import NativeWorkerManagerConfig, NativeWorkerManagerMode
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.worker.worker import Worker
 from scaler.worker_manager_adapter.capacity_coordinator import CapacityCoordinator
 from scaler.worker_manager_adapter.common import extract_desired_count
@@ -94,6 +95,10 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
         )
 
     def run_fixed(self) -> None:
+        bootstrap_process(
+            self._logging_paths, self._logging_config_file, self._logging_level, process_name="worker_manager_native"
+        )
+
         workers: List[Worker] = []
         for _ in range(self._max_task_concurrency):
             worker = self._create_worker()

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -128,6 +128,11 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
                     logger.info(
                         f"native worker {worker.identity!r} stopped (exitcode={_describe_exitcode(worker.exitcode)})"
                     )
+                elif worker.exitcode == 0:
+                    # A worker exits 0 only when it was told to stop (by the scheduler or a
+                    # cancellation), never as a symptom of a problem, even though this manager
+                    # was not the one that asked.
+                    logger.info(f"native worker {worker.identity!r} shut down cleanly")
                 else:
                     logger.warning(
                         f"native worker {worker.identity!r} exited unexpectedly "

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing.connection
 import os
 import signal
 import sys
 import uuid
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, List, Optional
 
 import psutil
 
 from scaler.config.section.native_worker_manager import NativeWorkerManagerConfig, NativeWorkerManagerMode
-from scaler.utility.identifiers import WorkerID
 from scaler.worker.worker import Worker
 from scaler.worker_manager_adapter.capacity_coordinator import CapacityCoordinator
 from scaler.worker_manager_adapter.common import extract_desired_count
@@ -21,6 +21,15 @@ if TYPE_CHECKING:
     from scaler.protocol.capnp import WorkerManagerCommand
 
 logger = logging.getLogger(__name__)
+
+
+def _describe_exitcode(exitcode: Optional[int]) -> str:
+    if exitcode is not None and exitcode < 0:
+        try:
+            return f"{exitcode} ({signal.Signals(-exitcode).name})"
+        except ValueError:
+            pass
+    return str(exitcode)
 
 
 class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
@@ -85,23 +94,40 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
         )
 
     def run_fixed(self) -> None:
-        fixed_workers: Dict[WorkerID, Worker] = {}
+        workers: List[Worker] = []
         for _ in range(self._max_task_concurrency):
             worker = self._create_worker()
             worker.start()
-            fixed_workers[worker.identity] = worker
+            workers.append(worker)
+
+        shutting_down = False
 
         def _on_signal(sig: int, frame: object) -> None:
+            nonlocal shutting_down
+            shutting_down = True
             logger.info("NativeWorkerProvisioner (FIXED): received signal %d, terminating workers", sig)
-            for worker in fixed_workers.values():
+            for worker in workers:
                 if worker.is_alive():
                     worker.terminate()
 
         signal.signal(signal.SIGTERM, _on_signal)
         signal.signal(signal.SIGINT, _on_signal)
 
-        for worker in fixed_workers.values():
-            worker.join()
+        workers_by_sentinel = {worker.sentinel: worker for worker in workers}
+        while workers_by_sentinel:
+            for sentinel in multiprocessing.connection.wait(list(workers_by_sentinel)):
+                worker = workers_by_sentinel.pop(sentinel)
+                worker.join()
+
+                if shutting_down:
+                    logger.info(
+                        f"native worker {worker.identity!r} stopped (exitcode={_describe_exitcode(worker.exitcode)})"
+                    )
+                else:
+                    logger.warning(
+                        f"native worker {worker.identity!r} exited unexpectedly "
+                        f"(exitcode={_describe_exitcode(worker.exitcode)})"
+                    )
 
     async def set_desired_task_concurrency(
         self, requests: List[WorkerManagerCommand.DesiredTaskConcurrencyRequest]

--- a/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
+++ b/src/scaler/worker_manager_adapter/orb_aws_ec2/worker_manager.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError as exc:
 from scaler.config.section.orb_aws_ec2_worker_manager import ORBAWSEC2WorkerManagerConfig
 from scaler.protocol.capnp import WorkerManagerCommand
 from scaler.utility.event_loop import register_event_loop, run_task_forever
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.worker_manager_adapter.capacity_coordinator import CapacityCoordinator
 from scaler.worker_manager_adapter.common import extract_desired_count, format_capabilities, load_requirements_content
 from scaler.worker_manager_adapter.mixins import DeclarativeWorkerProvisioner
@@ -304,9 +304,9 @@ class ORBAWSEC2WorkerManager:
         get_container().register_instance(ConfigurationManager, ConfigurationManager(config_dict=app_config))
         os.environ["AWS_DEFAULT_REGION"] = self._config.aws_region
         async with orb(app_config=app_config) as sdk:
-            # setup_logger is called after the ORB context is entered because ORB reconfigures
+            # bootstrap_process is called after the ORB context is entered because ORB reconfigures
             # the root logger during __aenter__, which would otherwise suppress scaler log output.
-            setup_logger(self._logging_paths, self._logging_config_file, self._logging_level)
+            bootstrap_process(self._logging_paths, self._logging_config_file, self._logging_level)
             await self._setup(sdk)
             try:
                 await self._runner.run_in_loop(self._loop)

--- a/src/scaler/worker_manager_adapter/worker_process.py
+++ b/src/scaler/worker_manager_adapter/worker_process.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import multiprocessing
 import signal
+import sys
 from collections import deque
 from typing import Callable, Dict, Optional
 
@@ -21,7 +22,7 @@ from scaler.protocol.capnp import (
     WorkerHeartbeatEcho,
 )
 from scaler.utility.event_loop import create_async_loop_routine, register_event_loop, run_task_forever
-from scaler.utility.exceptions import ClientShutdownException
+from scaler.utility.exceptions import ClientShutdownException, ObjectStorageException
 from scaler.utility.identifiers import WorkerID
 from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.worker.agent.timeout_manager import VanillaTimeoutManager
@@ -92,14 +93,43 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
 
     def run(self) -> None:
         self._loop = asyncio.new_event_loop()
-        run_task_forever(self._loop, self._run(), cleanup_callback=self._cleanup)
+        exit_code = run_task_forever(self._loop, self._run(), cleanup_callback=self._cleanup)
+        if exit_code:
+            sys.exit(exit_code)
 
-    async def _run(self) -> None:
-        self.__initialize()
+    async def _run(self) -> int:
+        exit_code = 0
+        try:
+            self.__initialize()
 
-        self._task = self._loop.create_task(self.__get_loops())
-        self.__register_signal()
-        await self._task
+            self._task = self._loop.create_task(self.__main_loop())
+            self.__register_signal()
+            await self._task
+        except asyncio.CancelledError:
+            logger.info(f"{self.identity!r}: cancelled, shutting down")
+        except ObjectStorageException as e:
+            logger.info(f"{self.identity!r}: object storage exception: {e}")
+        except ymq.YMQException as e:
+            if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
+                logger.info(f"{self.identity!r}: connector socket closed by remote end: {e}")
+            elif e.code == ymq.ErrorCode.SocketStopRequested:
+                # A YMQ socket was shut down via `disconnect`/teardown while a send or recv driven
+                # by one of the loops above was still in flight: an expected teardown condition
+                # that is out of our control.
+                logger.info(f"{self.identity!r}: a YMQ socket was shut down during teardown: {e}")
+            else:
+                logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+                exit_code = 1
+        except (ClientShutdownException, TimeoutError) as e:
+            logger.info(f"{self.identity!r}: {str(e)}")
+        except Exception as e:
+            logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+            exit_code = 1
+        finally:
+            await self.__teardown()
+
+        logger.info(f"{self.identity!r}: quit")
+        return exit_code
 
     def _cleanup(self) -> None:
         if self._connector_external is not None:
@@ -190,7 +220,7 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
 
         raise TypeError(f"Unknown {message=}")
 
-    async def __get_loops(self) -> None:
+    async def __main_loop(self) -> None:
         await self._connector_external.connect(
             self._address, ConnectorRemoteType.Binder, security_config=self._security_config
         )
@@ -198,27 +228,19 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
         if self._object_storage_address is not None:
             await self._connector_storage.connect(self._object_storage_address, security_config=self._security_config)
 
-        try:
-            await asyncio.gather(
-                create_async_loop_routine(self._connector_external.routine, 0),
-                create_async_loop_routine(self._connector_storage.routine, 0),
-                create_async_loop_routine(self._heartbeat_manager.routine, self._heartbeat_interval_seconds),
-                create_async_loop_routine(self._timeout_manager.routine, 1),
-                create_async_loop_routine(self._execution_backend.routine, 0),
-                create_async_loop_routine(self._task_manager.process_task, 0),
-                create_async_loop_routine(self._task_manager.resolve_tasks, 0),
-            )
-        except asyncio.CancelledError:
-            pass
-        except (ClientShutdownException, TimeoutError) as e:
-            logger.info(f"{self.identity!r}: {str(e)}")
-        except Exception as e:
-            logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
+        await asyncio.gather(
+            create_async_loop_routine(self._connector_external.routine, 0),
+            create_async_loop_routine(self._connector_storage.routine, 0),
+            create_async_loop_routine(self._heartbeat_manager.routine, self._heartbeat_interval_seconds),
+            create_async_loop_routine(self._timeout_manager.routine, 1),
+            create_async_loop_routine(self._execution_backend.routine, 0),
+            create_async_loop_routine(self._task_manager.process_task, 0),
+            create_async_loop_routine(self._task_manager.resolve_tasks, 0),
+        )
 
+    async def __teardown(self) -> None:
         if isinstance(self._backend, ZMQNetworkBackend):
             await self.__graceful_shutdown()
-
-        logger.info(f"{self.identity!r}: quit")
 
     def __register_signal(self) -> None:
         if isinstance(self._backend, ZMQNetworkBackend):
@@ -229,6 +251,9 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
             self._loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.ensure_future(self.__graceful_shutdown()))
 
     async def __graceful_shutdown(self) -> None:
+        if self._connector_external is None:
+            return
+
         try:
             await self._connector_external.send(DisconnectRequest(worker=self.identity))
         except ymq.YMQException:

--- a/src/scaler/worker_manager_adapter/worker_process.py
+++ b/src/scaler/worker_manager_adapter/worker_process.py
@@ -108,7 +108,10 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
         except asyncio.CancelledError:
             logger.info(f"{self.identity!r}: cancelled, shutting down")
         except ObjectStorageException as e:
-            logger.info(f"{self.identity!r}: object storage exception: {e}")
+            # Nobody asked this worker to stop; it gave up because it could not reach a
+            # dependency it needs to do its job, so this is an anomaly worth a nonzero exit.
+            logger.warning(f"{self.identity!r}: object storage exception: {e}")
+            exit_code = 1
         except ymq.YMQException as e:
             if e.code == ymq.ErrorCode.ConnectorSocketClosedByRemoteEnd:
                 logger.info(f"{self.identity!r}: connector socket closed by remote end: {e}")
@@ -120,8 +123,14 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
             else:
                 logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
                 exit_code = 1
-        except (ClientShutdownException, TimeoutError) as e:
+        except ClientShutdownException as e:
             logger.info(f"{self.identity!r}: {str(e)}")
+        except TimeoutError as e:
+            # The worker decided on its own that it is orphaned (no heartbeat from the scheduler
+            # within death_timeout_seconds), not that anyone asked it to stop: an anomaly worth a
+            # nonzero exit.
+            logger.warning(f"{self.identity!r}: {str(e)}")
+            exit_code = 1
         except Exception as e:
             logger.exception(f"{self.identity!r}: failed with unhandled exception:\n{e}")
             exit_code = 1

--- a/src/scaler/worker_manager_adapter/worker_process.py
+++ b/src/scaler/worker_manager_adapter/worker_process.py
@@ -23,7 +23,7 @@ from scaler.protocol.capnp import (
 from scaler.utility.event_loop import create_async_loop_routine, register_event_loop, run_task_forever
 from scaler.utility.exceptions import ClientShutdownException
 from scaler.utility.identifiers import WorkerID
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.process_bootstrap import bootstrap_process
 from scaler.worker.agent.timeout_manager import VanillaTimeoutManager
 from scaler.worker_manager_adapter.heartbeat_manager import HeartbeatManager
 from scaler.worker_manager_adapter.mixins import ExecutionBackend, ProcessorStatusProvider
@@ -109,7 +109,7 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
             self._connector_storage.destroy()
 
     def __initialize(self) -> None:
-        setup_logger()
+        bootstrap_process()
         register_event_loop(self._event_loop)
 
         self._backend = get_network_backend_from_env(io_threads=self._io_threads)

--- a/tests/entry_points/test_all.py
+++ b/tests/entry_points/test_all.py
@@ -328,7 +328,7 @@ class TestScalerAllConfigShape(unittest.TestCase):
 
 
 class TestRunWorkerManager(unittest.TestCase):
-    """Tests that _run_worker_manager calls register_event_loop and setup_logger from the per-manager config."""
+    """Tests that _run_worker_manager calls register_event_loop and bootstrap_process from the per-manager config."""
 
     def _make_native_config(self, event_loop="builtin", logging_level="INFO"):
         from scaler.config.common.logging import LoggingConfig
@@ -353,7 +353,7 @@ class TestRunWorkerManager(unittest.TestCase):
 
         with (
             patch("scaler.entry_points.scaler.register_event_loop") as mock_reg,
-            patch("scaler.entry_points.scaler.setup_logger"),
+            patch("scaler.entry_points.scaler.bootstrap_process"),
             patch("scaler.worker_manager_adapter.baremetal.native.NativeWorkerManager") as mock_nm,
         ):
             mock_nm.return_value.run.return_value = None
@@ -361,13 +361,13 @@ class TestRunWorkerManager(unittest.TestCase):
 
         mock_reg.assert_called_once_with("builtin")
 
-    def test_setup_logger_called_with_logging_config(self) -> None:
+    def test_bootstrap_process_called_with_logging_config(self) -> None:
         from scaler.entry_points.scaler import _run_worker_manager
 
         config = self._make_native_config(logging_level="WARNING")
 
         with (
-            patch("scaler.entry_points.scaler.setup_logger") as mock_log,
+            patch("scaler.entry_points.scaler.bootstrap_process") as mock_log,
             patch("scaler.entry_points.scaler.register_event_loop"),
             patch("scaler.worker_manager_adapter.baremetal.native.NativeWorkerManager") as mock_nm,
         ):
@@ -402,7 +402,7 @@ class TestRunWorkerManager(unittest.TestCase):
         config = self._make_orb_aws_ec2_config()
 
         with (
-            patch("scaler.entry_points.scaler.setup_logger"),
+            patch("scaler.entry_points.scaler.bootstrap_process"),
             patch("scaler.entry_points.scaler.register_event_loop"),
             patch("scaler.worker_manager_adapter.orb_aws_ec2.worker_manager.ORBAWSEC2WorkerManager") as mock_orb,
         ):
@@ -419,7 +419,7 @@ class TestRunWorkerManager(unittest.TestCase):
 
         with (
             patch("scaler.entry_points.scaler.register_event_loop") as mock_reg,
-            patch("scaler.entry_points.scaler.setup_logger"),
+            patch("scaler.entry_points.scaler.bootstrap_process"),
             patch("scaler.worker_manager_adapter.orb_aws_ec2.worker_manager.ORBAWSEC2WorkerManager") as mock_orb,
         ):
             mock_orb.return_value.run.return_value = None

--- a/tests/entry_points/test_worker_manager.py
+++ b/tests/entry_points/test_worker_manager.py
@@ -740,7 +740,7 @@ class TestOCIRawWorkerManagerConfig(unittest.TestCase):
     def test_oci_raw_subcommand_dispatches_worker_manager(self) -> None:
         with (
             patch("sys.argv", ["scaler_worker_manager", "oci_raw", *_OCI_RAW_BASE_ARGV]),
-            patch("scaler.entry_points.worker_manager.setup_logger"),
+            patch("scaler.entry_points.worker_manager.bootstrap_process"),
             patch("scaler.entry_points.worker_manager.register_event_loop"),
             patch("scaler.worker_manager_adapter.oci_raw.worker_manager.OCIRawWorkerManager") as mock_mgr,
         ):
@@ -1067,7 +1067,7 @@ worker_manager_id = "wm-2"
     def test_oci_hpc_subcommand_dispatches_worker_manager(self) -> None:
         with (
             patch("sys.argv", ["scaler_worker_manager", "oci_hpc", *_OCI_HPC_BASE_ARGV]),
-            patch("scaler.entry_points.worker_manager.setup_logger"),
+            patch("scaler.entry_points.worker_manager.bootstrap_process"),
             patch("scaler.entry_points.worker_manager.register_event_loop"),
             patch("scaler.worker_manager_adapter.oci_hpc.worker_manager.OCIHPCWorkerManager") as mock_mgr,
         ):

--- a/tests/utility/test_process_bootstrap.py
+++ b/tests/utility/test_process_bootstrap.py
@@ -13,21 +13,29 @@ class TestBootstrapProcessEnablesFaulthandler(unittest.TestCase):
         mock.patch("scaler.utility.process_bootstrap.setup_logger").start()
         self.addCleanup(mock.patch.stopall)
 
+    def _mock_resolved_log_path(self, log_path: str) -> None:
+        mock.patch("scaler.utility.process_bootstrap.get_logger_info", return_value=("", "INFO", (log_path,))).start()
+
     def test_dash_sentinel_targets_stdout(self) -> None:
-        bootstrap_process(log_paths=("-",))
+        self._mock_resolved_log_path("-")
+
+        bootstrap_process()
 
         self.mock_enable.assert_called_once_with(file=sys.stdout, all_threads=True)
 
     def test_dev_stdout_sentinel_targets_stdout(self) -> None:
-        bootstrap_process(log_paths=("/dev/stdout",))
+        self._mock_resolved_log_path("/dev/stdout")
+
+        bootstrap_process()
 
         self.mock_enable.assert_called_once_with(file=sys.stdout, all_threads=True)
 
     def test_file_path_opens_that_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             log_path = os.path.join(tmp_dir, "crash.log")
+            self._mock_resolved_log_path(log_path)
 
-            bootstrap_process(log_paths=(log_path,))
+            bootstrap_process()
 
             self.mock_enable.assert_called_once()
             _, kwargs = self.mock_enable.call_args
@@ -36,14 +44,24 @@ class TestBootstrapProcessEnablesFaulthandler(unittest.TestCase):
             kwargs["file"].close()
 
     def test_unopenable_path_falls_back_to_stderr(self) -> None:
-        bootstrap_process(log_paths=("/nonexistent-directory-xyz/crash.log",))
+        self._mock_resolved_log_path("/nonexistent-directory-xyz/crash.log")
+
+        bootstrap_process()
 
         self.mock_enable.assert_called_once_with(all_threads=True)
 
-    def test_no_log_paths_falls_back_to_stderr(self) -> None:
-        bootstrap_process(log_paths=())
+    def test_logging_config_file_derives_target_from_configured_logger_not_log_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = os.path.join(tmp_dir, "from_config_file.log")
+            self._mock_resolved_log_path(log_path)
 
-        self.mock_enable.assert_called_once_with(all_threads=True)
+            # log_paths points at stdout, but the resolved logger state must win regardless.
+            bootstrap_process(logging_config_file="unused.ini", log_paths=("/dev/stdout",))
+
+            self.mock_enable.assert_called_once()
+            _, kwargs = self.mock_enable.call_args
+            self.assertEqual(kwargs["file"].name, log_path)
+            kwargs["file"].close()
 
 
 if __name__ == "__main__":

--- a/tests/utility/test_process_bootstrap.py
+++ b/tests/utility/test_process_bootstrap.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+from scaler.utility.process_bootstrap import bootstrap_process
+
+
+class TestBootstrapProcessEnablesFaulthandler(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_enable = mock.patch("scaler.utility.process_bootstrap.faulthandler.enable").start()
+        mock.patch("scaler.utility.process_bootstrap.setup_logger").start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_dash_sentinel_targets_stdout(self) -> None:
+        bootstrap_process(log_paths=("-",))
+
+        self.mock_enable.assert_called_once_with(file=sys.stdout, all_threads=True)
+
+    def test_dev_stdout_sentinel_targets_stdout(self) -> None:
+        bootstrap_process(log_paths=("/dev/stdout",))
+
+        self.mock_enable.assert_called_once_with(file=sys.stdout, all_threads=True)
+
+    def test_file_path_opens_that_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = os.path.join(tmp_dir, "crash.log")
+
+            bootstrap_process(log_paths=(log_path,))
+
+            self.mock_enable.assert_called_once()
+            _, kwargs = self.mock_enable.call_args
+            self.assertEqual(kwargs["file"].name, log_path)
+            self.assertTrue(kwargs["all_threads"])
+            kwargs["file"].close()
+
+    def test_unopenable_path_falls_back_to_stderr(self) -> None:
+        bootstrap_process(log_paths=("/nonexistent-directory-xyz/crash.log",))
+
+        self.mock_enable.assert_called_once_with(all_threads=True)
+
+    def test_no_log_paths_falls_back_to_stderr(self) -> None:
+        bootstrap_process(log_paths=())
+
+        self.mock_enable.assert_called_once_with(all_threads=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utility/test_process_bootstrap.py
+++ b/tests/utility/test_process_bootstrap.py
@@ -62,7 +62,3 @@ class TestBootstrapProcessEnablesFaulthandler(unittest.TestCase):
             _, kwargs = self.mock_enable.call_args
             self.assertEqual(kwargs["file"].name, log_path)
             kwargs["file"].close()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -1,16 +1,17 @@
-"""Regression tests for the worker's top-level YMQ error handling (``Worker.__get_loops``).
+"""Regression tests for the worker's top-level lifecycle handling (``Worker._run``).
 
 The ``jne-fix-ymq`` failure: a worker's internal YMQ binder is shut down (``disconnect``/teardown)
 while a ``binder.send`` driven by one of the worker's loops is still in flight. The send surfaces
 ``SocketStopRequested`` (see ``tests/io/test_ymq_async_binder.py``), which propagates through
-``asyncio.gather`` into ``Worker.__get_loops``. Before the fix the handler logged it as a "failed
+``asyncio.gather`` into ``Worker._run``. Before the fix the handler logged it as a "failed
 with unhandled exception" crash; it must instead be treated like ``ConnectorSocketClosedByRemoteEnd``
-- an expected teardown condition that is logged, never surfaced as a crash.
+- an expected teardown condition that is logged, never surfaced as a crash, and does not produce a
+nonzero exit code.
 """
 
 import asyncio
 import unittest
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Tuple
 from unittest import mock
 
 import scaler.worker.worker as worker_module
@@ -25,7 +26,7 @@ async def _hang() -> None:
 
 
 class _StubCollaborator:
-    """Minimal stand-in for a worker collaborator, exposing the hooks ``__get_loops`` touches."""
+    """Minimal stand-in for a worker collaborator, exposing the hooks ``__main_loop`` touches."""
 
     def __init__(self, routine_behavior: Callable[[], Awaitable[None]] = _hang) -> None:
         self._routine_behavior = routine_behavior
@@ -51,7 +52,7 @@ class WorkerTeardownYMQErrorTest(unittest.IsolatedAsyncioTestCase):
     @staticmethod
     def _build_worker(task_routine_error: ymq.YMQException) -> Any:
         # Typed as Any: the test deliberately injects duck-typed stubs into the worker's typed
-        # collaborator slots and reaches a name-mangled private loop, which the type system rejects.
+        # collaborator slots and reaches a name-mangled private method, which the type system rejects.
         worker: Any = Worker(
             event_loop="builtin",
             name="test-worker",
@@ -75,6 +76,10 @@ class WorkerTeardownYMQErrorTest(unittest.IsolatedAsyncioTestCase):
         worker._backend = None  # not a ZMQ backend -> no graceful-shutdown handshake on teardown
         worker._address_internal = AddressConfig.from_string("tcp://127.0.0.1:2346")  # tcp -> no ipc unlink
 
+        # __initialize would overwrite the stubs below with real backend collaborators; skip it and
+        # go straight to __main_loop with the worker already wired up.
+        worker._Worker__initialize = lambda: None
+
         async def _raise() -> None:
             raise task_routine_error
 
@@ -92,7 +97,7 @@ class WorkerTeardownYMQErrorTest(unittest.IsolatedAsyncioTestCase):
         return worker
 
     async def _drain_pending_tasks(self) -> None:
-        # The sibling loop coroutines created by __get_loops's gather keep running after the gather
+        # The sibling loop coroutines created by __main_loop's gather keep running after the gather
         # propagates the first exception; cancel them so the test loop tears down cleanly.
         pending = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
         for task in pending:
@@ -100,19 +105,20 @@ class WorkerTeardownYMQErrorTest(unittest.IsolatedAsyncioTestCase):
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
 
-    async def _run_get_loops(self, task_routine_error: ymq.YMQException) -> mock.MagicMock:
+    async def _run_worker(self, task_routine_error: ymq.YMQException) -> Tuple[mock.MagicMock, int]:
         worker = self._build_worker(task_routine_error)
+        worker._loop = asyncio.get_running_loop()
         with mock.patch.object(worker_module, "logger") as mock_logger:
-            await worker._Worker__get_loops()  # name-mangled private method
+            exit_code = await worker._run()
         await self._drain_pending_tasks()
 
         # Regardless of the error, the worker must always reach clean teardown.
         self.assertTrue(worker._binder_internal.destroyed, "worker did not reach teardown / destroy")
-        return mock_logger
+        return mock_logger, exit_code
 
     async def test_socket_stop_requested_during_teardown_is_logged_not_crashed(self) -> None:
         error = SocketStopRequestedError(ymq.ErrorCode.SocketStopRequested, "binder socket shut down mid-send")
-        mock_logger = await self._run_get_loops(error)
+        mock_logger, exit_code = await self._run_worker(error)
 
         unhandled = [c for c in mock_logger.exception.call_args_list if "failed with unhandled exception" in str(c)]
         self.assertEqual(unhandled, [], "SocketStopRequested surfaced as an unhandled-exception crash")
@@ -120,14 +126,19 @@ class WorkerTeardownYMQErrorTest(unittest.IsolatedAsyncioTestCase):
         handled = [c for c in mock_logger.info.call_args_list if "shut down during teardown" in str(c)]
         self.assertTrue(handled, "SocketStopRequested was not logged as an expected teardown condition")
 
+        self.assertEqual(exit_code, 0, "an expected teardown condition should not produce a nonzero exit code")
+
     async def test_unexpected_ymq_error_still_surfaces_as_unhandled(self) -> None:
         # A YMQ error that is NOT an expected teardown condition must still be logged loudly, so real
-        # bugs continue to fail fast during development rather than being blanket-swallowed.
+        # bugs continue to fail fast during development rather than being blanket-swallowed, and must
+        # produce a nonzero exit code so process-level monitoring can tell it apart from a clean exit.
         error = SysCallError(ymq.ErrorCode.SysCallError, "something genuinely broke")
-        mock_logger = await self._run_get_loops(error)
+        mock_logger, exit_code = await self._run_worker(error)
 
         unhandled = [c for c in mock_logger.exception.call_args_list if "failed with unhandled exception" in str(c)]
         self.assertTrue(unhandled, "an unexpected YMQ error should still be logged as an unhandled exception")
+
+        self.assertEqual(exit_code, 1, "an unexpected error should produce a nonzero exit code")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Throwaway diagnostic branch to root-cause a windows-latest CI failure seen on #907 (`test_scheduler_disconnect_raises_disconnected_error` hangs the full 30s on Windows instead of getting `DisconnectedError`/`TimeoutError`).

Adds temporary instrumentation to `ClientAgent`/`ClientHeartbeatManager` to check whether the client agent's asyncio event loop keeps ticking on Windows after the scheduler is killed, or stalls outright. Will be closed once the Windows job finishes.