### PR TITLE
fix: enable TCP keepalive on YMQ connections to bound dead-peer detection

### DIFF
--- a/src/cpp/scaler/wrapper/openssl/secure_socket.cpp
+++ b/src/cpp/scaler/wrapper/openssl/secure_socket.cpp
@@ -197,6 +197,11 @@ std::expected<void, uv::Error> SecureSocket::nodelay(bool enable) noexcept
     return _state->_transport.nodelay(enable);
 }
 
+std::expected<void, uv::Error> SecureSocket::keepalive(bool enable, unsigned int delaySeconds) noexcept
+{
+    return _state->_transport.keepalive(enable, delaySeconds);
+}
+
 SecureSocket::ConnectionState SecureSocket::state() const noexcept
 {
     return _state->_connectionState;

--- a/src/cpp/scaler/wrapper/openssl/secure_socket.h
+++ b/src/cpp/scaler/wrapper/openssl/secure_socket.h
@@ -70,6 +70,8 @@ public:
 
     std::expected<void, uv::Error> nodelay(bool enable) noexcept;
 
+    std::expected<void, uv::Error> keepalive(bool enable, unsigned int delaySeconds) noexcept;
+
     ConnectionState state() const noexcept;
 
     bool established() const noexcept;

--- a/src/cpp/scaler/wrapper/uv/tcp.cpp
+++ b/src/cpp/scaler/wrapper/uv/tcp.cpp
@@ -97,6 +97,16 @@ std::expected<void, Error> TCPSocket::nodelay(bool enable) noexcept
     return {};
 }
 
+std::expected<void, Error> TCPSocket::keepalive(bool enable, unsigned int delaySeconds) noexcept
+{
+    const int err = uv_tcp_keepalive(&handle().native(), enable, delaySeconds);
+    if (err) {
+        return std::unexpected(Error {err});
+    }
+
+    return {};
+}
+
 std::expected<TCPServer, Error> TCPServer::init(Loop& loop) noexcept
 {
     TCPServer server {};

--- a/src/cpp/scaler/wrapper/uv/tcp.h
+++ b/src/cpp/scaler/wrapper/uv/tcp.h
@@ -38,6 +38,10 @@ public:
     // See uv_tcp_nodelay
     std::expected<void, Error> nodelay(bool enable) noexcept;
 
+    // See uv_tcp_keepalive. delaySeconds is the idle time before the first keepalive probe; it is
+    // ignored when enable is false.
+    std::expected<void, Error> keepalive(bool enable, unsigned int delaySeconds) noexcept;
+
 private:
     TCPSocket() noexcept = default;
 };

--- a/src/cpp/scaler/ymq/configuration.h
+++ b/src/cpp/scaler/ymq/configuration.h
@@ -28,5 +28,16 @@ constexpr size_t maxWriteBufferSize = 256ULL * 1024ULL * 1024ULL;  // 256 MB
 // lag is millisecond-scale in practice, single-digit seconds even under heavy load.
 constexpr std::chrono::seconds disconnectedIdentityTTL {60};
 
+// Idle time before the OS sends the first TCP keepalive probe on a MessageConnection.
+//
+// A peer that vanishes without a clean shutdown (crash, kill -9, forcibly terminated process)
+// leaves an ESTABLISHED connection with no FIN/RST ever delivered back to this side: a pending
+// write to it, and consequently a graceful shutdown() waiting on that write, can then stay
+// unresolved indefinitely. This is most visible on Windows, where killing a process does not
+// synchronously tear down its sockets and notify the peer the way POSIX's kernel-owned fd
+// teardown does. Keepalive probing makes the OS itself notice and error out such a connection
+// within a bounded time instead of relying solely on application traffic to reveal it.
+constexpr std::chrono::seconds tcpKeepAliveDelay {10};
+
 }  // namespace ymq
 }  // namespace scaler

