### PR TITLE
test: skip Windows scheduler-crash tests that hang CI

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -3,6 +3,7 @@ import logging
 import multiprocessing
 import os
 import random
+import sys
 import tempfile
 import time
 import unittest
@@ -282,6 +283,11 @@ class TestClient(unittest.TestCase):
             fut = client.submit(add, ref, [6])
             self.assertEqual(fut.result(), [1, 2, 3, 4, 5, 6])
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "hangs on Windows: client teardown blocks forever waiting on a killed peer's socket "
+        "shutdown; see https://github.com/finos/opengris-scaler/issues/912",
+    )
     def test_scheduler_crash(self):
         client_timeout_seconds = 5
         with Client(address=self.address, timeout_seconds=client_timeout_seconds) as client:

--- a/tests/cluster/test_cluster_disconnect.py
+++ b/tests/cluster/test_cluster_disconnect.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import sys
 import time
 import unittest
 from concurrent.futures import CancelledError
@@ -77,6 +78,11 @@ class TestClusterDisconnect(unittest.TestCase):
             client.clear()
             future_result.result()
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "hangs on Windows: client teardown blocks forever waiting on a killed peer's socket "
+        "shutdown; see https://github.com/finos/opengris-scaler/issues/912",
+    )
     def test_scheduler_disconnect_raises_disconnected_error(self):
         """When the scheduler connection drops with tasks in flight, the futures fail with a descriptive
         DisconnectedError naming the scheduler -- not a bare TimeoutError() that reads as if the task


### PR DESCRIPTION
## Summary
- `test_scheduler_crash` and `test_scheduler_disconnect_raises_disconnected_error` both kill the scheduler mid-test and immediately tear the client down in the same test, which wedges forever on Windows in an unbounded socket-shutdown wait, hanging the whole `Run Unittests` step.
- Skips both on `win32` as an interim mitigation with a link to #912, which tracks the underlying teardown bug and the real fix.