### PR TITLE
fix: make client heartbeat death-timeout independent of the heartbeat send

### DIFF
--- a/src/cpp/scaler/wrapper/openssl/secure_socket.cpp
+++ b/src/cpp/scaler/wrapper/openssl/secure_socket.cpp
@@ -197,6 +197,11 @@ std::expected<void, uv::Error> SecureSocket::nodelay(bool enable) noexcept
     return _state->_transport.nodelay(enable);
 }
 
+std::expected<void, uv::Error> SecureSocket::keepalive(bool enable, unsigned int delaySeconds) noexcept
+{
+    return _state->_transport.keepalive(enable, delaySeconds);
+}
+
 SecureSocket::ConnectionState SecureSocket::state() const noexcept
 {
     return _state->_connectionState;

--- a/src/cpp/scaler/wrapper/openssl/secure_socket.h
+++ b/src/cpp/scaler/wrapper/openssl/secure_socket.h
@@ -70,6 +70,8 @@ public:
 
     std::expected<void, uv::Error> nodelay(bool enable) noexcept;
 
+    std::expected<void, uv::Error> keepalive(bool enable, unsigned int delaySeconds) noexcept;
+
     ConnectionState state() const noexcept;
 
     bool established() const noexcept;

--- a/src/cpp/scaler/wrapper/uv/tcp.cpp
+++ b/src/cpp/scaler/wrapper/uv/tcp.cpp
@@ -97,6 +97,16 @@ std::expected<void, Error> TCPSocket::nodelay(bool enable) noexcept
     return {};
 }
 
+std::expected<void, Error> TCPSocket::keepalive(bool enable, unsigned int delaySeconds) noexcept
+{
+    const int err = uv_tcp_keepalive(&handle().native(), enable, delaySeconds);
+    if (err) {
+        return std::unexpected(Error {err});
+    }
+
+    return {};
+}
+
 std::expected<TCPServer, Error> TCPServer::init(Loop& loop) noexcept
 {
     TCPServer server {};

--- a/src/cpp/scaler/wrapper/uv/tcp.h
+++ b/src/cpp/scaler/wrapper/uv/tcp.h
@@ -38,6 +38,10 @@ public:
     // See uv_tcp_nodelay
     std::expected<void, Error> nodelay(bool enable) noexcept;
 
+    // See uv_tcp_keepalive. delaySeconds is the idle time before the first keepalive probe; it is
+    // ignored when enable is false.
+    std::expected<void, Error> keepalive(bool enable, unsigned int delaySeconds) noexcept;
+
 private:
     TCPSocket() noexcept = default;
 };

--- a/src/cpp/scaler/ymq/configuration.h
+++ b/src/cpp/scaler/ymq/configuration.h
@@ -28,5 +28,16 @@ constexpr size_t maxWriteBufferSize = 256ULL * 1024ULL * 1024ULL;  // 256 MB
 // lag is millisecond-scale in practice, single-digit seconds even under heavy load.
 constexpr std::chrono::seconds disconnectedIdentityTTL {60};
 
+// Idle time before the OS sends the first TCP keepalive probe on a MessageConnection.
+//
+// A peer that vanishes without a clean shutdown (crash, kill -9, forcibly terminated process)
+// leaves an ESTABLISHED connection with no FIN/RST ever delivered back to this side: a pending
+// write to it, and consequently a graceful shutdown() waiting on that write, can then stay
+// unresolved indefinitely. This is most visible on Windows, where killing a process does not
+// synchronously tear down its sockets and notify the peer the way POSIX's kernel-owned fd
+// teardown does. Keepalive probing makes the OS itself notice and error out such a connection
+// within a bounded time instead of relying solely on application traffic to reveal it.
+constexpr std::chrono::seconds tcpKeepAliveDelay {10};
+
 }  // namespace ymq
 }  // namespace scaler

--- a/src/cpp/scaler/ymq/internal/client.cpp
+++ b/src/cpp/scaler/ymq/internal/client.cpp
@@ -107,6 +107,23 @@ std::expected<void, scaler::wrapper::uv::Error> Client::setNoDelay(bool enable) 
     return {};
 }
 