--- a/src/cpp/scaler/ymq/internal/client.cpp
+++ b/src/cpp/scaler/ymq/internal/client.cpp
@@ -107,6 +107,23 @@ std::expected<void, scaler::wrapper::uv::Error> Client::setNoDelay(bool enable) 
     return {};
 }
 
+std::expected<void, scaler::wrapper::uv::Error> Client::setKeepAlive(bool enable, unsigned int delaySeconds) noexcept
+{
+    if (auto* tcp = std::get_if<scaler::wrapper::uv::TCPSocket>(&_socket)) {
+        return tcp->keepalive(enable, delaySeconds);
+    }
+    if (auto* tls = std::get_if<scaler::wrapper::openssl::SecureSocket>(&_socket)) {
+        return tls->keepalive(enable, delaySeconds);
+    }
+    if (auto* ws = std::get_if<WebSocketStream>(&_socket)) {
+        return std::visit(
+            [enable, delaySeconds](auto& transport) { return transport.keepalive(enable, delaySeconds); },
+            ws->transport());
+    }
+    // IPC does not need dead-peer detection.
+    return {};
+}
+
 std::expected<void, scaler::wrapper::uv::Error> Client::shutdown(
     scaler::wrapper::uv::ShutdownCallback callback) noexcept
 {

--- a/src/cpp/scaler/ymq/internal/client.h
+++ b/src/cpp/scaler/ymq/internal/client.h
@@ -48,6 +48,14 @@ public:
 
     std::expected<void, scaler::wrapper::uv::Error> setNoDelay(bool enable) noexcept;
 
+    // Enables the OS's TCP keepalive probing so a peer that vanishes without a clean shutdown
+    // (crash, network partition, forcefully killed process) gets noticed by the OS itself within a
+    // bounded time, instead of relying solely on an application-level read or write happening to
+    // fail. delaySeconds is the idle time before the first probe; ignored when enable is false.
+    //
+    // No-op on IPC (Pipe), which does not need dead-peer detection.
+    std::expected<void, scaler::wrapper::uv::Error> setKeepAlive(bool enable, unsigned int delaySeconds) noexcept;
+
     std::expected<void, scaler::wrapper::uv::Error> shutdown(scaler::wrapper::uv::ShutdownCallback callback) noexcept;
 
     // Send a RST packet to the remote, immediately closing the connection.

--- a/src/cpp/scaler/ymq/internal/message_connection.cpp
+++ b/src/cpp/scaler/ymq/internal/message_connection.cpp
@@ -66,6 +66,7 @@ void MessageConnection::connect(Client client) noexcept
     _state  = State::Connected;
 
     UV_EXIT_ON_ERROR(_client->setNoDelay(true));
+    UV_EXIT_ON_ERROR(_client->setKeepAlive(true, static_cast<unsigned int>(tcpKeepAliveDelay.count())));
     UV_EXIT_ON_ERROR(_client->readStart(std::bind_front(&MessageConnection::onRead, this)));
     processSendQueue();
 }


### PR DESCRIPTION
## Summary

Isolating one half of the investigation into the Windows CI hang first observed on #906 (see also #909 for the other half).

`MessageConnection::shutdownClient()`'s graceful `uv_shutdown()` waits for any pending write to complete before its callback fires, and `PyConnectorSocket_shutdown` blocks synchronously on that with no timeout of its own. If a peer vanishes without a clean FIN/RST -- which happens on Windows when a process is forcibly killed, since socket teardown isn't a synchronous side effect of process termination there the way it is on POSIX -- that pending write, and everything waiting on `disconnect()`, can hang indefinitely.

This PR enables `SO_KEEPALIVE` on every YMQ `MessageConnection` (TCP, TLS, WebSocket), so the OS itself notices and errors out a silently-dead connection within a bounded time, instead of relying solely on application traffic to reveal it.

This is intentionally based on `main` (not stacked on #909's death-timeout fix) so CI here isolates whether keepalive alone resolves the Windows hang.

Opening as a draft to confirm this in CI before marking ready for review.