### PR TITLE
fix: inconsistent log path handling and add /dev/stderr support

### DIFF
--- a/src/scaler/config/common/logging.py
+++ b/src/scaler/config/common/logging.py
@@ -16,7 +16,7 @@ class LoggingConfig(ConfigClass):
             short="-lp",
             nargs="*",
             help="specify where the cluster's log should logged to, there can be multiple paths."
-            '"/dev/stdout" means output to stdout, and is the default. '
+            '"/dev/stdout" means output to stdout, and is the default. "/dev/stderr" means output to stderr. '
             "each worker has its own log file with process id appended to the path",
         ),
     )

--- a/src/scaler/utility/logging/utility.py
+++ b/src/scaler/utility/logging/utility.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class LogType(enum.Enum):
-    Screen = enum.auto()
+    Stdout = enum.auto()
+    Stderr = enum.auto()
     File = enum.auto()
 
 
@@ -54,13 +55,16 @@ def setup_logger(
 
 
 def is_screen_log_path(path: str) -> bool:
-    """Returns True if the path refers to the screen (stdout) rather than a file to write logs to."""
-    return path in {"-", "/dev/stdout"}
+    """Returns True if the path refers to a screen stream (stdout/stderr) rather than a file to write logs to."""
+    return path in {"-", "/dev/stdout", "/dev/stderr"}
 
 
 def __detect_log_types(file_name: str) -> LogType:
-    if is_screen_log_path(file_name):
-        return LogType.Screen
+    if file_name in {"-", "/dev/stdout"}:
+        return LogType.Stdout
+
+    if file_name == "/dev/stderr":
+        return LogType.Stderr
 
     return LogType.File
 
@@ -99,9 +103,16 @@ def __logging_config(
     scaler_handlers = config["loggers"]["scaler"]["handlers"]
 
     for log_path in log_paths:
-        if log_path.log_type == LogType.Screen:
-            handlers["console"] = __create_stdout_handler(logging_level)
-            scaler_handlers.append("console")
+        if log_path.log_type == LogType.Stdout:
+            if "console_stdout" not in handlers:
+                handlers["console_stdout"] = __create_stream_handler(logging_level, "ext://sys.stdout")
+                scaler_handlers.append("console_stdout")
+            continue
+
+        elif log_path.log_type == LogType.Stderr:
+            if "console_stderr" not in handlers:
+                handlers["console_stderr"] = __create_stream_handler(logging_level, "ext://sys.stderr")
+                scaler_handlers.append("console_stderr")
             continue
 
         elif log_path.log_type == LogType.File:
@@ -114,13 +125,8 @@ def __logging_config(
     logging.config.dictConfig(config)
 
 
-def __create_stdout_handler(logging_level: str):
-    return {
-        "class": "logging.StreamHandler",
-        "level": logging_level,
-        "formatter": "standard",
-        "stream": "ext://sys.stdout",
-    }
+def __create_stream_handler(logging_level: str, stream: str):
+    return {"class": "logging.StreamHandler", "level": logging_level, "formatter": "standard", "stream": stream}
 
 
 def __create_time_rotating_file_handler(logging_level: str, file_path: str):

--- a/src/scaler/utility/logging/utility.py
+++ b/src/scaler/utility/logging/utility.py
@@ -53,8 +53,13 @@ def setup_logger(
     logger.info(f"logging to {log_paths}")
 
 
+def is_screen_log_path(path: str) -> bool:
+    """Returns True if the path refers to the screen (stdout) rather than a file to write logs to."""
+    return path in {"-", "/dev/stdout"}
+
+
 def __detect_log_types(file_name: str) -> LogType:
-    if file_name in {"-", "/dev/stdout"}:
+    if is_screen_log_path(file_name):
         return LogType.Screen
 
     return LogType.File

--- a/src/scaler/worker/agent/processor/processor.py
+++ b/src/scaler/worker/agent/processor/processor.py
@@ -30,7 +30,7 @@ from scaler.protocol.capnp import (
 )
 from scaler.utility.exceptions import ObjectStorageException
 from scaler.utility.identifiers import ClientID, ObjectID, TaskID
-from scaler.utility.logging.utility import setup_logger
+from scaler.utility.logging.utility import is_screen_log_path, setup_logger
 from scaler.utility.metadata.task_flags import retrieve_task_flags_from_task
 from scaler.utility.serialization import serialize_failure
 from scaler.worker.agent.processor.object_cache import ObjectCache
@@ -110,10 +110,8 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
     def __initialize(self):
         self._listener_shutdown = threading.Event()
 
-        # modify the logging path and add process id to the path
-        logging_paths = [f"{path}-{os.getpid()}" for path in self._logging_paths if path != "/dev/stdout"]
-        if "/dev/stdout" in self._logging_paths:
-            logging_paths.append("/dev/stdout")
+        # modify the logging path and add process id to the path, leaving screen paths (e.g. "/dev/stdout") untouched
+        logging_paths = [path if is_screen_log_path(path) else f"{path}-{os.getpid()}" for path in self._logging_paths]
 
         setup_logger(log_paths=tuple(logging_paths), logging_level=self._logging_level)
         tblib.pickling_support.install()


### PR DESCRIPTION
## Summary
- Fix `Processor.__initialize()`, which only recognized the literal string `"/dev/stdout"` as a screen path when appending the per-worker pid suffix to log paths, incorrectly treating `-` as a file path instead. Extracted a shared `is_screen_log_path()` helper (used by both the log-type detection and the processor) to fix this.
- Add support for `/dev/stderr` as a logging path. Previously it fell through to the file-path branch and was wrapped in a `TimedRotatingFileHandler`, which doesn't make sense for a device path. `LogType.Screen` is now split into `LogType.Stdout` and `LogType.Stderr`, each with its own `StreamHandler` keyed separately so `/dev/stdout` and `/dev/stderr` can both be configured at once without collision.