+std::expected<void, scaler::wrapper::uv::Error> Client::setKeepAlive(bool enable, unsigned int delaySeconds) noexcept
+{
+    if (auto* tcp = std::get_if<scaler::wrapper::uv::TCPSocket>(&_socket)) {
+        return tcp->keepalive(enable, delaySeconds);
+    }
+    if (auto* tls = std::get_if<scaler::wrapper::openssl::SecureSocket>(&_socket)) {
+        return tls->keepalive(enable, delaySeconds);
+    }
+    if (auto* ws = std::get_if<WebSocketStream>(&_socket)) {
+        return std::visit(
+            [enable, delaySeconds](auto& transport) { return transport.keepalive(enable, delaySeconds); },
+            ws->transport());
+    }
+    // IPC does not need dead-peer detection.
+    return {};
+}
+
 std::expected<void, scaler::wrapper::uv::Error> Client::shutdown(
     scaler::wrapper::uv::ShutdownCallback callback) noexcept
 {

--- a/src/cpp/scaler/ymq/internal/client.h
+++ b/src/cpp/scaler/ymq/internal/client.h
@@ -48,6 +48,14 @@ public:
 
     std::expected<void, scaler::wrapper::uv::Error> setNoDelay(bool enable) noexcept;
 
+    // Enables the OS's TCP keepalive probing so a peer that vanishes without a clean shutdown
+    // (crash, network partition, forcefully killed process) gets noticed by the OS itself within a
+    // bounded time, instead of relying solely on an application-level read or write happening to
+    // fail. delaySeconds is the idle time before the first probe; ignored when enable is false.
+    //
+    // No-op on IPC (Pipe), which does not need dead-peer detection.
+    std::expected<void, scaler::wrapper::uv::Error> setKeepAlive(bool enable, unsigned int delaySeconds) noexcept;
+
     std::expected<void, scaler::wrapper::uv::Error> shutdown(scaler::wrapper::uv::ShutdownCallback callback) noexcept;
 
     // Send a RST packet to the remote, immediately closing the connection.

--- a/src/cpp/scaler/ymq/internal/message_connection.cpp
+++ b/src/cpp/scaler/ymq/internal/message_connection.cpp
@@ -66,6 +66,7 @@ void MessageConnection::connect(Client client) noexcept
     _state  = State::Connected;
 
     UV_EXIT_ON_ERROR(_client->setNoDelay(true));
+    UV_EXIT_ON_ERROR(_client->setKeepAlive(true, static_cast<unsigned int>(tcpKeepAliveDelay.count())));
     UV_EXIT_ON_ERROR(_client->readStart(std::bind_front(&MessageConnection::onRead, this)));
     processSendQueue();
 }

--- a/src/scaler/client/agent/client_agent.py
+++ b/src/scaler/client/agent/client_agent.py
@@ -39,6 +39,9 @@ from scaler.utility.identifiers import ClientID
 
 logger = logging.getLogger(__name__)
 
+# How often to re-check the heartbeat death-timeout, independent of the heartbeat send cadence.
+_DEATH_TIMEOUT_CHECK_INTERVAL_SECONDS = 1
+
 
 class ClientAgent(threading.Thread):
     def __init__(
@@ -193,6 +196,9 @@ class ClientAgent(threading.Thread):
                 create_async_loop_routine(self._connector_external.routine, 0),
                 create_async_loop_routine(self._connector_internal.routine, 0),
                 create_async_loop_routine(self._heartbeat_manager.routine, self._heartbeat_interval_seconds),
+                create_async_loop_routine(
+                    self._heartbeat_manager.death_timeout_routine, _DEATH_TIMEOUT_CHECK_INTERVAL_SECONDS
+                ),
             ]
 
             await asyncio.gather(*loops)

--- a/src/scaler/client/agent/heartbeat_manager.py
+++ b/src/scaler/client/agent/heartbeat_manager.py
@@ -68,6 +68,21 @@ class ClientHeartbeatManager(Looper, HeartbeatManager):
         )
 
     async def routine(self):
+        if self._start_timestamp_ns != 0:
+            # already sent heartbeat, expecting heartbeat echo, so not sending
+            return
+
+        await self.send_heartbeat()
+        self._start_timestamp_ns = time.time_ns()
+
+    async def death_timeout_routine(self):
+        # Runs as its own loop, independent of routine()/send_heartbeat(). send_heartbeat()
+        # awaits a network write that is not guaranteed to fail promptly when the scheduler is
+        # already gone -- on Windows a write to a dead peer can stay unresolved for tens of
+        # seconds instead of failing immediately as it does on POSIX. If this wall-clock check
+        # lived inside the same loop as routine(), a stuck send_heartbeat() would prevent it
+        # from ever re-running, defeating the timeout it's supposed to guarantee.
+
         # On Pyodide the agent shares the single asyncio event loop with the
         # user's notebook code. Any long synchronous block in user code (large
         # cloudpickle (de)serialization, pargraph graph walking, big numpy
@@ -77,19 +92,14 @@ class ClientHeartbeatManager(Looper, HeartbeatManager):
         # raise, killing the agent mid-computation. The scheduler still runs
         # its own dead-client cleanup over the WebSocket, and the user can
         # interrupt the kernel manually, so skip the local check in browser.
-        if sys.platform != "emscripten":
-            if time.time() - self._last_scheduler_contact > self._death_timeout_seconds:
-                raise TimeoutError(
-                    f"Timeout when connecting to scheduler {self._connector_external.address} "
-                    f"in {self._death_timeout_seconds} seconds"
-                )
-
-        if self._start_timestamp_ns != 0:
-            # already sent heartbeat, expecting heartbeat echo, so not sending
+        if sys.platform == "emscripten":
             return
 
-        await self.send_heartbeat()
-        self._start_timestamp_ns = time.time_ns()
+        if time.time() - self._last_scheduler_contact > self._death_timeout_seconds:
+            raise TimeoutError(
+                f"Timeout when connecting to scheduler {self._connector_external.address} "
+                f"in {self._death_timeout_seconds} seconds"
+            )
 
     def get_object_storage_address(self) -> AddressConfig:
         """Returns the object storage configuration, or block until it receives it."""

--- a/tests/client/agent/test_heartbeat_manager.py
+++ b/tests/client/agent/test_heartbeat_manager.py
@@ -1,0 +1,86 @@
+import asyncio
+import time
+import unittest
+from concurrent.futures import Future
+from unittest.mock import AsyncMock
+
+from scaler.client.agent.heartbeat_manager import ClientHeartbeatManager
+from scaler.io.mixins import AsyncConnector
+from scaler.utility.event_loop import create_async_loop_routine
+from scaler.utility.logging.utility import setup_logger
+from tests.utility.utility import logging_test_name
+
+
+def _make_heartbeat_manager(death_timeout_seconds: int) -> ClientHeartbeatManager:
+    return ClientHeartbeatManager(death_timeout_seconds=death_timeout_seconds, storage_address_future=Future())
+
+
+class TestClientHeartbeatManagerDeathTimeout(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        setup_logger()
+        logging_test_name(self)
+        self.heartbeat_manager = _make_heartbeat_manager(death_timeout_seconds=5)
+        self.connector_external = AsyncMock(spec=AsyncConnector)
+        self.heartbeat_manager.register(connector_external=self.connector_external)
+
+    async def test_death_timeout_routine_raises_once_timeout_elapsed(self) -> None:
+        self.heartbeat_manager._last_scheduler_contact = time.time() - 10
+
+        with self.assertRaises(TimeoutError):
+            await self.heartbeat_manager.death_timeout_routine()
+
+    async def test_death_timeout_routine_does_not_raise_within_window(self) -> None:
+        self.heartbeat_manager._last_scheduler_contact = time.time()
+
+        await self.heartbeat_manager.death_timeout_routine()
+
+    async def test_death_timeout_routine_does_not_send_heartbeat(self) -> None:
+        # death_timeout_routine() must never depend on send_heartbeat() completing: a heartbeat
+        # send that hangs (e.g. writing to an already-dead scheduler) must not be able to block
+        # this wall-clock check from firing.
+        self.heartbeat_manager._last_scheduler_contact = time.time() - 10
+
+        with self.assertRaises(TimeoutError):
+            await self.heartbeat_manager.death_timeout_routine()
+
+        self.connector_external.send.assert_not_called()
+
+
+class TestClientHeartbeatManagerLoopIntegration(unittest.IsolatedAsyncioTestCase):
+    """Runs routine() and death_timeout_routine() together the same way ClientAgent.__get_loops()
+    does (via create_async_loop_routine + asyncio.gather), with a heartbeat send that never
+    completes -- reproducing what a dead scheduler does when the OS is slow to fail the write
+    (observed to take ~50s on windows-latest CI, vs. sub-second on Linux/macOS).
+
+    Regression coverage for: a hung send_heartbeat() used to prevent the death-timeout check from
+    ever re-running, because both lived in the same routine() loop iteration."""
+
+    async def test_death_timeout_fires_promptly_even_when_heartbeat_send_never_completes(self) -> None:
+        death_timeout_seconds = 1
+        heartbeat_manager = _make_heartbeat_manager(death_timeout_seconds=death_timeout_seconds)
+        connector_external = AsyncMock(spec=AsyncConnector)
+
+        async def hang_forever(*args, **kwargs):
+            await asyncio.Event().wait()  # never set, so this never resolves
+
+        connector_external.send.side_effect = hang_forever
+        heartbeat_manager.register(connector_external=connector_external)
+
+        loops = [
+            create_async_loop_routine(heartbeat_manager.routine, 0),
+            create_async_loop_routine(heartbeat_manager.death_timeout_routine, 1),
+        ]
+
+        # The outer bound is only a safety net so a regression fails the test instead of hanging
+        # the suite; the real assertion is that we come in well under it, close to death_timeout.
+        start = time.monotonic()
+        with self.assertRaises(TimeoutError):
+            await asyncio.wait_for(asyncio.gather(*loops), timeout=10)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            death_timeout_seconds + 2,
+            f"death timeout took {elapsed:.1f}s to fire; expected ~{death_timeout_seconds}s "
+            f"-- the death-timeout check is being blocked by the hung heartbeat send",
+        )


### PR DESCRIPTION
## Summary

Windows CI has been hanging for hours on `Run Unittests`, first observed on #906. Root cause is two independent gaps that only line up when a peer (e.g. the scheduler) is killed mid-connection:

1. `ClientHeartbeatManager.routine()` checked the death-timeout and sent the heartbeat in the same loop iteration, so a stuck `send_heartbeat()` write prevented the timeout from ever being re-checked.
2. `MessageConnection::shutdownClient()`'s graceful `uv_shutdown()` waits for any pending write to complete before its callback fires, and `PyConnectorSocket_shutdown` blocks synchronously on that with no timeout of its own. If a peer vanishes without a clean FIN/RST -- which happens on Windows when a process is forcibly killed, since socket teardown isn't a synchronous side effect of process termination there the way it is on POSIX -- that pending write, and everything waiting on `disconnect()`, can hang indefinitely.

These were isolated and tested independently first:

- **#910** (keepalive only, based on `main`): confirmed the multi-hour hang is gone -- the full suite now completes in ~476s instead of hanging for hours. It still hits the original `test_scheduler_disconnect_raises_disconnected_error` race (bare `TimeoutError`) from #906, since it lacks fix (1).
- This branch, with only fix (1): isolates whether death-timeout independence alone is enough.

This PR now combines both fixes to confirm they resolve the issue entirely: no hang, and the disconnect test passes with the intended `DisconnectedError`.

Opening as a draft until Windows CI confirms both green.