### PR TITLE
fix: Monitor webui hanging when there are lots of workers

### DIFF
--- a/docs/source/tutorials/commands.rst
+++ b/docs/source/tutorials/commands.rst
@@ -273,6 +273,14 @@ Scheduler arguments
      - No
      - ``1``
      - I/O backend thread count.
+   * - ``-sri``, ``--status-report-interval-seconds``
+     - No
+     - ``2``
+     - Interval between status reports the scheduler publishes to monitors (``scaler_top``/``scaler_gui``).
+   * - ``-srwl``, ``--status-report-worker-limit``
+     - No
+     - ``-1``
+     - Maximum workers whose full detail is serialized into each status report (``-1`` is unlimited).
 
 .. list-table:: Policy options
    :header-rows: 1
@@ -1014,6 +1022,22 @@ UI arguments
      - No
      - ``0.0.0.0:50001``
      - Host and port for the web server.
+   * - ``-bi``, ``--broadcast-interval-seconds``
+     - No
+     - ``0.1``
+     - Interval between updates the web GUI pushes to connected browsers.
+   * - ``-tl``, ``--task-log-max-size``
+     - No
+     - ``500``
+     - Maximum completed tasks kept and shown in the task log.
+   * - ``-wl``, ``--worker-display-limit``
+     - No
+     - ``500``
+     - Maximum workers sent to each browser (``-1`` is unlimited); the backend still aggregates the whole fleet.
+   * - ``-sri``, ``--status-report-interval-seconds``
+     - No
+     - ``2``
+     - The scheduler's status report interval; set it to match so the scheduler-stale indicator is accurate.
    * - ``-ll``, ``--logging-level``
      - No
      - ``INFO``

--- a/docs/source/tutorials/commands.rst
+++ b/docs/source/tutorials/commands.rst
@@ -1020,7 +1020,7 @@ UI arguments
      - Host and port for the web server.
    * - ``-bi``, ``--broadcast-interval-seconds``
      - No
-     - ``0.1``
+     - ``0.5``
      - Interval between updates the web GUI pushes to connected browsers.
    * - ``-tl``, ``--task-log-max-size``
      - No

--- a/docs/source/tutorials/commands.rst
+++ b/docs/source/tutorials/commands.rst
@@ -277,10 +277,6 @@ Scheduler arguments
      - No
      - ``2``
      - Interval between status reports the scheduler publishes to monitors (``scaler_top``/``scaler_gui``).
-   * - ``-srwl``, ``--status-report-worker-limit``
-     - No
-     - ``-1``
-     - Maximum workers whose full detail is serialized into each status report (``-1`` is unlimited).
 
 .. list-table:: Policy options
    :header-rows: 1

--- a/docs/source/tutorials/commands.rst
+++ b/docs/source/tutorials/commands.rst
@@ -1026,10 +1026,6 @@ UI arguments
      - No
      - ``500``
      - Maximum completed tasks kept and shown in the task log.
-   * - ``-wl``, ``--worker-display-limit``
-     - No
-     - ``500``
-     - Maximum workers sent to each browser (``-1`` is unlimited); the backend still aggregates the whole fleet.
    * - ``-sri``, ``--status-report-interval-seconds``
      - No
      - ``2``

--- a/docs/source/tutorials/commands.rst
+++ b/docs/source/tutorials/commands.rst
@@ -275,7 +275,7 @@ Scheduler arguments
      - I/O backend thread count.
    * - ``-sri``, ``--status-report-interval-seconds``
      - No
-     - ``2``
+     - ``1``
      - Interval between status reports the scheduler publishes to monitors (``scaler_top``/``scaler_gui``).
 
 .. list-table:: Policy options
@@ -1028,7 +1028,7 @@ UI arguments
      - Maximum completed tasks kept and shown in the task log.
    * - ``-sri``, ``--status-report-interval-seconds``
      - No
-     - ``2``
+     - ``1``
      - The scheduler's status report interval; set it to match so the scheduler-stale indicator is accurate.
    * - ``-ll``, ``--logging-level``
      - No

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -8,8 +8,11 @@ from scaler.config.types.network_backend import NetworkBackendType
 # object clean up time interval
 CLEANUP_INTERVAL_SECONDS = 1
 
-# status report interval, used by poke or scaled monitor
-STATUS_REPORT_INTERVAL_SECONDS = 1
+# how often the scheduler publishes full status (every worker and processor) to monitors and the web GUI.
+# The scheduler builds this on its event loop every interval whether or not a monitor is attached, so the
+# cost scales with worker/processor count; 2s keeps a dashboard responsive while halving that overhead
+# versus 1s. Very large fleets (thousands of workers) should raise it further via -sri.
+STATUS_REPORT_INTERVAL_SECONDS = 2
 
 # number of seconds for profiling
 PROFILING_INTERVAL_SECONDS = 1
@@ -91,6 +94,15 @@ DEFAULT_LOGGING_LEVEL = "INFO"
 
 # default logging paths
 DEFAULT_LOGGING_PATHS = ("/dev/stdout",)
+
+# =======================
+# WEB GUI (scaler_gui) SPECIFIC OPTIONS
+
+# how often the web GUI backend pushes an update to connected browsers; drives the streaming chart cadence
+DEFAULT_GUI_BROADCAST_INTERVAL_SECONDS = 0.1
+
+# maximum number of completed tasks the web GUI retains and shows in the task log
+DEFAULT_GUI_TASK_LOG_MAX_SIZE = 500
 
 # =======================
 # SCALER NETWORK BACKEND SPECIFIC OPTIONS

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -110,6 +110,11 @@ DEFAULT_GUI_BROADCAST_INTERVAL_SECONDS = 0.1
 # maximum number of completed tasks the web GUI retains and shows in the task log
 DEFAULT_GUI_TASK_LOG_MAX_SIZE = 500
 
+# maximum number of workers the web GUI backend sends to each browser (with per-processor detail); -1 means
+# unlimited. The backend keeps and aggregates the whole fleet, so per-manager stats stay complete -- this
+# only bounds what a browser must receive and render, which is what lags a viewer's machine at scale.
+DEFAULT_GUI_WORKER_DISPLAY_LIMIT = 500
+
 # =======================
 # SCALER NETWORK BACKEND SPECIFIC OPTIONS
 

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -10,8 +10,8 @@ CLEANUP_INTERVAL_SECONDS = 1
 
 # how often the scheduler publishes full status (every worker and processor) to monitors and the web GUI.
 # The scheduler builds this on its event loop every interval whether or not a monitor is attached, so the
-# cost scales with worker/processor count; 2s keeps a dashboard responsive while halving that overhead
-# versus 1s. Very large fleets (thousands of workers) should raise it further via -sri.
+# cost scales with worker/processor count. Raise it via -sri on very large fleets (thousands of workers) to
+# cut that overhead.
 STATUS_REPORT_INTERVAL_SECONDS = 2
 
 # number of seconds for profiling

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -55,6 +55,12 @@ DEFAULT_LOAD_BALANCE_TRIGGER_TIMES = 2
 # number of tasks can be queued to each worker on scheduler side
 DEFAULT_PER_WORKER_QUEUE_SIZE = 1000
 
+# maximum number of workers whose full detail (per-processor stats) the scheduler serializes into each status
+# report; -1 (default) means unlimited. Serializing every worker each report is the dominant monitoring cost
+# at thousands of workers. Fleet and per-manager worker counts always stay accurate, but the web GUI's
+# per-manager resource sums are computed from the reported detail, so they undercount once this caps it.
+DEFAULT_STATUS_REPORT_WORKER_LIMIT = -1
+
 # =======================
 # WORKER SPECIFIC OPTIONS
 

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -9,10 +9,9 @@ from scaler.config.types.network_backend import NetworkBackendType
 CLEANUP_INTERVAL_SECONDS = 1
 
 # how often the scheduler publishes full status (every worker and processor) to monitors and the web GUI.
-# The scheduler builds this on its event loop every interval whether or not a monitor is attached, so the
-# cost scales with worker/processor count. Raise it via -sri on very large fleets (thousands of workers) to
-# cut that overhead.
-STATUS_REPORT_INTERVAL_SECONDS = 2
+# It is built on the scheduler's event loop whether or not a monitor is attached, so very large fleets
+# should raise it via -sri.
+STATUS_REPORT_INTERVAL_SECONDS = 1
 
 # number of seconds for profiling
 PROFILING_INTERVAL_SECONDS = 1

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -98,8 +98,9 @@ DEFAULT_LOGGING_PATHS = ("/dev/stdout",)
 # =======================
 # WEB GUI (scaler_gui) SPECIFIC OPTIONS
 
-# how often the web GUI backend pushes an update to connected browsers; drives the streaming chart cadence
-DEFAULT_GUI_BROADCAST_INTERVAL_SECONDS = 0.1
+# how often the web GUI backend pushes an update to connected browsers; drives the streaming chart cadence.
+# Pushing faster mostly redraws the same picture: one tick is about a pixel over the stream's 5 minute window.
+DEFAULT_GUI_BROADCAST_INTERVAL_SECONDS = 0.5
 
 # maximum number of completed tasks the web GUI retains and shows in the task log
 DEFAULT_GUI_TASK_LOG_MAX_SIZE = 500

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -104,11 +104,6 @@ DEFAULT_GUI_BROADCAST_INTERVAL_SECONDS = 0.1
 # maximum number of completed tasks the web GUI retains and shows in the task log
 DEFAULT_GUI_TASK_LOG_MAX_SIZE = 500
 
-# maximum number of workers the web GUI backend sends to each browser (with per-processor detail); -1 means
-# unlimited. The backend keeps and aggregates the whole fleet, so per-manager stats stay complete -- this
-# only bounds what a browser must receive and render, which is what lags a viewer's machine at scale.
-DEFAULT_GUI_WORKER_DISPLAY_LIMIT = 500
-
 # =======================
 # SCALER NETWORK BACKEND SPECIFIC OPTIONS
 

--- a/src/scaler/config/defaults.py
+++ b/src/scaler/config/defaults.py
@@ -55,12 +55,6 @@ DEFAULT_LOAD_BALANCE_TRIGGER_TIMES = 2
 # number of tasks can be queued to each worker on scheduler side
 DEFAULT_PER_WORKER_QUEUE_SIZE = 1000
 
-# maximum number of workers whose full detail (per-processor stats) the scheduler serializes into each status
-# report; -1 (default) means unlimited. Serializing every worker each report is the dominant monitoring cost
-# at thousands of workers. Fleet and per-manager worker counts always stay accurate, but the web GUI's
-# per-manager resource sums are computed from the reported detail, so they undercount once this caps it.
-DEFAULT_STATUS_REPORT_WORKER_LIMIT = -1
-
 # =======================
 # WORKER SPECIFIC OPTIONS
 

--- a/src/scaler/config/section/scheduler.py
+++ b/src/scaler/config/section/scheduler.py
@@ -61,6 +61,16 @@ class SchedulerConfig(ConfigClass):
             "running thousands of workers or tasks.",
         ),
     )
+    status_report_worker_limit: int = dataclasses.field(
+        default=defaults.DEFAULT_STATUS_REPORT_WORKER_LIMIT,
+        metadata=dict(
+            short="-srwl",
+            help="maximum number of workers whose full detail is serialized into each status report; -1 "
+            "(default) for unlimited. Set it (e.g. 1000) to keep the monitor and web GUI responsive with many "
+            "thousands of workers; worker counts stay accurate, but per-manager resource sums then cover only "
+            "the reported workers.",
+        ),
+    )
     protected: bool = dataclasses.field(
         default=False,
         metadata=dict(
@@ -125,3 +135,5 @@ class SchedulerConfig(ConfigClass):
             raise ValueError("load_balance_trigger_times must be a positive integer.")
         if self.status_report_interval_seconds <= 0:
             raise ValueError("status_report_interval_seconds must be positive.")
+        if self.status_report_worker_limit == 0 or self.status_report_worker_limit < -1:
+            raise ValueError("status_report_worker_limit must be -1 (unlimited) or a positive integer.")

--- a/src/scaler/config/section/scheduler.py
+++ b/src/scaler/config/section/scheduler.py
@@ -65,10 +65,11 @@ class SchedulerConfig(ConfigClass):
         default=defaults.DEFAULT_STATUS_REPORT_WORKER_LIMIT,
         metadata=dict(
             short="-srwl",
-            help="maximum number of workers whose full detail is serialized into each status report; -1 "
-            "(default) for unlimited. Set it (e.g. 1000) to keep the monitor and web GUI responsive with many "
-            "thousands of workers; worker counts stay accurate, but per-manager resource sums then cover only "
-            "the reported workers.",
+            help="maximum number of workers whose full detail the scheduler serializes into each status report; "
+            "-1 (default) for unlimited. Rarely needed: it only bounds work on the scheduler's own event loop at "
+            "extreme scale. To keep browsers responsive, bound what they receive with scaler_gui "
+            "--worker-display-limit instead, which keeps per-manager resource sums complete; setting this caps "
+            "the data those sums see.",
         ),
     )
     protected: bool = dataclasses.field(

--- a/src/scaler/config/section/scheduler.py
+++ b/src/scaler/config/section/scheduler.py
@@ -52,6 +52,15 @@ class SchedulerConfig(ConfigClass):
             "tcp://localhost:2347",
         ),
     )
+    status_report_interval_seconds: int = dataclasses.field(
+        default=defaults.STATUS_REPORT_INTERVAL_SECONDS,
+        metadata=dict(
+            short="-sri",
+            help="number of seconds between scheduler status reports to the monitors (scaler_top / scaler_gui). "
+            "Each report serializes every worker and processor, so raise this to cut monitoring overhead when "
+            "running thousands of workers or tasks.",
+        ),
+    )
     protected: bool = dataclasses.field(
         default=False,
         metadata=dict(
@@ -114,3 +123,5 @@ class SchedulerConfig(ConfigClass):
             raise ValueError("load_balance_seconds must be non-zero (use a negative value to disable balancing).")
         if self.load_balance_trigger_times <= 0:
             raise ValueError("load_balance_trigger_times must be a positive integer.")
+        if self.status_report_interval_seconds <= 0:
+            raise ValueError("status_report_interval_seconds must be positive.")

--- a/src/scaler/config/section/scheduler.py
+++ b/src/scaler/config/section/scheduler.py
@@ -61,17 +61,6 @@ class SchedulerConfig(ConfigClass):
             "running thousands of workers or tasks.",
         ),
     )
-    status_report_worker_limit: int = dataclasses.field(
-        default=defaults.DEFAULT_STATUS_REPORT_WORKER_LIMIT,
-        metadata=dict(
-            short="-srwl",
-            help="maximum number of workers whose full detail the scheduler serializes into each status report; "
-            "-1 (default) for unlimited. Rarely needed: it only bounds work on the scheduler's own event loop at "
-            "extreme scale. To keep browsers responsive, bound what they receive with scaler_gui "
-            "--worker-display-limit instead, which keeps per-manager resource sums complete; setting this caps "
-            "the data those sums see.",
-        ),
-    )
     protected: bool = dataclasses.field(
         default=False,
         metadata=dict(
@@ -136,5 +125,3 @@ class SchedulerConfig(ConfigClass):
             raise ValueError("load_balance_trigger_times must be a positive integer.")
         if self.status_report_interval_seconds <= 0:
             raise ValueError("status_report_interval_seconds must be positive.")
-        if self.status_report_worker_limit == 0 or self.status_report_worker_limit < -1:
-            raise ValueError("status_report_worker_limit must be -1 (unlimited) or a positive integer.")

--- a/src/scaler/config/section/webgui.py
+++ b/src/scaler/config/section/webgui.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+from scaler.config import defaults
 from scaler.config.common.logging import LoggingConfig
 from scaler.config.common.security import SecurityConfig
 from scaler.config.config_class import ConfigClass
@@ -16,6 +17,36 @@ class WebGUIConfig(ConfigClass):
         default_factory=lambda: HTTPConfig("0.0.0.0", 50001),
         metadata=dict(help="host and port for the web server (e.g. 0.0.0.0:50001)"),
     )
+    broadcast_interval_seconds: float = dataclasses.field(
+        default=defaults.DEFAULT_GUI_BROADCAST_INTERVAL_SECONDS,
+        metadata=dict(
+            short="-bi",
+            help="how often (seconds) the web GUI pushes updates to browsers; drives the streaming chart "
+            "smoothness. Raise it to cut browser and network load with many connected viewers.",
+        ),
+    )
+    task_log_max_size: int = dataclasses.field(
+        default=defaults.DEFAULT_GUI_TASK_LOG_MAX_SIZE,
+        metadata=dict(
+            short="-tl", help="maximum number of completed tasks the web GUI keeps and displays in the task log."
+        ),
+    )
+    status_report_interval_seconds: int = dataclasses.field(
+        default=defaults.STATUS_REPORT_INTERVAL_SECONDS,
+        metadata=dict(
+            short="-sri",
+            help="the scheduler's status report interval (its own -sri); the GUI marks the scheduler stale after "
+            "about 5x this without an update, so set it to match the scheduler.",
+        ),
+    )
 
     logging_config: LoggingConfig = dataclasses.field(default_factory=LoggingConfig)
     security: SecurityConfig = dataclasses.field(default_factory=SecurityConfig)
+
+    def __post_init__(self):
+        if self.broadcast_interval_seconds <= 0:
+            raise ValueError("broadcast_interval_seconds must be positive.")
+        if self.task_log_max_size <= 0:
+            raise ValueError("task_log_max_size must be positive.")
+        if self.status_report_interval_seconds <= 0:
+            raise ValueError("status_report_interval_seconds must be positive.")

--- a/src/scaler/config/section/webgui.py
+++ b/src/scaler/config/section/webgui.py
@@ -31,6 +31,15 @@ class WebGUIConfig(ConfigClass):
             short="-tl", help="maximum number of completed tasks the web GUI keeps and displays in the task log."
         ),
     )
+    worker_display_limit: int = dataclasses.field(
+        default=defaults.DEFAULT_GUI_WORKER_DISPLAY_LIMIT,
+        metadata=dict(
+            short="-wl",
+            help="maximum number of workers the web GUI sends to each browser; -1 for unlimited. The backend "
+            "still holds and aggregates the whole fleet (per-manager stats stay complete); this bounds only what "
+            "a browser must receive and render, which is what lags a viewer's machine at large scale.",
+        ),
+    )
     status_report_interval_seconds: int = dataclasses.field(
         default=defaults.STATUS_REPORT_INTERVAL_SECONDS,
         metadata=dict(
@@ -48,5 +57,7 @@ class WebGUIConfig(ConfigClass):
             raise ValueError("broadcast_interval_seconds must be positive.")
         if self.task_log_max_size <= 0:
             raise ValueError("task_log_max_size must be positive.")
+        if self.worker_display_limit == 0 or self.worker_display_limit < -1:
+            raise ValueError("worker_display_limit must be -1 (unlimited) or a positive integer.")
         if self.status_report_interval_seconds <= 0:
             raise ValueError("status_report_interval_seconds must be positive.")

--- a/src/scaler/config/section/webgui.py
+++ b/src/scaler/config/section/webgui.py
@@ -31,15 +31,6 @@ class WebGUIConfig(ConfigClass):
             short="-tl", help="maximum number of completed tasks the web GUI keeps and displays in the task log."
         ),
     )
-    worker_display_limit: int = dataclasses.field(
-        default=defaults.DEFAULT_GUI_WORKER_DISPLAY_LIMIT,
-        metadata=dict(
-            short="-wl",
-            help="maximum number of workers the web GUI sends to each browser; -1 for unlimited. The backend "
-            "still holds and aggregates the whole fleet (per-manager stats stay complete); this bounds only what "
-            "a browser must receive and render, which is what lags a viewer's machine at large scale.",
-        ),
-    )
     status_report_interval_seconds: int = dataclasses.field(
         default=defaults.STATUS_REPORT_INTERVAL_SECONDS,
         metadata=dict(
@@ -57,7 +48,5 @@ class WebGUIConfig(ConfigClass):
             raise ValueError("broadcast_interval_seconds must be positive.")
         if self.task_log_max_size <= 0:
             raise ValueError("task_log_max_size must be positive.")
-        if self.worker_display_limit == 0 or self.worker_display_limit < -1:
-            raise ValueError("worker_display_limit must be -1 (unlimited) or a positive integer.")
         if self.status_report_interval_seconds <= 0:
             raise ValueError("status_report_interval_seconds must be positive.")

--- a/src/scaler/scheduler/controllers/worker_controller.py
+++ b/src/scaler/scheduler/controllers/worker_controller.py
@@ -112,9 +112,9 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
     def get_status(self) -> WorkerManagerStatus:
         worker_to_task_numbers = self._policy_controller.statistics()
         # Cap the per-worker detail list: serializing every worker (with its per-processor stats) on the
-        # scheduler loop every report is the dominant monitoring cost at thousands of workers. Per-manager
-        # counts and aggregates are reported separately and always cover the whole fleet, so monitor totals
-        # stay accurate; this only bounds the detail list.
+        # scheduler loop every report is the dominant monitoring cost at thousands of workers. The per-manager
+        # worker lists are reported in full separately, so worker counts stay accurate; only the per-worker
+        # detail is bounded, so monitors that sum resources from it then cover just the reported workers.
         limit = self._config_controller.get_config("status_report_worker_limit")
         capped = itertools.islice(self._worker_alive_since.items(), limit if limit >= 0 else None)
         return WorkerManagerStatus(

--- a/src/scaler/scheduler/controllers/worker_controller.py
+++ b/src/scaler/scheduler/controllers/worker_controller.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import time
 from typing import Dict, List, Optional, Set, Tuple
@@ -110,10 +111,16 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
 
     def get_status(self) -> WorkerManagerStatus:
         worker_to_task_numbers = self._policy_controller.statistics()
+        # Cap the per-worker detail list: serializing every worker (with its per-processor stats) on the
+        # scheduler loop every report is the dominant monitoring cost at thousands of workers. Per-manager
+        # counts and aggregates are reported separately and always cover the whole fleet, so monitor totals
+        # stay accurate; this only bounds the detail list.
+        limit = self._config_controller.get_config("status_report_worker_limit")
+        capped = itertools.islice(self._worker_alive_since.items(), limit if limit >= 0 else None)
         return WorkerManagerStatus(
             workers=[
                 self.__worker_status_from_heartbeat(worker, worker_to_task_numbers[worker], last, info)
-                for worker, (last, info) in self._worker_alive_since.items()
+                for worker, (last, info) in capped
             ]
         )
 

--- a/src/scaler/scheduler/controllers/worker_controller.py
+++ b/src/scaler/scheduler/controllers/worker_controller.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import time
 from typing import Dict, List, Optional, Set, Tuple
@@ -111,16 +110,10 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
 
     def get_status(self) -> WorkerManagerStatus:
         worker_to_task_numbers = self._policy_controller.statistics()
-        # Cap the per-worker detail list: serializing every worker (with its per-processor stats) on the
-        # scheduler loop every report is the dominant monitoring cost at thousands of workers. The per-manager
-        # worker lists are reported in full separately, so worker counts stay accurate; only the per-worker
-        # detail is bounded, so monitors that sum resources from it then cover just the reported workers.
-        limit = self._config_controller.get_config("status_report_worker_limit")
-        capped = itertools.islice(self._worker_alive_since.items(), limit if limit >= 0 else None)
         return WorkerManagerStatus(
             workers=[
                 self.__worker_status_from_heartbeat(worker, worker_to_task_numbers[worker], last, info)
-                for worker, (last, info) in capped
+                for worker, (last, info) in self._worker_alive_since.items()
             ]
         )
 

--- a/src/scaler/scheduler/scheduler.py
+++ b/src/scaler/scheduler/scheduler.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from scaler.config.defaults import CLEANUP_INTERVAL_SECONDS, STATUS_REPORT_INTERVAL_SECONDS
+from scaler.config.defaults import CLEANUP_INTERVAL_SECONDS
 from scaler.config.section.scheduler import SchedulerConfig
 from scaler.config.types.address import AddressConfig
 from scaler.io.mixins import AsyncBinder, AsyncObjectStorageConnector, AsyncPublisher
@@ -267,7 +267,10 @@ class Scheduler:
             create_async_loop_routine(self._object_controller.routine, CLEANUP_INTERVAL_SECONDS),
             create_async_loop_routine(self._worker_controller.routine, CLEANUP_INTERVAL_SECONDS),
             create_async_loop_routine(self._worker_manager_controller.routine, CLEANUP_INTERVAL_SECONDS),
-            create_async_loop_routine(self._information_controller.routine, STATUS_REPORT_INTERVAL_SECONDS),
+            create_async_loop_routine(
+                self._information_controller.routine,
+                self._config_controller.get_config("status_report_interval_seconds"),
+            ),
         ]
 
         try:

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -751,6 +751,7 @@ class WebUIApp:
 
             # Always send chart data (auto-scrolling)
             stream_data = self._task_stream.get_render_data()
+            self._cap_stream_rows(stream_data)
             self._enrich_stream_with_managers(stream_data)
             payload["task_stream"] = stream_data
 
@@ -1036,6 +1037,18 @@ class WebUIApp:
             self._active_tasks[task_id_hex] = entry
             return entry
 
+    def _cap_stream_rows(self, stream_data: Dict[str, Any]) -> None:
+        """Bound the task stream to worker_display_limit, like the tables: without this the stream carries a
+        row (and its bars) per worker, so a browser would receive the whole fleet even though the tables do
+        not. Rows beyond the limit, and their bars, are dropped before the data is sent."""
+        limit = self._worker_display_limit
+        if limit < 0 or len(stream_data.get("rows", [])) <= limit:
+            return
+        stream_data["rows"] = stream_data["rows"][:limit]
+        if "full_rows" in stream_data:
+            stream_data["full_rows"] = stream_data["full_rows"][:limit]
+        stream_data["bars"] = [bar for bar in stream_data.get("bars", []) if bar.get("r", 0) < limit]
+
     def _enrich_stream_with_managers(self, stream_data: Dict[str, Any]) -> None:
         """Add per-row manager IDs and a manager color legend to task stream data."""
         full_rows = stream_data.get("full_rows", [])
@@ -1151,6 +1164,7 @@ class WebUIApp:
         self._drain_pending_messages()
 
         stream_data = self._task_stream.get_render_data()
+        self._cap_stream_rows(stream_data)
         self._enrich_stream_with_managers(stream_data)
         memory_data = self._memory_chart.get_render_data(stream_data["window"])
         # combine active + completed for initial task log, sorted by time (newest first). _active_tasks is

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -14,7 +14,6 @@ from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from scaler.config.defaults import STATUS_REPORT_INTERVAL_SECONDS
 from scaler.config.section.webgui import WebGUIConfig
 from scaler.io.mixins import SyncSubscriber
 from scaler.io.network_backends import get_network_backend_from_env
@@ -36,13 +35,6 @@ from scaler.utility.metadata.profile_result import ProfileResult
 _logger = logging.getLogger(__name__)
 
 STATIC_DIR = Path(__file__).parent / "static"
-
-BATCH_INTERVAL_SECONDS = 0.1
-TASK_LOG_MAX_SIZE = 500
-
-# Mark the scheduler stale once its periodic StateScheduler heartbeat has not arrived for this long. The
-# heartbeat runs on the scheduler's main loop, so a stalled loop stops it and the UI reflects that.
-SCHEDULER_STALE_SECONDS = 5 * STATUS_REPORT_INTERVAL_SECONDS
 
 COMPLETED_TASK_STATUSES = (
     TaskState.success,
@@ -629,6 +621,13 @@ class WebUIApp:
 
     def __init__(self, config: WebGUIConfig) -> None:
         self._config = config
+        self._broadcast_interval_seconds: float = config.broadcast_interval_seconds
+        self._task_log_max_size: int = config.task_log_max_size
+        # Mark the scheduler stale once its periodic StateScheduler heartbeat has not arrived for ~5x its
+        # report interval; that heartbeat runs on the scheduler's main loop, so a stalled loop stops it.
+        self._scheduler_stale_seconds: float = 5 * config.status_report_interval_seconds
+        # Total completed tasks seen since this GUI process started, uncapped by the display ring buffer.
+        self._task_log_total: int = 0
         self._message_queue: queue.Queue[BaseMessage] = queue.Queue()
         self._clients: List[WebSocket] = []
         self._clients_lock = asyncio.Lock()
@@ -637,7 +636,7 @@ class WebUIApp:
         self._scheduler_data: Dict[str, Any] = {}
         self._workers_data: Dict[str, Dict[str, Any]] = {}
         self._worker_capabilities: Dict[str, Dict[str, int]] = {}
-        self._task_log: Deque[Dict[str, Any]] = deque(maxlen=TASK_LOG_MAX_SIZE)
+        self._task_log: Deque[Dict[str, Any]] = deque(maxlen=self._task_log_max_size)
         self._active_tasks: Dict[str, Dict[str, Any]] = {}  # task_id_hex -> entry (running tasks)
         self._task_id_to_function: Dict[str, str] = {}
         self._task_stream = TaskStreamState()
@@ -690,9 +689,9 @@ class WebUIApp:
                 pass
 
     async def _batch_loop(self) -> None:
-        """Drain message queue every BATCH_INTERVAL_SECONDS and broadcast."""
+        """Drain the message queue every broadcast interval and push to browsers."""
         while True:
-            await asyncio.sleep(BATCH_INTERVAL_SECONDS)
+            await asyncio.sleep(self._broadcast_interval_seconds)
             messages: List[BaseMessage] = []
             while True:
                 try:
@@ -743,6 +742,7 @@ class WebUIApp:
 
             if new_task_logs:
                 payload["task_updates"] = new_task_logs
+                payload["task_log_total"] = self._task_log_total
 
             # Always send chart data (auto-scrolling)
             stream_data = self._task_stream.get_render_data()
@@ -994,6 +994,7 @@ class WebUIApp:
                 "capabilities": caps_str,
             }
             self._task_log.appendleft(entry)
+            self._task_log_total += 1
             return entry
         else:
             # running/inactive/canceling - track as active task
@@ -1003,7 +1004,9 @@ class WebUIApp:
                 worker_str = prev_entry.get("worker", "")
                 full_worker = prev_entry.get("full_worker", "")
             # remove stale completed entry if task was re-submitted
-            self._task_log = deque((e for e in self._task_log if e["task_id"] != task_id_hex), maxlen=TASK_LOG_MAX_SIZE)
+            self._task_log = deque(
+                (e for e in self._task_log if e["task_id"] != task_id_hex), maxlen=self._task_log_max_size
+            )
             entry = {
                 "task_id": task_id_hex,
                 "function": func_name,
@@ -1107,7 +1110,7 @@ class WebUIApp:
         if self._last_scheduler_heartbeat_time is None:
             return {"last_seen": "\u2014", "stale": False}
         elapsed = int((datetime.datetime.now() - self._last_scheduler_heartbeat_time).total_seconds())
-        return {"last_seen": format_seconds(elapsed), "stale": elapsed > SCHEDULER_STALE_SECONDS}
+        return {"last_seen": format_seconds(elapsed), "stale": elapsed > self._scheduler_stale_seconds}
 
     def get_full_state(self) -> Dict[str, Any]:
         """Get complete current state for a newly connected client."""
@@ -1118,9 +1121,12 @@ class WebUIApp:
         stream_data = self._task_stream.get_render_data()
         self._enrich_stream_with_managers(stream_data)
         memory_data = self._memory_chart.get_render_data(stream_data["window"])
-        # combine active + completed for initial task log, sorted by time (newest first)
+        # combine active + completed for initial task log, sorted by time (newest first). _active_tasks is
+        # unbounded (one entry per running task), so cap the snapshot to the display size -- at thousands of
+        # concurrent tasks the browser only shows task_log_max_size rows anyway, and the rest stream in.
         initial_task_log = list(self._active_tasks.values()) + list(self._task_log)
         initial_task_log.sort(key=lambda e: e.get("time", 0), reverse=True)
+        initial_task_log = initial_task_log[: self._task_log_max_size]
         # Build scheduler data with a last_seen derived from the periodic heartbeat.
         sched = dict(self._scheduler_data) if self._scheduler_data else {}
         sched.update(self.__scheduler_liveness())
@@ -1129,7 +1135,8 @@ class WebUIApp:
             "scheduler": sched,
             "workers": list(self._workers_data.values()),
             "task_log": initial_task_log,
-            "task_log_max_size": TASK_LOG_MAX_SIZE,
+            "task_log_max_size": self._task_log_max_size,
+            "task_log_total": self._task_log_total,
             "task_stream": stream_data,
             "memory_chart": memory_data,
             "processors": self._build_processors_data(),

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import hashlib
+import itertools
 import json
 import logging
 import queue
@@ -623,6 +624,7 @@ class WebUIApp:
         self._config = config
         self._broadcast_interval_seconds: float = config.broadcast_interval_seconds
         self._task_log_max_size: int = config.task_log_max_size
+        self._worker_display_limit: int = config.worker_display_limit
         # Mark the scheduler stale once its periodic StateScheduler heartbeat has not arrived for ~5x its
         # report interval; that heartbeat runs on the scheduler's main loop, so a stalled loop stops it.
         self._scheduler_stale_seconds: float = 5 * config.status_report_interval_seconds
@@ -737,7 +739,7 @@ class WebUIApp:
                 payload["scheduler"] = sched
 
             if has_scheduler_update:
-                payload["workers"] = list(self._workers_data.values())
+                payload["workers"] = self._capped_workers()
                 payload["workers_total"] = self._total_workers
 
             if worker_events:
@@ -1049,8 +1051,17 @@ class WebUIApp:
         ]
         stream_data["manager_legend"] = manager_legend
 
+    def _capped_workers(self) -> List[Dict[str, Any]]:
+        """The worker rows to send a browser: the full detail list bounded by worker_display_limit. The
+        backend keeps the whole fleet in self._workers_data and aggregates over all of it; only what a
+        browser must receive and render is bounded here."""
+        workers = list(self._workers_data.values())
+        if self._worker_display_limit >= 0:
+            return workers[: self._worker_display_limit]
+        return workers
+
     def _build_processors_data(self) -> List[Dict[str, Any]]:
-        # Group workers by manager_id and include per-manager summary stats
+        # Group every worker by manager for complete per-manager summaries.
         managers: Dict[str, List[Dict[str, Any]]] = {}
         for wp in self._worker_processors.values():
             mid = wp.get("manager_id", "—")
@@ -1059,6 +1070,14 @@ class WebUIApp:
         # Ensure all known worker managers appear even if they have no workers
         for mid in self._worker_managers_data:
             managers.setdefault(mid, [])
+
+        # The bounded slice of per-worker detail a browser receives, grouped back under its manager. Summaries
+        # below still cover every worker; only this detail is capped, since it dominates the payload size.
+        limit = self._worker_display_limit
+        detail_source = itertools.islice(self._worker_processors.values(), limit if limit >= 0 else None)
+        shown_by_manager: Dict[str, List[Dict[str, Any]]] = {}
+        for wp in detail_source:
+            shown_by_manager.setdefault(wp.get("manager_id", "—"), []).append(wp)
 
         result = []
         for manager_id, workers in sorted(managers.items()):
@@ -1081,7 +1100,7 @@ class WebUIApp:
                     "total_cpu": round(total_cpu, 1),
                     "total_processors": total_processors,
                     "active_processors": active_processors,
-                    "workers": workers,
+                    "workers": shown_by_manager.get(manager_id, []),
                 }
             )
         return result
@@ -1146,7 +1165,7 @@ class WebUIApp:
 
         return {
             "scheduler": sched,
-            "workers": list(self._workers_data.values()),
+            "workers": self._capped_workers(),
             "workers_total": self._total_workers,
             "task_log": initial_task_log,
             "task_log_max_size": self._task_log_max_size,

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -628,6 +628,8 @@ class WebUIApp:
         self._scheduler_stale_seconds: float = 5 * config.status_report_interval_seconds
         # Total completed tasks seen since this GUI process started, uncapped by the display ring buffer.
         self._task_log_total: int = 0
+        # Full fleet worker count from per-manager totals; the workers detail list may be capped by the scheduler.
+        self._total_workers: int = 0
         self._message_queue: queue.Queue[BaseMessage] = queue.Queue()
         self._clients: List[WebSocket] = []
         self._clients_lock = asyncio.Lock()
@@ -736,6 +738,7 @@ class WebUIApp:
 
             if has_scheduler_update:
                 payload["workers"] = list(self._workers_data.values())
+                payload["workers_total"] = self._total_workers
 
             if worker_events:
                 payload["worker_events"] = worker_events
@@ -767,28 +770,39 @@ class WebUIApp:
             "monitor_address": self._monitor_address,
         }
 
-        # Update persistent worker-to-manager mapping with latest data
-        managed_workers_lookup: Dict[bytes, list] = {}
+        # Update the worker-to-manager mapping and count workers per manager and across the fleet, in a
+        # single pass while each capnp workerIDs list is freshly accessed. Storing the lazy lists to len()
+        # them in the detail loop below is unreliable -- the references do not survive -- which otherwise
+        # reports 0 workers for every manager past the first. The fleet total also feeds the "N of M"
+        # workers indicator, since the scheduler may cap the per-worker detail it serializes.
+        # Key by the decoded manager name (a materialized str), not by the capnp id field: reading that
+        # field more than once per detail returns divergent values under capnp aliasing, so joining the two
+        # loops on it silently misses.
+        manager_worker_counts: Dict[str, int] = {}
+        total_workers = 0
         for pair in data.scalingManager.managedWorkers:
-            manager_id_bytes = pair.workerManagerID
-            worker_ids = pair.workerIDs
-            managed_workers_lookup[bytes(manager_id_bytes)] = worker_ids
-            manager_name = manager_id_bytes.decode() if manager_id_bytes else "unknown"
-            for wid in worker_ids:
+            manager_id_raw = bytes(pair.workerManagerID)
+            manager_name = manager_id_raw.decode() if manager_id_raw else "unknown"
+            manager_worker_count = 0
+            for wid in pair.workerIDs:
                 self._worker_manager_map[bytes(wid).decode()] = manager_name
+                manager_worker_count += 1
+            manager_worker_counts[manager_name] = manager_worker_count
+            total_workers += manager_worker_count
+        self._total_workers = total_workers
 
         # Update worker manager details from scaling_manager
         current_managers: Set[str] = set()
         for detail in data.scalingManager.workerManagerDetails:
-            manager_id = detail.workerManagerID.decode() if detail.workerManagerID else "unknown"
+            manager_id_raw = bytes(detail.workerManagerID)
+            manager_id = manager_id_raw.decode() if manager_id_raw else "unknown"
             current_managers.add(manager_id)
-            worker_ids_for_manager = managed_workers_lookup.get(bytes(detail.workerManagerID), [])
             self._worker_managers_data[manager_id] = {
                 "manager_id": manager_id,
                 "identity": detail.identity,
                 "last_seen": format_seconds(detail.lastSeenS),
                 "max_task_concurrency": detail.maxTaskConcurrency,
-                "worker_count": len(worker_ids_for_manager),
+                "worker_count": manager_worker_counts.get(manager_id, 0),
                 "pending_workers": detail.pendingWorkers,
                 "capabilities": detail.capabilities,
             }
@@ -890,7 +904,9 @@ class WebUIApp:
                 StateWorker(workerId=WorkerID(w.encode()), state=WorkerState.disconnected, capabilities=[])
             )
 
-        # Aggregate summary stats from workers into each worker manager entry
+        # Aggregate summary stats from the workers the GUI holds into each manager entry. worker_count is
+        # left as the full per-manager total computed above; these sums only cover workers currently in the
+        # detail list, which the scheduler may cap, so they are a lower bound at large scale.
         for manager_id, mgr_data in self._worker_managers_data.items():
             mgr_proc_cpu = 0.0
             mgr_proc_rss = 0
@@ -898,17 +914,14 @@ class WebUIApp:
             mgr_sent = 0
             mgr_queued = 0
             mgr_suspended = 0
-            worker_count = 0
             for w_data in self._workers_data.values():
                 if w_data.get("manager_id") == manager_id:
-                    worker_count += 1
                     mgr_proc_cpu += w_data.get("proc_cpu", 0)
                     mgr_proc_rss += w_data.get("proc_rss", 0)
                     mgr_free += w_data.get("free", 0)
                     mgr_sent += w_data.get("sent", 0)
                     mgr_queued += w_data.get("queued", 0)
                     mgr_suspended += w_data.get("suspended", 0)
-            mgr_data["worker_count"] = worker_count
             mgr_data["total_proc_cpu"] = round(mgr_proc_cpu, 1)
             mgr_data["total_proc_rss"] = mgr_proc_rss
             mgr_data["total_free"] = mgr_free
@@ -1134,6 +1147,7 @@ class WebUIApp:
         return {
             "scheduler": sched,
             "workers": list(self._workers_data.values()),
+            "workers_total": self._total_workers,
             "task_log": initial_task_log,
             "task_log_max_size": self._task_log_max_size,
             "task_log_total": self._task_log_total,

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -630,7 +630,7 @@ class WebUIApp:
         self._scheduler_stale_seconds: float = 5 * config.status_report_interval_seconds
         # Total completed tasks seen since this GUI process started, uncapped by the display ring buffer.
         self._task_log_total: int = 0
-        # Full fleet worker count from per-manager totals; the workers detail list may be capped by the scheduler.
+        # Full fleet worker count from per-manager totals; the worker rows sent to each browser are a bounded subset.
         self._total_workers: int = 0
         self._message_queue: queue.Queue[BaseMessage] = queue.Queue()
         self._clients: List[WebSocket] = []
@@ -776,7 +776,7 @@ class WebUIApp:
         # single pass while each capnp workerIDs list is freshly accessed. Storing the lazy lists to len()
         # them in the detail loop below is unreliable -- the references do not survive -- which otherwise
         # reports 0 workers for every manager past the first. The fleet total also feeds the "N of M"
-        # workers indicator, since the scheduler may cap the per-worker detail it serializes.
+        # workers indicator, since each browser receives only a bounded subset of workers.
         # Key by the decoded manager name (a materialized str), not by the capnp id field: reading that
         # field more than once per detail returns divergent values under capnp aliasing, so joining the two
         # loops on it silently misses.
@@ -906,9 +906,9 @@ class WebUIApp:
                 StateWorker(workerId=WorkerID(w.encode()), state=WorkerState.disconnected, capabilities=[])
             )
 
-        # Aggregate summary stats from the workers the GUI holds into each manager entry. worker_count is
-        # left as the full per-manager total computed above; these sums only cover workers currently in the
-        # detail list, which the scheduler may cap, so they are a lower bound at large scale.
+        # Aggregate per-manager summary stats over every worker the backend received (the whole fleet by
+        # default) -- so these sums are complete even though each browser is sent only a bounded subset for
+        # display. worker_count keeps the full per-manager total computed above.
         for manager_id, mgr_data in self._worker_managers_data.items():
             mgr_proc_cpu = 0.0
             mgr_proc_rss = 0

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -740,7 +740,7 @@ class WebUIApp:
 
             if has_scheduler_update:
                 payload["workers"] = self._capped_workers()
-                payload["workers_total"] = self._total_workers
+                payload["workers_total"] = self._fleet_worker_count()
 
             if worker_events:
                 payload["worker_events"] = worker_events
@@ -1073,6 +1073,15 @@ class WebUIApp:
             return workers[: self._worker_display_limit]
         return workers
 
+    def _fleet_worker_count(self) -> int:
+        """Full fleet size, for the "N of M" indicator next to a bounded worker list.
+
+        Per-manager totals are authoritative when managers report in, but a deployment can run workers
+        without a registered worker manager (e.g. the native manager in fixed mode), leaving those totals
+        at zero -- in which case the workers this backend holds are the fleet it knows about.
+        """
+        return max(self._total_workers, len(self._workers_data))
+
     def _build_processors_data(self) -> List[Dict[str, Any]]:
         # Group every worker by manager for complete per-manager summaries.
         managers: Dict[str, List[Dict[str, Any]]] = {}
@@ -1180,7 +1189,7 @@ class WebUIApp:
         return {
             "scheduler": sched,
             "workers": self._capped_workers(),
-            "workers_total": self._total_workers,
+            "workers_total": self._fleet_worker_count(),
             "task_log": initial_task_log,
             "task_log_max_size": self._task_log_max_size,
             "task_log_total": self._task_log_total,

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -1,7 +1,7 @@
 import asyncio
+import dataclasses
 import datetime
 import hashlib
-import itertools
 import json
 import logging
 import queue
@@ -9,7 +9,7 @@ import struct
 import threading
 from collections import deque
 from pathlib import Path
-from typing import Any, Deque, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
@@ -50,6 +50,117 @@ SLIDING_WINDOW_OPTIONS = {
     10: datetime.timedelta(minutes=10),
     30: datetime.timedelta(minutes=30),
 }
+
+DEFAULT_STREAM_WINDOW_MINUTES = 5
+
+# Rows per page for the views a browser pages through. The server owns these because it now serves one
+# page at a time: the browser reads them from the initial state, so the two cannot drift apart.
+WORKERS_PAGE_SIZE = 50
+PROCESSORS_PAGE_SIZE = 20
+STREAM_PAGE_SIZE = 50
+
+# Columns the workers table can be sorted by, and how. Sorting runs here rather than in the browser
+# because the browser only ever holds one page; these mirror the table's columns.
+WORKER_SORT_NUMERIC_FIELDS = frozenset(
+    {"agt_cpu", "agt_rss", "proc_cpu", "proc_rss", "mem_used_pct", "free", "sent", "queued", "suspended"}
+)
+# Columns whose display value is preformatted; sort them by the raw number behind it instead.
+WORKER_SORT_RAW_FIELDS = {"lag": "lag_us", "last_seen": "last_s"}
+WORKER_SORT_FIELDS = frozenset(
+    WORKER_SORT_NUMERIC_FIELDS | set(WORKER_SORT_RAW_FIELDS) | {"name", "manager_id", "itl", "capabilities"}
+)
+
+
+@dataclasses.dataclass
+class ClientView:
+    """What one browser is looking at: its page in each paged view, its sort column, its chart settings.
+
+    Held per socket. Two browsers therefore never overwrite each other -- paging, sorting and the
+    stream/memory chart controls used to be global server state, so one viewer's click moved everyone.
+    """
+
+    workers_page: int = 0
+    workers_sort: Optional[str] = None
+    workers_sort_ascending: bool = True
+    processors_page: int = 0
+    stream_page: int = 0
+    stream_window_minutes: int = DEFAULT_STREAM_WINDOW_MINUTES
+    memory_scale: str = "linear"
+
+    def apply_view(self, view: Dict[str, Any]) -> None:
+        """Apply a browser's `view` message, ignoring anything unrecognised."""
+        for name in ("workers_page", "processors_page", "stream_page"):
+            if name in view:
+                setattr(self, name, max(0, int(view[name])))
+
+        if "workers_sort" in view:
+            field = view["workers_sort"]
+            self.workers_sort = str(field) if field in WORKER_SORT_FIELDS else None
+        if "workers_sort_ascending" in view:
+            self.workers_sort_ascending = bool(view["workers_sort_ascending"])
+
+    def apply_settings(self, settings: Dict[str, Any]) -> None:
+        """Apply a browser's `settings` message (the stream window and memory scale controls)."""
+        if "stream_window" in settings:
+            window = int(settings["stream_window"])
+            if window in SLIDING_WINDOW_OPTIONS:
+                self.stream_window_minutes = window
+        if "memory_scale" in settings:
+            scale = str(settings["memory_scale"])
+            if scale in ("log", "linear"):
+                self.memory_scale = scale
+
+    def settings(self) -> Dict[str, Any]:
+        return {"stream_window": self.stream_window_minutes, "memory_scale": self.memory_scale}
+
+
+class _RenderCache:
+    """Memoizes the whole-fleet work shared by every connected browser, for one tick.
+
+    Browsers are served one page each, but the sort, the processor grouping and the stream render still
+    run over the whole fleet. Viewers usually share the same sort column and window, so this computes
+    each distinct one once per tick instead of once per browser.
+    """
+
+    def __init__(self) -> None:
+        self._sorted_workers: Dict[Tuple[Optional[str], bool], List[Dict[str, Any]]] = {}
+        self._processors: Optional[List[Dict[str, Any]]] = None
+        self._stream: Dict[int, Dict[str, Any]] = {}
+        self._memory: Dict[Tuple[float, str], Dict[str, Any]] = {}
+
+    def sorted_workers(self, app: "WebUIApp", view: ClientView) -> List[Dict[str, Any]]:
+        key = (view.workers_sort, view.workers_sort_ascending)
+        if key not in self._sorted_workers:
+            self._sorted_workers[key] = app._sorted_workers(*key)
+        return self._sorted_workers[key]
+
+    def processors(self, app: "WebUIApp") -> List[Dict[str, Any]]:
+        if self._processors is None:
+            self._processors = app._build_processors_data()
+        return self._processors
+
+    def stream(self, app: "WebUIApp", window_minutes: int) -> Dict[str, Any]:
+        if window_minutes not in self._stream:
+            stream_data = app._task_stream.get_render_data(window_minutes)
+            app._enrich_stream_with_managers(stream_data)
+            self._stream[window_minutes] = stream_data
+        return self._stream[window_minutes]
+
+    def memory(self, app: "WebUIApp", window_seconds: float, scale: str) -> Dict[str, Any]:
+        key = (window_seconds, scale)
+        if key not in self._memory:
+            self._memory[key] = app._memory_chart.get_render_data(window_seconds, scale)
+        return self._memory[key]
+
+
+def paginate(items: List[Any], page: int, size: int) -> Tuple[List[Any], int, int]:
+    """Slice `items` into the requested page, clamping it to what exists.
+
+    Returns (rows, clamped page, total pages).
+    """
+    total_pages = max(1, (len(items) + size - 1) // size)
+    page = min(max(page, 0), total_pages - 1)
+    return items[page * size : page * size + size], page, total_pages
 
 
 def _format_worker_name(worker_name: str, cutoff: int = 15) -> str:
@@ -130,7 +241,6 @@ class TaskStreamState:
     """Server-side state for the task stream chart."""
 
     def __init__(self) -> None:
-        self._stream_window = datetime.timedelta(minutes=5)
         self._memory_store_time = datetime.timedelta(minutes=30)
 
         # worker tracking
@@ -152,9 +262,6 @@ class TaskStreamState:
         self._dead_workers: Deque[Tuple[datetime.datetime, str]] = deque()
 
         self._lock = threading.Lock()
-
-    def set_stream_window(self, minutes: int) -> None:
-        self._stream_window = SLIDING_WINDOW_OPTIONS.get(minutes, datetime.timedelta(minutes=5))
 
     def _caps_to_colors(self, caps_str: str) -> List[str]:
         """Return a list of colors for the capabilities string.
@@ -343,13 +450,16 @@ class TaskStreamState:
             self._worker_capabilities.pop(worker, None)
             self._seen_workers.discard(worker)
 
-    def get_render_data(self) -> Dict[str, Any]:
+    def get_render_data(self, window_minutes: int) -> Dict[str, Any]:
+        """Render the stream over the requested window. The window is a per-browser setting, so it is
+        passed in rather than held here -- viewers can watch different windows at the same time."""
         now = datetime.datetime.now()
         now_ts = now.timestamp()
 
         with self._lock:
             self._prune_old_data(now)
-            window_seconds = self._stream_window.total_seconds()
+            window = SLIDING_WINDOW_OPTIONS.get(window_minutes, SLIDING_WINDOW_OPTIONS[DEFAULT_STREAM_WINDOW_MINUTES])
+            window_seconds = window.total_seconds()
             window_start_ts = now_ts - window_seconds
 
             # one row per worker, sorted by name - only include workers with visible activity
@@ -553,12 +663,7 @@ class MemoryChartState:
         self._start_time = datetime.datetime.now()
         self._points: List[Tuple[float, int]] = []  # (timestamp, memory_bytes)
         self._memory_store_time = datetime.timedelta(minutes=30)
-        self._memory_scale = "linear"
         self._lock = threading.Lock()
-
-    def set_memory_scale(self, scale: str) -> None:
-        if scale in ("log", "linear"):
-            self._memory_scale = scale
 
     def handle_task_state(self, state_task: StateTask) -> None:
         if state_task.metadata == b"":
@@ -578,7 +683,8 @@ class MemoryChartState:
             self._points.append((start_ts, profile.memory_peak))
             self._points.append((now.timestamp(), -profile.memory_peak))
 
-    def get_render_data(self, window_seconds: float) -> Dict[str, Any]:
+    def get_render_data(self, window_seconds: float, scale: str) -> Dict[str, Any]:
+        """Render the chart for one browser's window and scale, both per-viewer settings."""
         now = datetime.datetime.now()
         now_ts = now.timestamp()
         cutoff_ts = now_ts - self._memory_store_time.total_seconds()
@@ -614,7 +720,7 @@ class MemoryChartState:
             val = int(max_mem * i / 4)
             y_ticks.append({"val": val, "label": format_bytes(val)})
 
-        return {"points": chart_points, "y_ticks": y_ticks, "scale": self._memory_scale, "window": window_seconds}
+        return {"points": chart_points, "y_ticks": y_ticks, "scale": scale, "window": window_seconds}
 
 
 class WebUIApp:
@@ -624,16 +730,15 @@ class WebUIApp:
         self._config = config
         self._broadcast_interval_seconds: float = config.broadcast_interval_seconds
         self._task_log_max_size: int = config.task_log_max_size
-        self._worker_display_limit: int = config.worker_display_limit
         # Mark the scheduler stale once its periodic StateScheduler heartbeat has not arrived for ~5x its
         # report interval; that heartbeat runs on the scheduler's main loop, so a stalled loop stops it.
         self._scheduler_stale_seconds: float = 5 * config.status_report_interval_seconds
         # Total completed tasks seen since this GUI process started, uncapped by the display ring buffer.
         self._task_log_total: int = 0
-        # Full fleet worker count from per-manager totals; the worker rows sent to each browser are a bounded subset.
+        # Full fleet worker count from per-manager totals; each browser is sent one page of worker rows.
         self._total_workers: int = 0
         self._message_queue: queue.Queue[BaseMessage] = queue.Queue()
-        self._clients: List[WebSocket] = []
+        self._clients: Dict[WebSocket, ClientView] = {}
         self._clients_lock = asyncio.Lock()
 
         # server-side state
@@ -654,8 +759,6 @@ class WebUIApp:
         # Timestamp of the last StateScheduler heartbeat; the scheduler's last-seen derives from it and goes
         # stale when the main loop stalls.
         self._last_scheduler_heartbeat_time: Optional[datetime.datetime] = None
-
-        self._settings = {"stream_window": 5, "memory_scale": "linear"}
 
         self._identity = generate_identity_from_name("webui")
 
@@ -729,41 +832,39 @@ class WebUIApp:
             if has_scheduler_update:
                 self._last_scheduler_heartbeat_time = datetime.datetime.now()
 
-            # Build broadcast payload
-            payload: Dict[str, Any] = {}
+            # The parts every browser gets identically.
+            shared: Dict[str, Any] = {}
 
             # Always include scheduler data with a last_seen derived from the periodic heartbeat.
             if self._scheduler_data:
                 sched = dict(self._scheduler_data)
                 sched.update(self.__scheduler_liveness())
-                payload["scheduler"] = sched
-
-            if has_scheduler_update:
-                payload["workers"] = self._capped_workers()
-                payload["workers_total"] = self._fleet_worker_count()
+                shared["scheduler"] = sched
 
             if worker_events:
-                payload["worker_events"] = worker_events
+                shared["worker_events"] = worker_events
 
             if new_task_logs:
-                payload["task_updates"] = new_task_logs
-                payload["task_log_total"] = self._task_log_total
+                shared["task_updates"] = new_task_logs
+                shared["task_log_total"] = self._task_log_total
 
-            # Always send chart data (auto-scrolling)
-            stream_data = self._task_stream.get_render_data()
-            self._cap_stream_rows(stream_data)
-            self._enrich_stream_with_managers(stream_data)
-            payload["task_stream"] = stream_data
-
-            memory_data = self._memory_chart.get_render_data(stream_data["window"])
-            payload["memory_chart"] = memory_data
-
-            # Worker processors
             if has_scheduler_update:
-                payload["processors"] = self._build_processors_data()
-                payload["worker_managers"] = list(self._worker_managers_data.values())
+                shared["worker_managers"] = list(self._worker_managers_data.values())
 
-            await self._broadcast(payload)
+            # The paged parts differ per browser, so serialize per client. The whole-fleet work behind
+            # them (sort, grouping, stream render) is shared through the cache.
+            cache = _RenderCache()
+            await self._send_to_clients(
+                lambda view: {
+                    **shared,
+                    **(self._workers_section(view, cache) if has_scheduler_update else {}),
+                    **(self._processors_section(view, cache) if has_scheduler_update else {}),
+                    "task_stream": self._stream_section(view, cache),
+                    "memory_chart": cache.memory(
+                        self, cache.stream(self, view.stream_window_minutes)["window"], view.memory_scale
+                    ),
+                }
+            )
 
     def _process_scheduler(self, data: StateScheduler) -> None:
         self._scheduler_data = {
@@ -866,6 +967,10 @@ class WebUIApp:
                 "queued": worker_data.queued,
                 "suspended": worker_data.suspended,
                 "lag": format_microseconds(worker_data.lagUS),
+                # raw values behind the two preformatted columns, so sorting on them orders by magnitude
+                # instead of by the display string
+                "lag_us": worker_data.lagUS,
+                "last_s": worker_data.lastS,
                 "itl": worker_data.itl,
                 "last_seen": format_seconds(worker_data.lastS),
                 "capabilities": _display_capabilities(set(self._worker_capabilities.get(worker_name, {}).keys())),
@@ -1037,18 +1142,6 @@ class WebUIApp:
             self._active_tasks[task_id_hex] = entry
             return entry
 
-    def _cap_stream_rows(self, stream_data: Dict[str, Any]) -> None:
-        """Bound the task stream to worker_display_limit, like the tables: without this the stream carries a
-        row (and its bars) per worker, so a browser would receive the whole fleet even though the tables do
-        not. Rows beyond the limit, and their bars, are dropped before the data is sent."""
-        limit = self._worker_display_limit
-        if limit < 0 or len(stream_data.get("rows", [])) <= limit:
-            return
-        stream_data["rows"] = stream_data["rows"][:limit]
-        if "full_rows" in stream_data:
-            stream_data["full_rows"] = stream_data["full_rows"][:limit]
-        stream_data["bars"] = [bar for bar in stream_data.get("bars", []) if bar.get("r", 0) < limit]
-
     def _enrich_stream_with_managers(self, stream_data: Dict[str, Any]) -> None:
         """Add per-row manager IDs and a manager color legend to task stream data."""
         full_rows = stream_data.get("full_rows", [])
@@ -1064,14 +1157,79 @@ class WebUIApp:
         ]
         stream_data["manager_legend"] = manager_legend
 
-    def _capped_workers(self) -> List[Dict[str, Any]]:
-        """The worker rows to send a browser: the full detail list bounded by worker_display_limit. The
-        backend keeps the whole fleet in self._workers_data and aggregates over all of it; only what a
-        browser must receive and render is bounded here."""
+    def _sorted_workers(self, sort_field: Optional[str], ascending: bool) -> List[Dict[str, Any]]:
+        """The whole fleet in one browser's sort order. Sorting happens here because the browser is only
+        ever sent a page: it has no full array to sort."""
         workers = list(self._workers_data.values())
-        if self._worker_display_limit >= 0:
-            return workers[: self._worker_display_limit]
-        return workers
+        if sort_field is None:
+            return workers
+
+        raw_field = WORKER_SORT_RAW_FIELDS.get(sort_field, sort_field)
+        if sort_field in WORKER_SORT_NUMERIC_FIELDS or sort_field in WORKER_SORT_RAW_FIELDS:
+
+            def key(worker: Dict[str, Any]) -> Any:
+                value = worker.get(raw_field, 0)
+                return value if isinstance(value, (int, float)) else 0
+
+        else:
+
+            def key(worker: Dict[str, Any]) -> Any:
+                return str(worker.get(raw_field, "")).lower()
+
+        return sorted(workers, key=key, reverse=not ascending)
+
+    def _workers_section(self, view: ClientView, cache: "_RenderCache") -> Dict[str, Any]:
+        workers = cache.sorted_workers(self, view)
+        rows, page, total_pages = paginate(workers, view.workers_page, WORKERS_PAGE_SIZE)
+        view.workers_page = page
+        return {
+            "workers": rows,
+            "workers_total": self._fleet_worker_count(),
+            "workers_page": page,
+            "workers_pages": total_pages,
+        }
+
+    def _processors_section(self, view: ClientView, cache: "_RenderCache") -> Dict[str, Any]:
+        """One page of per-worker processor detail, regrouped under the managers it belongs to. The
+        per-manager summaries are computed over every worker, not just this page."""
+        groups = cache.processors(self)
+        flat: List[Tuple[str, Dict[str, Any]]] = [
+            (group["manager_id"], worker) for group in groups for worker in group["workers"]
+        ]
+        page_rows, page, total_pages = paginate(flat, view.processors_page, PROCESSORS_PAGE_SIZE)
+        view.processors_page = page
+
+        shown: Dict[str, List[Dict[str, Any]]] = {}
+        for manager_id, worker in page_rows:
+            shown.setdefault(manager_id, []).append(worker)
+
+        paged_groups = [dict(group, workers=shown.get(group["manager_id"], [])) for group in groups]
+        return {
+            "processors": paged_groups,
+            "processors_page": page,
+            "processors_pages": total_pages,
+            "processors_total": len(flat),
+        }
+
+    def _stream_section(self, view: ClientView, cache: "_RenderCache") -> Dict[str, Any]:
+        """One page of stream rows, with each bar's row index rebased to the page."""
+        stream_data = dict(cache.stream(self, view.stream_window_minutes))
+        rows = stream_data.get("rows", [])
+        _, page, total_pages = paginate(rows, view.stream_page, STREAM_PAGE_SIZE)
+        view.stream_page = page
+
+        start = page * STREAM_PAGE_SIZE
+        end = start + STREAM_PAGE_SIZE
+        stream_data["rows"] = rows[start:end]
+        stream_data["full_rows"] = stream_data.get("full_rows", [])[start:end]
+        stream_data["row_managers"] = stream_data.get("row_managers", [])[start:end]
+        stream_data["bars"] = [
+            dict(bar, r=bar["r"] - start) for bar in stream_data.get("bars", []) if start <= bar.get("r", 0) < end
+        ]
+        stream_data["page"] = page
+        stream_data["pages"] = total_pages
+        stream_data["total_rows"] = len(rows)
+        return stream_data
 
     def _fleet_worker_count(self) -> int:
         """Full fleet size, for the "N of M" indicator next to a bounded worker list.
@@ -1093,14 +1251,8 @@ class WebUIApp:
         for mid in self._worker_managers_data:
             managers.setdefault(mid, [])
 
-        # The bounded slice of per-worker detail a browser receives, grouped back under its manager. Summaries
-        # below still cover every worker; only this detail is capped, since it dominates the payload size.
-        limit = self._worker_display_limit
-        detail_source = itertools.islice(self._worker_processors.values(), limit if limit >= 0 else None)
-        shown_by_manager: Dict[str, List[Dict[str, Any]]] = {}
-        for wp in detail_source:
-            shown_by_manager.setdefault(wp.get("manager_id", "—"), []).append(wp)
-
+        # Every worker's detail, grouped under its manager. _processors_section slices one page out of
+        # this for each browser; the summaries below always cover the whole fleet.
         result = []
         for manager_id, workers in sorted(managers.items()):
             total_rss = 0
@@ -1122,22 +1274,10 @@ class WebUIApp:
                     "total_cpu": round(total_cpu, 1),
                     "total_processors": total_processors,
                     "active_processors": active_processors,
-                    "workers": shown_by_manager.get(manager_id, []),
+                    "workers": workers,
                 }
             )
         return result
-
-    def update_settings(self, settings: Dict[str, Any]) -> None:
-        if "stream_window" in settings:
-            val = int(settings["stream_window"])
-            if val in SLIDING_WINDOW_OPTIONS:
-                self._settings["stream_window"] = val
-                self._task_stream.set_stream_window(val)
-        if "memory_scale" in settings:
-            scale = str(settings["memory_scale"])
-            if scale in ("log", "linear"):
-                self._settings["memory_scale"] = scale
-                self._memory_chart.set_memory_scale(scale)
 
     def _drain_pending_messages(self) -> None:
         """Process any pending messages from the queue immediately.
@@ -1166,16 +1306,15 @@ class WebUIApp:
         elapsed = int((datetime.datetime.now() - self._last_scheduler_heartbeat_time).total_seconds())
         return {"last_seen": format_seconds(elapsed), "stale": elapsed > self._scheduler_stale_seconds}
 
-    def get_full_state(self) -> Dict[str, Any]:
-        """Get complete current state for a newly connected client."""
+    def get_full_state(self, view: ClientView) -> Dict[str, Any]:
+        """Get complete current state for one client, in that client's view."""
         # Flush any messages that arrived since the last batch-loop iteration so
         # the snapshot is as fresh as possible.
         self._drain_pending_messages()
 
-        stream_data = self._task_stream.get_render_data()
-        self._cap_stream_rows(stream_data)
-        self._enrich_stream_with_managers(stream_data)
-        memory_data = self._memory_chart.get_render_data(stream_data["window"])
+        cache = _RenderCache()
+        stream_data = self._stream_section(view, cache)
+        memory_data = cache.memory(self, stream_data["window"], view.memory_scale)
         # combine active + completed for initial task log, sorted by time (newest first). _active_tasks is
         # unbounded (one entry per running task), so cap the snapshot to the display size -- at thousands of
         # concurrent tasks the browser only shows task_log_max_size rows anyway, and the rest stream in.
@@ -1188,38 +1327,57 @@ class WebUIApp:
 
         return {
             "scheduler": sched,
-            "workers": self._capped_workers(),
-            "workers_total": self._fleet_worker_count(),
+            **self._workers_section(view, cache),
             "task_log": initial_task_log,
             "task_log_max_size": self._task_log_max_size,
             "task_log_total": self._task_log_total,
             "task_stream": stream_data,
             "memory_chart": memory_data,
-            "processors": self._build_processors_data(),
+            **self._processors_section(view, cache),
             "worker_managers": list(self._worker_managers_data.values()),
-            "settings": self._settings,
+            "settings": view.settings(),
+            "page_sizes": {
+                "workers": WORKERS_PAGE_SIZE,
+                "processors": PROCESSORS_PAGE_SIZE,
+                "stream": STREAM_PAGE_SIZE,
+            },
+            "sort_fields": sorted(WORKER_SORT_FIELDS),
         }
 
-    async def add_client(self, ws: WebSocket) -> None:
+    def view_update(self, view: ClientView) -> Dict[str, Any]:
+        """The paged sections for one client, answered as soon as it changes page/sort/settings rather
+        than at the next tick, so the click feels immediate."""
+        cache = _RenderCache()
+        stream_data = self._stream_section(view, cache)
+        return {
+            **self._workers_section(view, cache),
+            **self._processors_section(view, cache),
+            "task_stream": stream_data,
+            "memory_chart": cache.memory(self, stream_data["window"], view.memory_scale),
+            "settings": view.settings(),
+        }
+
+    async def add_client(self, ws: WebSocket) -> ClientView:
+        view = ClientView()
         async with self._clients_lock:
-            self._clients.append(ws)
+            self._clients[ws] = view
+        return view
 
     async def remove_client(self, ws: WebSocket) -> None:
         async with self._clients_lock:
-            if ws in self._clients:
-                self._clients.remove(ws)
+            self._clients.pop(ws, None)
 
-    async def _broadcast(self, payload: Dict[str, Any]) -> None:
-        data = json.dumps(payload)
+    async def _send_to_clients(self, build_payload: Callable[[ClientView], Dict[str, Any]]) -> None:
+        """Serialize and send one payload per client: each browser is on its own page and sort order."""
         async with self._clients_lock:
             dead: List[WebSocket] = []
-            for ws in self._clients:
+            for ws, view in self._clients.items():
                 try:
-                    await ws.send_text(data)
+                    await ws.send_text(json.dumps(build_payload(view)))
                 except Exception:
                     dead.append(ws)
             for ws in dead:
-                self._clients.remove(ws)
+                self._clients.pop(ws, None)
 
 
 def create_app(config: WebGUIConfig) -> FastAPI:
@@ -1256,21 +1414,30 @@ def create_app(config: WebGUIConfig) -> FastAPI:
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:
         await ws.accept()
-        await app_state.add_client(ws)
+        view = await app_state.add_client(ws)
         try:
             # send full state on connect
-            full_state = app_state.get_full_state()
+            full_state = app_state.get_full_state(view)
             full_state["type"] = "full_state"
             await ws.send_text(json.dumps(full_state))
 
-            # listen for client messages (settings changes)
+            # listen for this browser's view changes: paging, sorting and the chart settings, all of
+            # which only move this browser's own view
             while True:
                 data = await ws.receive_text()
                 try:
                     msg = json.loads(data)
-                    if msg.get("type") == "settings":
-                        app_state.update_settings(msg.get("settings", {}))
-                except (json.JSONDecodeError, KeyError):
+                    message_type = msg.get("type")
+                    if message_type == "settings":
+                        view.apply_settings(msg.get("settings", {}))
+                    elif message_type == "view":
+                        view.apply_view(msg.get("view", {}))
+                    else:
+                        continue
+                    update = app_state.view_update(view)
+                    update["type"] = "view_update"
+                    await ws.send_text(json.dumps(update))
+                except (json.JSONDecodeError, KeyError, TypeError, ValueError):
                     pass
         except WebSocketDisconnect:
             pass

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -53,7 +53,8 @@ SLIDING_WINDOW_OPTIONS = {
 
 DEFAULT_STREAM_WINDOW_MINUTES = 5
 
-# Rows per page. The browser reads these from the initial state, so the two cannot drift apart.
+# Rows per page. Server-side only: the browser is told which page it got and how many exist, never
+# the size, so it never has to agree with these.
 WORKERS_PAGE_SIZE = 50
 PROCESSORS_PAGE_SIZE = 20
 STREAM_PAGE_SIZE = 50
@@ -1317,12 +1318,6 @@ class WebUIApp:
             **self._processors_section(view, cache),
             "worker_managers": list(self._worker_managers_data.values()),
             "settings": view.settings(),
-            "page_sizes": {
-                "workers": WORKERS_PAGE_SIZE,
-                "processors": PROCESSORS_PAGE_SIZE,
-                "stream": STREAM_PAGE_SIZE,
-            },
-            "sort_fields": sorted(WORKER_SORT_FIELDS),
         }
 
     def view_update(self, view: ClientView) -> Dict[str, Any]:

--- a/src/scaler/ui/app.py
+++ b/src/scaler/ui/app.py
@@ -53,14 +53,12 @@ SLIDING_WINDOW_OPTIONS = {
 
 DEFAULT_STREAM_WINDOW_MINUTES = 5
 
-# Rows per page for the views a browser pages through. The server owns these because it now serves one
-# page at a time: the browser reads them from the initial state, so the two cannot drift apart.
+# Rows per page. The browser reads these from the initial state, so the two cannot drift apart.
 WORKERS_PAGE_SIZE = 50
 PROCESSORS_PAGE_SIZE = 20
 STREAM_PAGE_SIZE = 50
 
-# Columns the workers table can be sorted by, and how. Sorting runs here rather than in the browser
-# because the browser only ever holds one page; these mirror the table's columns.
+# Columns the workers table can be sorted by, mirroring the table's own columns.
 WORKER_SORT_NUMERIC_FIELDS = frozenset(
     {"agt_cpu", "agt_rss", "proc_cpu", "proc_rss", "mem_used_pct", "free", "sent", "queued", "suspended"}
 )
@@ -73,11 +71,7 @@ WORKER_SORT_FIELDS = frozenset(
 
 @dataclasses.dataclass
 class ClientView:
-    """What one browser is looking at: its page in each paged view, its sort column, its chart settings.
-
-    Held per socket. Two browsers therefore never overwrite each other -- paging, sorting and the
-    stream/memory chart controls used to be global server state, so one viewer's click moved everyone.
-    """
+    """What one browser is looking at. Held per socket, so viewers never move each other's view."""
 
     workers_page: int = 0
     workers_sort: Optional[str] = None
@@ -100,7 +94,7 @@ class ClientView:
             self.workers_sort_ascending = bool(view["workers_sort_ascending"])
 
     def apply_settings(self, settings: Dict[str, Any]) -> None:
-        """Apply a browser's `settings` message (the stream window and memory scale controls)."""
+        """Apply a browser's `settings` message, ignoring anything unrecognised."""
         if "stream_window" in settings:
             window = int(settings["stream_window"])
             if window in SLIDING_WINDOW_OPTIONS:
@@ -115,12 +109,8 @@ class ClientView:
 
 
 class _RenderCache:
-    """Memoizes the whole-fleet work shared by every connected browser, for one tick.
-
-    Browsers are served one page each, but the sort, the processor grouping and the stream render still
-    run over the whole fleet. Viewers usually share the same sort column and window, so this computes
-    each distinct one once per tick instead of once per browser.
-    """
+    """Memoizes the whole-fleet work (sort, grouping, stream render) for one tick, so N browsers
+    sharing a sort column cost one sort rather than N."""
 
     def __init__(self) -> None:
         self._sorted_workers: Dict[Tuple[Optional[str], bool], List[Dict[str, Any]]] = {}
@@ -154,10 +144,7 @@ class _RenderCache:
 
 
 def paginate(items: List[Any], page: int, size: int) -> Tuple[List[Any], int, int]:
-    """Slice `items` into the requested page, clamping it to what exists.
-
-    Returns (rows, clamped page, total pages).
-    """
+    """Slice `items` into the requested page, clamped to what exists: (rows, page, total pages)."""
     total_pages = max(1, (len(items) + size - 1) // size)
     page = min(max(page, 0), total_pages - 1)
     return items[page * size : page * size + size], page, total_pages
@@ -451,8 +438,7 @@ class TaskStreamState:
             self._seen_workers.discard(worker)
 
     def get_render_data(self, window_minutes: int) -> Dict[str, Any]:
-        """Render the stream over the requested window. The window is a per-browser setting, so it is
-        passed in rather than held here -- viewers can watch different windows at the same time."""
+        """Render the stream. The window is per-browser, so it is passed in rather than held here."""
         now = datetime.datetime.now()
         now_ts = now.timestamp()
 
@@ -684,7 +670,7 @@ class MemoryChartState:
             self._points.append((now.timestamp(), -profile.memory_peak))
 
     def get_render_data(self, window_seconds: float, scale: str) -> Dict[str, Any]:
-        """Render the chart for one browser's window and scale, both per-viewer settings."""
+        """Render the chart. Window and scale are per-browser, so they are passed in."""
         now = datetime.datetime.now()
         now_ts = now.timestamp()
         cutoff_ts = now_ts - self._memory_store_time.total_seconds()
@@ -851,8 +837,7 @@ class WebUIApp:
             if has_scheduler_update:
                 shared["worker_managers"] = list(self._worker_managers_data.values())
 
-            # The paged parts differ per browser, so serialize per client. The whole-fleet work behind
-            # them (sort, grouping, stream render) is shared through the cache.
+            # The paged parts differ per browser; the fleet-wide work behind them is shared via the cache.
             cache = _RenderCache()
             await self._send_to_clients(
                 lambda view: {
@@ -967,8 +952,7 @@ class WebUIApp:
                 "queued": worker_data.queued,
                 "suspended": worker_data.suspended,
                 "lag": format_microseconds(worker_data.lagUS),
-                # raw values behind the two preformatted columns, so sorting on them orders by magnitude
-                # instead of by the display string
+                # raw values behind the preformatted columns, so sorting them orders by magnitude
                 "lag_us": worker_data.lagUS,
                 "last_s": worker_data.lastS,
                 "itl": worker_data.itl,
@@ -1158,8 +1142,7 @@ class WebUIApp:
         stream_data["manager_legend"] = manager_legend
 
     def _sorted_workers(self, sort_field: Optional[str], ascending: bool) -> List[Dict[str, Any]]:
-        """The whole fleet in one browser's sort order. Sorting happens here because the browser is only
-        ever sent a page: it has no full array to sort."""
+        """The whole fleet in one browser's sort order; the browser holds a page and cannot sort."""
         workers = list(self._workers_data.values())
         if sort_field is None:
             return workers
@@ -1190,8 +1173,7 @@ class WebUIApp:
         }
 
     def _processors_section(self, view: ClientView, cache: "_RenderCache") -> Dict[str, Any]:
-        """One page of per-worker processor detail, regrouped under the managers it belongs to. The
-        per-manager summaries are computed over every worker, not just this page."""
+        """One page of processor detail; the per-manager summaries still cover every worker."""
         groups = cache.processors(self)
         flat: List[Tuple[str, Dict[str, Any]]] = [
             (group["manager_id"], worker) for group in groups for worker in group["workers"]
@@ -1251,8 +1233,7 @@ class WebUIApp:
         for mid in self._worker_managers_data:
             managers.setdefault(mid, [])
 
-        # Every worker's detail, grouped under its manager. _processors_section slices one page out of
-        # this for each browser; the summaries below always cover the whole fleet.
+        # Every worker's detail; _processors_section slices one page out of it per browser.
         result = []
         for manager_id, workers in sorted(managers.items()):
             total_rss = 0
@@ -1345,8 +1326,7 @@ class WebUIApp:
         }
 
     def view_update(self, view: ClientView) -> Dict[str, Any]:
-        """The paged sections for one client, answered as soon as it changes page/sort/settings rather
-        than at the next tick, so the click feels immediate."""
+        """The paged sections for one client, answered on its change instead of at the next tick."""
         cache = _RenderCache()
         stream_data = self._stream_section(view, cache)
         return {
@@ -1421,8 +1401,7 @@ def create_app(config: WebGUIConfig) -> FastAPI:
             full_state["type"] = "full_state"
             await ws.send_text(json.dumps(full_state))
 
-            # listen for this browser's view changes: paging, sorting and the chart settings, all of
-            # which only move this browser's own view
+            # this browser's own view changes: paging, sorting, chart settings
             while True:
                 data = await ws.receive_text()
                 try:

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -8,7 +8,7 @@ var workerRows = {};       // worker_id -> <tr> element
 var workerSortField = null;  // current sort column field name
 var workerSortAsc = true;    // sort direction
 var lastWorkersData = [];    // latest workers array for re-sorting
-var workersTotal = 0;        // full fleet size; workers array may be capped by the scheduler
+var workersTotal = 0;        // full fleet size; the workers array a browser receives may be a bounded subset
 var taskLogTotal = 0;  // completed tasks seen by the server since it started, uncapped by the display ring
 var TASK_LOG_MAX_SIZE = 100;  // overridden by server's task_log_max_size on initial state
 var taskRowMap = {};  // task_id -> tr element for in-place updates
@@ -376,8 +376,8 @@ function renderWorkers() {
     updateWorkersCountBadge();
 }
 
-// The scheduler caps the per-worker detail it serializes at scale; show "shown of total" (total covers the
-// whole fleet via per-manager counts) so a capped view is explicit rather than looking like the whole fleet.
+// The backend sends each browser only a bounded set of workers at scale; show "shown of total" (total is the
+// full fleet size) so a capped view is explicit rather than looking like the whole fleet.
 function updateWorkersCountBadge() {
     var shown = lastWorkersData.length;
     workersCount.textContent = workersTotal > shown ? (shown + " of " + workersTotal) : shown;

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -8,6 +8,7 @@ var workerRows = {};       // worker_id -> <tr> element
 var workerSortField = null;  // current sort column field name
 var workerSortAsc = true;    // sort direction
 var lastWorkersData = [];    // latest workers array for re-sorting
+var workersTotal = 0;        // full fleet size; workers array may be capped by the scheduler
 var taskLogTotal = 0;  // completed tasks seen by the server since it started, uncapped by the display ring
 var TASK_LOG_MAX_SIZE = 100;  // overridden by server's task_log_max_size on initial state
 var taskRowMap = {};  // task_id -> tr element for in-place updates
@@ -40,6 +41,7 @@ var schedRssFree = $("sched-rss-free");
 var schedLastSeen = $("sched-last-seen");
 var managersBody = $("managers-body");
 var workersBody = $("workers-body");
+var workersCount = $("workers-count");
 var tasklogBody = $("tasklog-body");
 var tasklogCount = $("tasklog-count");
 var streamCanvas = $("stream-canvas");
@@ -183,6 +185,7 @@ function handleMessage(data) {
         updateScheduler(data.scheduler);
     }
     if (data.workers) {
+        if (typeof data.workers_total === "number") workersTotal = data.workers_total;
         updateWorkers(data.workers);
     }
     if (data.worker_managers) {
@@ -208,6 +211,7 @@ function handleMessage(data) {
 
 function handleFullState(data) {
     if (data.scheduler) updateScheduler(data.scheduler);
+    if (typeof data.workers_total === "number") workersTotal = data.workers_total;
     if (data.workers) updateWorkers(data.workers);
     if (data.worker_managers) updateWorkerManagers(data.worker_managers);
     if (typeof data.task_log_max_size === "number" && data.task_log_max_size > 0) {
@@ -369,6 +373,14 @@ function renderWorkers() {
     if (workerSortField) {
         applySortOrder();
     }
+    updateWorkersCountBadge();
+}
+
+// The scheduler caps the per-worker detail it serializes at scale; show "shown of total" (total covers the
+// whole fleet via per-manager counts) so a capped view is explicit rather than looking like the whole fleet.
+function updateWorkersCountBadge() {
+    var shown = lastWorkersData.length;
+    workersCount.textContent = workersTotal > shown ? (shown + " of " + workersTotal) : shown;
 }
 
 function applySortOrder() {

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -4,18 +4,29 @@
 // -- State --
 var ws = null;
 var reconnectDelay = 500;
-var workerRows = {};       // worker_id -> <tr> element
 var workerSortField = null;  // current sort column field name
 var workerSortAsc = true;    // sort direction
-var lastWorkersData = [];    // latest workers array for re-sorting
+var lastWorkersData = [];    // workers array the browser received (bounded by -wl); sorted + paged client-side
 var workersTotal = 0;        // full fleet size; the workers array a browser receives may be a bounded subset
 var taskLogTotal = 0;  // completed tasks seen by the server since it started, uncapped by the display ring
 var TASK_LOG_MAX_SIZE = 100;  // overridden by server's task_log_max_size on initial state
-var taskRowMap = {};  // task_id -> tr element for in-place updates
-var streamBars = [];       // current bar data from server
-var streamRows = [];       // row labels (truncated)
-var streamFullRows = [];   // row labels (full worker names)
-var streamRowManagers = []; // manager color per row
+var taskLogData = [];        // full task-log data, newest first, up to TASK_LOG_MAX_SIZE
+var taskLogById = {};        // task_id -> entry, for in-place status updates
+// Numbered-page virtualization: each view keeps its full (received) data but renders only the current page,
+// so the DOM/canvas stays bounded to one page regardless of fleet or task count.
+var PAGE_SIZE = 50;
+var workersPage = 0;
+var taskLogPage = 0;
+var processorsPage = 0;
+var streamPage = 0;
+var streamBars = [];       // bars for the current page (row index re-based to page-local)
+var streamRows = [];       // row labels (truncated) for the current page
+var streamFullRows = [];   // row labels (full worker names) for the current page
+var streamRowManagers = []; // manager color per row, current page
+var streamBarsFull = [];       // full received stream data; sliced into the page vars above for drawing
+var streamRowsFull = [];
+var streamFullRowsFull = [];
+var streamRowManagersFull = [];
 var streamManagerColors = {}; // manager_id -> color
 var memoryPoints = [];     // memory chart points
 var memoryScale = "linear";
@@ -82,6 +93,8 @@ function renderActiveTab() {
         if (lastSchedulerData) renderScheduler(lastSchedulerData);
         renderWorkers();
         renderManagers();
+    } else if (activeTab === "tasklog") {
+        renderTaskLog();
     } else if (activeTab === "processors") {
         renderProcessors();
     } else if (activeTab === "stream") {
@@ -89,6 +102,40 @@ function renderActiveTab() {
         streamNeedsRedraw = true;
         memoryNeedsRedraw = true;
     }
+}
+
+// Numbered-page controls: renders "Prev  Page X / Y (N)  Next" into elId; onPage(newPage) re-renders the view.
+// Renders nothing (hidden via CSS) when there is only one page.
+function renderPager(elId, page, totalPages, total, onPage) {
+    var el = $(elId);
+    if (!el) return;
+    if (totalPages <= 1) { el.innerHTML = ""; return; }
+    el.innerHTML = "";
+    var prev = document.createElement("button");
+    prev.className = "pager-btn";
+    prev.textContent = "‹ Prev";
+    prev.disabled = page <= 0;
+    prev.addEventListener("click", function() { if (page > 0) onPage(page - 1); });
+    var info = document.createElement("span");
+    info.className = "pager-info";
+    info.textContent = "Page " + (page + 1) + " / " + totalPages + "  (" + total + ")";
+    var next = document.createElement("button");
+    next.className = "pager-btn";
+    next.textContent = "Next ›";
+    next.disabled = page >= totalPages - 1;
+    next.addEventListener("click", function() { if (page < totalPages - 1) onPage(page + 1); });
+    el.appendChild(prev);
+    el.appendChild(info);
+    el.appendChild(next);
+}
+
+// Clamp a page index and return the slice bounds ([start, end)) for the current page over `total` items.
+function pageSlice(page, total, size) {
+    size = size || PAGE_SIZE;
+    var totalPages = Math.max(1, Math.ceil(total / size));
+    if (page >= totalPages) page = totalPages - 1;
+    if (page < 0) page = 0;
+    return { page: page, totalPages: totalPages, start: page * size, end: page * size + size };
 }
 
 // -- Fit Page Toggle --
@@ -219,9 +266,7 @@ function handleFullState(data) {
     }
     taskLogTotal = typeof data.task_log_total === "number" ? data.task_log_total : 0;
     if (data.task_log) {
-        tasklogBody.innerHTML = "";
-        taskRowMap = {};
-        addTaskLogEntries(data.task_log, true);
+        setTaskLog(data.task_log);
     }
     if (data.task_stream) updateTaskStream(data.task_stream);
     if (data.memory_chart) updateMemoryChart(data.memory_chart);
@@ -348,32 +393,24 @@ function updateWorkers(workers) {
 }
 
 function renderWorkers() {
-    var workers = lastWorkersData;
-    var seen = {};
-    for (var i = 0; i < workers.length; i++) {
-        var w = workers[i];
-        seen[w.id] = true;
-        var row = workerRows[w.id];
-        if (!row) {
-            row = createWorkerRow(w);
-            workerRows[w.id] = row;
-            workersBody.appendChild(row);
-        }
-        updateWorkerRow(row, w);
-    }
-    // remove dead workers
-    var ids = Object.keys(workerRows);
-    for (var j = 0; j < ids.length; j++) {
-        if (!seen[ids[j]]) {
-            workersBody.removeChild(workerRows[ids[j]]);
-            delete workerRows[ids[j]];
-        }
-    }
-    // apply current sort order
-    if (workerSortField) {
-        applySortOrder();
+    var data = lastWorkersData.slice();
+    if (workerSortField) sortWorkerData(data);
+    var pg = pageSlice(workersPage, data.length);
+    workersPage = pg.page;
+    var pageRows = data.slice(pg.start, pg.end);
+
+    // Rebuild just this page's rows (<= PAGE_SIZE) each update; the DOM never holds the whole fleet.
+    workersBody.innerHTML = "";
+    for (var i = 0; i < pageRows.length; i++) {
+        var row = createWorkerRow(pageRows[i]);
+        updateWorkerRow(row, pageRows[i]);
+        workersBody.appendChild(row);
     }
     updateWorkersCountBadge();
+    renderPager("workers-pager", workersPage, pg.totalPages, data.length, function(p) {
+        workersPage = p;
+        renderWorkers();
+    });
 }
 
 // The backend sends each browser only a bounded set of workers at scale; show "shown of total" (total is the
@@ -383,37 +420,16 @@ function updateWorkersCountBadge() {
     workersCount.textContent = workersTotal > shown ? (shown + " of " + workersTotal) : shown;
 }
 
-function applySortOrder() {
-    var rows = Array.prototype.slice.call(workersBody.children);
-    var field = workerSortField;
-    var asc = workerSortAsc;
-    var isNumeric = WORKER_NUMERIC_FIELDS[field];
-
-    // build a lookup from the latest data
-    var dataById = {};
-    for (var i = 0; i < lastWorkersData.length; i++) {
-        dataById[lastWorkersData[i].id] = lastWorkersData[i];
-    }
-
-    rows.sort(function(a, b) {
-        var wa = dataById[a.getAttribute("data-worker")];
-        var wb = dataById[b.getAttribute("data-worker")];
-        if (!wa || !wb) return 0;
-        var va = wa[field], vb = wb[field];
+// Sort the worker data array in place by the active column; renderWorkers then paints the current page.
+function sortWorkerData(data) {
+    var field = workerSortField, asc = workerSortAsc, isNumeric = WORKER_NUMERIC_FIELDS[field];
+    data.sort(function(a, b) {
+        var va = a[field], vb = b[field];
         if (va == null) va = "";
         if (vb == null) vb = "";
-        var cmp;
-        if (isNumeric) {
-            cmp = (Number(va) || 0) - (Number(vb) || 0);
-        } else {
-            cmp = String(va).localeCompare(String(vb));
-        }
+        var cmp = isNumeric ? (Number(va) || 0) - (Number(vb) || 0) : String(va).localeCompare(String(vb));
         return asc ? cmp : -cmp;
     });
-
-    for (var j = 0; j < rows.length; j++) {
-        workersBody.appendChild(rows[j]);
-    }
 }
 
 function setupWorkerSort() {
@@ -437,7 +453,8 @@ function setupWorkerSort() {
                     allTh[k].classList.remove("sort-asc", "sort-desc");
                 }
                 th.classList.add(workerSortAsc ? "sort-asc" : "sort-desc");
-                applySortOrder();
+                workersPage = 0;  // jump to the top of the new sort order
+                renderWorkers();
             });
         })(ths[i], WORKER_FIELDS[i]);
     }
@@ -517,13 +534,16 @@ function updateWorkerRow(tr, w) {
 }
 
 function handleWorkerEvents(events) {
+    var removed = false;
     for (var i = 0; i < events.length; i++) {
         var ev = events[i];
-        if (ev.state === "disconnected" && workerRows[ev.worker_id]) {
-            workersBody.removeChild(workerRows[ev.worker_id]);
-            delete workerRows[ev.worker_id];
+        if (ev.state === "disconnected") {
+            var before = lastWorkersData.length;
+            lastWorkersData = lastWorkersData.filter(function(w) { return w.id !== ev.worker_id; });
+            if (lastWorkersData.length !== before) removed = true;
         }
     }
+    if (removed && activeTab === "live") renderWorkers();
 }
 
 // -- Task Log --
@@ -545,103 +565,78 @@ function statusClass(status) {
 function handleTaskUpdates(entries) {
     for (var i = 0; i < entries.length; i++) {
         var e = entries[i];
-        var existing = taskRowMap[e.task_id];
+        var existing = taskLogById[e.task_id];
         if (existing) {
-            // update cells in-place: worker(2), time(3), duration(4), peak_mem(5), status(6)
-            var cells = existing.children;
-            cells[2].textContent = e.worker || "";
-            cells[2].title = e.full_worker || e.worker || "";
-            cells[3].textContent = formatTime(e.time);
-            cells[4].textContent = e.duration;
-            cells[5].textContent = e.peak_mem;
-            cells[6].textContent = e.status;
-            cells[6].className = statusClass(e.status);
+            for (var k in e) { if (Object.prototype.hasOwnProperty.call(e, k)) existing[k] = e[k]; }
         } else {
-            // new task - insert at top
-            addTaskLogEntries([e]);
+            taskLogData.unshift(e);  // newest first
+            taskLogById[e.task_id] = e;
+            while (taskLogData.length > TASK_LOG_MAX_SIZE) {
+                var dropped = taskLogData.pop();
+                delete taskLogById[dropped.task_id];
+            }
         }
     }
+    if (activeTab === "tasklog") renderTaskLog();
+    else updateTaskLogBadge();  // the badge (server total) stays current even while the tab is hidden
 }
 
-function addTaskLogEntries(entries, append) {
-    for (var i = 0; i < entries.length; i++) {
-        var e = entries[i];
-        var tr = document.createElement("tr");
-        tr.dataset.taskId = e.task_id;
+// full_state: replace the whole task log (active + completed, newest first, already capped by the server).
+function setTaskLog(entries) {
+    taskLogData = entries.slice(0, TASK_LOG_MAX_SIZE);
+    taskLogById = {};
+    for (var i = 0; i < taskLogData.length; i++) taskLogById[taskLogData[i].task_id] = taskLogData[i];
+    taskLogPage = 0;
+    if (activeTab === "tasklog") renderTaskLog();
+    else updateTaskLogBadge();
+}
 
-        // Task ID (clickable to copy)
-        var tdId = document.createElement("td");
-        var span = document.createElement("span");
-        span.className = "task-id";
-        span.textContent = e.task_id;
-        span.title = e.task_id;
-        span.addEventListener("click", (function(id) {
-            return function() {
-                if (navigator.clipboard) {
-                    navigator.clipboard.writeText(id);
-                }
-            };
-        })(e.task_id));
-        tdId.appendChild(span);
-        tr.appendChild(tdId);
-
-        // Function
-        var tdFunc = document.createElement("td");
-        tdFunc.textContent = e.function;
-        tr.appendChild(tdFunc);
-
-        // Worker
-        var tdWorker = document.createElement("td");
-        tdWorker.textContent = e.worker || "";
-        tdWorker.title = e.full_worker || e.worker || "";
-        tr.appendChild(tdWorker);
-
-        // Time
-        var tdTime = document.createElement("td");
-        tdTime.textContent = formatTime(e.time);
-        tr.appendChild(tdTime);
-
-        // Duration
-        var tdDur = document.createElement("td");
-        tdDur.textContent = e.duration;
-        tr.appendChild(tdDur);
-
-        // Peak Mem
-        var tdMem = document.createElement("td");
-        tdMem.textContent = e.peak_mem;
-        tr.appendChild(tdMem);
-
-        // Status
-        var tdStatus = document.createElement("td");
-        tdStatus.textContent = e.status;
-        tdStatus.className = statusClass(e.status);
-        tr.appendChild(tdStatus);
-
-        // Capabilities
-        var tdCaps = document.createElement("td");
-        tdCaps.textContent = e.capabilities;
-        tr.appendChild(tdCaps);
-
-        // Insert row
-        if (append) {
-            tasklogBody.appendChild(tr);
-        } else if (tasklogBody.firstChild) {
-            tasklogBody.insertBefore(tr, tasklogBody.firstChild);
-        } else {
-            tasklogBody.appendChild(tr);
-        }
-        taskRowMap[e.task_id] = tr;
-    }
-
-    // Trim to configured size
-    while (tasklogBody.children.length > TASK_LOG_MAX_SIZE) {
-        var removed = tasklogBody.lastChild;
-        if (removed && removed.dataset && removed.dataset.taskId) {
-            delete taskRowMap[removed.dataset.taskId];
-        }
-        tasklogBody.removeChild(removed);
-    }
+function renderTaskLog() {
+    var pg = pageSlice(taskLogPage, taskLogData.length);
+    taskLogPage = pg.page;
+    var pageEntries = taskLogData.slice(pg.start, pg.end);
+    tasklogBody.innerHTML = "";
+    for (var i = 0; i < pageEntries.length; i++) tasklogBody.appendChild(makeTaskLogRow(pageEntries[i]));
     updateTaskLogBadge();
+    renderPager("tasklog-pager", taskLogPage, pg.totalPages, taskLogData.length, function(p) {
+        taskLogPage = p;
+        renderTaskLog();
+    });
+}
+
+function makeCell(text) {
+    var td = document.createElement("td");
+    td.textContent = text == null ? "" : text;
+    return td;
+}
+
+function makeTaskLogRow(e) {
+    var tr = document.createElement("tr");
+    tr.dataset.taskId = e.task_id;
+
+    var tdId = document.createElement("td");
+    var span = document.createElement("span");
+    span.className = "task-id";
+    span.textContent = e.task_id;
+    span.title = e.task_id;
+    span.addEventListener("click", (function(id) {
+        return function() { if (navigator.clipboard) navigator.clipboard.writeText(id); };
+    })(e.task_id));
+    tdId.appendChild(span);
+    tr.appendChild(tdId);
+
+    tr.appendChild(makeCell(e.function));
+    var tdWorker = makeCell(e.worker || "");
+    tdWorker.title = e.full_worker || e.worker || "";
+    tr.appendChild(tdWorker);
+    tr.appendChild(makeCell(formatTime(e.time)));
+    tr.appendChild(makeCell(e.duration));
+    tr.appendChild(makeCell(e.peak_mem));
+    var tdStatus = makeCell(e.status);
+    tdStatus.className = statusClass(e.status);
+    tr.appendChild(tdStatus);
+    tr.appendChild(makeCell(e.capabilities));
+    return tr;
 }
 
 // Badge shows the running total of completed tasks; once it passes the display cap it appends the cap it is
@@ -660,10 +655,10 @@ var STREAM_ROW_HEIGHT = 24;
 var STREAM_PADDING_TOP = 4;
 
 function updateTaskStream(data) {
-    streamBars = data.bars || [];
-    streamRows = data.rows || [];
-    streamFullRows = data.full_rows || streamRows;
-    streamRowManagers = data.row_managers || [];
+    streamBarsFull = data.bars || [];
+    streamRowsFull = data.rows || [];
+    streamFullRowsFull = data.full_rows || streamRowsFull;
+    streamRowManagersFull = data.row_managers || [];
     streamManagerColors = {};
     streamManagerLegendData = data.manager_legend || [];
     for (var ml = 0; ml < streamManagerLegendData.length; ml++) {
@@ -672,11 +667,37 @@ function updateTaskStream(data) {
     streamTicks = data.ticks || [];
     streamWindow = data.window || 300;
     streamLegendData = data.legend || [];
+    applyStreamPage();
 
     if (activeTab === "stream") {
         renderStreamStatic();
         streamNeedsRedraw = true;
     }
+}
+
+// Slice the full stream data into the current page's drawing vars, re-basing each bar's row to page-local so
+// the canvas height stays bounded to one page regardless of worker count.
+function applyStreamPage() {
+    var pg = pageSlice(streamPage, streamRowsFull.length);
+    streamPage = pg.page;
+    streamRows = streamRowsFull.slice(pg.start, pg.end);
+    streamFullRows = streamFullRowsFull.slice(pg.start, pg.end);
+    streamRowManagers = streamRowManagersFull.slice(pg.start, pg.end);
+    streamBars = [];
+    for (var i = 0; i < streamBarsFull.length; i++) {
+        var b = streamBarsFull[i];
+        if (b.r >= pg.start && b.r < pg.end) {
+            var nb = {};
+            for (var k in b) { if (Object.prototype.hasOwnProperty.call(b, k)) nb[k] = b[k]; }
+            nb.r = b.r - pg.start;
+            streamBars.push(nb);
+        }
+    }
+    renderPager("stream-pager", streamPage, pg.totalPages, streamRowsFull.length, function(p) {
+        streamPage = p;
+        applyStreamPage();
+        if (activeTab === "stream") streamNeedsRedraw = true;
+    });
 }
 
 // Rebuild the stream legend + time axis (DOM) from cached data; runs only while the stream tab is visible.
@@ -1125,126 +1146,111 @@ function updateProcessors(processors) {
     if (activeTab === "processors") renderProcessors();
 }
 
+var PROCESSORS_PAGE_SIZE = 20;  // worker detail tables are large, so page them smaller than the flat tables
+
 function renderProcessors() {
-    var processors = lastProcessorsData;
+    var groups = lastProcessorsData || [];
+    // Flatten workers across managers (keeping each worker's group, whose summary aggregates the full fleet).
+    var flat = [];
+    for (var g = 0; g < groups.length; g++) {
+        for (var i = 0; i < groups[g].workers.length; i++) {
+            flat.push({ group: groups[g], wp: groups[g].workers[i] });
+        }
+    }
+
     processorsContainer.innerHTML = "";
-    if (!processors || processors.length === 0) {
+    if (flat.length === 0) {
         processorsContainer.innerHTML = '<div class="card"><p style="color:#64748b">No workers connected</p></div>';
+        renderPager("processors-pager", 0, 1, 0, function() {});
         return;
     }
 
-    for (var g = 0; g < processors.length; g++) {
-        var group = processors[g];
+    var pg = pageSlice(processorsPage, flat.length, PROCESSORS_PAGE_SIZE);
+    processorsPage = pg.page;
+    var pageItems = flat.slice(pg.start, pg.end);
 
-        // Manager group as collapsible details/summary
-        var managerSection = document.createElement("details");
-        managerSection.className = "manager-group card";
-        managerSection.open = !managerCollapsed[group.manager_id];
-
-        var managerSummary = document.createElement("summary");
-        managerSummary.className = "manager-header";
-        managerSummary.innerHTML =
-            '<span class="manager-title">Manager: ' + escapeHTML(group.manager_id) + '</span>' +
-            '<span class="manager-stats">' +
-                '<span class="manager-stat"><b>Workers:</b> ' + group.worker_count + '</span>' +
-                '<span class="manager-stat"><b>Processors:</b> ' + group.active_processors + ' active</span>' +
-                '<span class="manager-stat"><b>Total PSS:</b> ' + group.total_rss + ' MB</span>' +
-                '<span class="manager-stat"><b>Total CPU:</b> ' + group.total_cpu + '%</span>' +
-            '</span>';
-        managerSection.appendChild(managerSummary);
-
-        // track manager toggle state
-        (function(mid, el) {
-            el.addEventListener("toggle", function() {
-                managerCollapsed[mid] = !el.open;
-            });
-        })(group.manager_id, managerSection);
-
-        // Worker details within this manager group
-        var workers = group.workers;
-        if (workers.length === 0) {
-            var emptyMsg = document.createElement("p");
-            emptyMsg.style.color = "#64748b";
-            emptyMsg.style.padding = "8px 16px";
-            emptyMsg.textContent = "No workers currently running for this manager";
-            managerSection.appendChild(emptyMsg);
+    // Render only this page's worker detail, opening a manager section whenever the manager changes.
+    var currentMid = null, section = null;
+    for (var k = 0; k < pageItems.length; k++) {
+        var item = pageItems[k];
+        if (item.group.manager_id !== currentMid) {
+            currentMid = item.group.manager_id;
+            section = buildManagerSection(item.group);
+            processorsContainer.appendChild(section);
         }
-        for (var i = 0; i < workers.length; i++) {
-            var wp = workers[i];
-            var details = document.createElement("details");
-            details.className = "card processor-group";
-            details.open = !processorsCollapsed[wp.name];
-
-            var summary = document.createElement("summary");
-            summary.textContent = "Worker " + wp.name;
-            summary.title = wp.full_name || wp.name;
-            details.appendChild(summary);
-
-            // track toggle state
-            (function(name, el) {
-                el.addEventListener("toggle", function() {
-                    processorsCollapsed[name] = !el.open;
-                });
-            })(wp.name, details);
-
-            var table = document.createElement("table");
-            table.className = "data-table";
-
-            // Header
-            var thead = document.createElement("thead");
-            var headerRow = document.createElement("tr");
-            // memory columns are PSS on Linux, RSS on macOS/Windows (see get_process_memory)
-            var headers = ["PID", "CPU %", "PSS (MB)", "Max PSS (MB)", "Initialized", "Has Task", "Suspended"];
-            for (var h = 0; h < headers.length; h++) {
-                var th = document.createElement("th");
-                th.textContent = headers[h];
-                headerRow.appendChild(th);
-            }
-            thead.appendChild(headerRow);
-            table.appendChild(thead);
-
-            // Body
-            var tbody = document.createElement("tbody");
-            for (var p = 0; p < wp.processors.length; p++) {
-                var proc = wp.processors[p];
-                var tr = document.createElement("tr");
-
-                var tdPid = document.createElement("td");
-                tdPid.textContent = proc.pid;
-                tr.appendChild(tdPid);
-
-                var tdCpu = document.createElement("td");
-                tdCpu.innerHTML = makeGaugeHTML(proc.cpu, 100, "%");
-                tr.appendChild(tdCpu);
-
-                var tdRss = document.createElement("td");
-                tdRss.innerHTML = makeGaugeHTML(proc.rss, proc.rss_max_gauge, "");
-                tr.appendChild(tdRss);
-
-                var tdMaxRss = document.createElement("td");
-                tdMaxRss.innerHTML = makeGaugeHTML(proc.max_rss, proc.rss_max_gauge, "");
-                tr.appendChild(tdMaxRss);
-
-                var tdInit = document.createElement("td");
-                tdInit.innerHTML = boolIndicator(proc.initialized);
-                tr.appendChild(tdInit);
-
-                var tdTask = document.createElement("td");
-                tdTask.innerHTML = boolIndicator(proc.has_task);
-                tr.appendChild(tdTask);
-
-                var tdSusp = document.createElement("td");
-                tdSusp.innerHTML = boolIndicator(proc.suspended);
-                tr.appendChild(tdSusp);
-
-                tbody.appendChild(tr);
-            }
-            table.appendChild(tbody);
-            details.appendChild(table);
-            managerSection.appendChild(details);
-        }
-        processorsContainer.appendChild(managerSection);
+        section.appendChild(buildWorkerProcessorDetail(item.wp));
     }
+    renderPager("processors-pager", processorsPage, pg.totalPages, flat.length, function(p) {
+        processorsPage = p;
+        renderProcessors();
+    });
+}
+
+function buildManagerSection(group) {
+    var managerSection = document.createElement("details");
+    managerSection.className = "manager-group card";
+    managerSection.open = !managerCollapsed[group.manager_id];
+
+    var managerSummary = document.createElement("summary");
+    managerSummary.className = "manager-header";
+    managerSummary.innerHTML =
+        '<span class="manager-title">Manager: ' + escapeHTML(group.manager_id) + '</span>' +
+        '<span class="manager-stats">' +
+            '<span class="manager-stat"><b>Workers:</b> ' + group.worker_count + '</span>' +
+            '<span class="manager-stat"><b>Processors:</b> ' + group.active_processors + ' active</span>' +
+            '<span class="manager-stat"><b>Total PSS:</b> ' + group.total_rss + ' MB</span>' +
+            '<span class="manager-stat"><b>Total CPU:</b> ' + group.total_cpu + '%</span>' +
+        '</span>';
+    managerSection.appendChild(managerSummary);
+    (function(mid, el) {
+        el.addEventListener("toggle", function() { managerCollapsed[mid] = !el.open; });
+    })(group.manager_id, managerSection);
+    return managerSection;
+}
+
+function buildWorkerProcessorDetail(wp) {
+    var details = document.createElement("details");
+    details.className = "card processor-group";
+    details.open = !processorsCollapsed[wp.name];
+
+    var summary = document.createElement("summary");
+    summary.textContent = "Worker " + wp.name;
+    summary.title = wp.full_name || wp.name;
+    details.appendChild(summary);
+    (function(name, el) {
+        el.addEventListener("toggle", function() { processorsCollapsed[name] = !el.open; });
+    })(wp.name, details);
+
+    var table = document.createElement("table");
+    table.className = "data-table";
+    var thead = document.createElement("thead");
+    var headerRow = document.createElement("tr");
+    // memory columns are PSS on Linux, RSS on macOS/Windows (see get_process_memory)
+    var headers = ["PID", "CPU %", "PSS (MB)", "Max PSS (MB)", "Initialized", "Has Task", "Suspended"];
+    for (var h = 0; h < headers.length; h++) {
+        var th = document.createElement("th");
+        th.textContent = headers[h];
+        headerRow.appendChild(th);
+    }
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    var tbody = document.createElement("tbody");
+    for (var p = 0; p < wp.processors.length; p++) {
+        var proc = wp.processors[p];
+        var tr = document.createElement("tr");
+        var tdPid = document.createElement("td"); tdPid.textContent = proc.pid; tr.appendChild(tdPid);
+        var tdCpu = document.createElement("td"); tdCpu.innerHTML = makeGaugeHTML(proc.cpu, 100, "%"); tr.appendChild(tdCpu);
+        var tdRss = document.createElement("td"); tdRss.innerHTML = makeGaugeHTML(proc.rss, proc.rss_max_gauge, ""); tr.appendChild(tdRss);
+        var tdMax = document.createElement("td"); tdMax.innerHTML = makeGaugeHTML(proc.max_rss, proc.rss_max_gauge, ""); tr.appendChild(tdMax);
+        var tdInit = document.createElement("td"); tdInit.innerHTML = boolIndicator(proc.initialized); tr.appendChild(tdInit);
+        var tdTask = document.createElement("td"); tdTask.innerHTML = boolIndicator(proc.has_task); tr.appendChild(tdTask);
+        var tdSusp = document.createElement("td"); tdSusp.innerHTML = boolIndicator(proc.suspended); tr.appendChild(tdSusp);
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    details.appendChild(table);
+    return details;
 }
 
 function boolIndicator(val) {

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -8,7 +8,7 @@ var workerRows = {};       // worker_id -> <tr> element
 var workerSortField = null;  // current sort column field name
 var workerSortAsc = true;    // sort direction
 var lastWorkersData = [];    // latest workers array for re-sorting
-var taskLogCount = 0;
+var taskLogTotal = 0;  // completed tasks seen by the server since it started, uncapped by the display ring
 var TASK_LOG_MAX_SIZE = 100;  // overridden by server's task_log_max_size on initial state
 var taskRowMap = {};  // task_id -> tr element for in-place updates
 var streamBars = [];       // current bar data from server
@@ -192,6 +192,7 @@ function handleMessage(data) {
         handleWorkerEvents(data.worker_events);
     }
     if (data.task_updates) {
+        if (typeof data.task_log_total === "number") taskLogTotal = data.task_log_total;
         handleTaskUpdates(data.task_updates);
     }
     if (data.task_stream) {
@@ -212,9 +213,9 @@ function handleFullState(data) {
     if (typeof data.task_log_max_size === "number" && data.task_log_max_size > 0) {
         TASK_LOG_MAX_SIZE = data.task_log_max_size;
     }
+    taskLogTotal = typeof data.task_log_total === "number" ? data.task_log_total : 0;
     if (data.task_log) {
         tasklogBody.innerHTML = "";
-        taskLogCount = 0;
         taskRowMap = {};
         addTaskLogEntries(data.task_log, true);
     }
@@ -618,7 +619,6 @@ function addTaskLogEntries(entries, append) {
             tasklogBody.appendChild(tr);
         }
         taskRowMap[e.task_id] = tr;
-        taskLogCount++;
     }
 
     // Trim to configured size
@@ -628,9 +628,18 @@ function addTaskLogEntries(entries, append) {
             delete taskRowMap[removed.dataset.taskId];
         }
         tasklogBody.removeChild(removed);
-        taskLogCount--;
     }
-    tasklogCount.textContent = Math.min(taskLogCount, TASK_LOG_MAX_SIZE);
+    updateTaskLogBadge();
+}
+
+// Badge shows the running total of completed tasks; once it passes the display cap it appends the cap it is
+// windowed to, e.g. "501 (showing 500)".
+function updateTaskLogBadge() {
+    if (taskLogTotal > TASK_LOG_MAX_SIZE) {
+        tasklogCount.textContent = taskLogTotal + " (showing " + TASK_LOG_MAX_SIZE + ")";
+    } else {
+        tasklogCount.textContent = taskLogTotal;
+    }
 }
 
 // -- Task Stream (Canvas) --

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -4,29 +4,31 @@
 // -- State --
 var ws = null;
 var reconnectDelay = 500;
-var workerSortField = null;  // current sort column field name
+var workerSortField = null;  // current sort column field name (the server does the sorting)
 var workerSortAsc = true;    // sort direction
-var lastWorkersData = [];    // workers array the browser received (bounded by -wl); sorted + paged client-side
-var workersTotal = 0;        // full fleet size; the workers array a browser receives may be a bounded subset
+var lastWorkersData = [];    // this browser's page of worker rows, already sorted by the server
+var workersTotal = 0;        // full fleet size, of which this browser holds one page
 var taskLogTotal = 0;  // completed tasks seen by the server since it started, uncapped by the display ring
 var TASK_LOG_MAX_SIZE = 100;  // overridden by server's task_log_max_size on initial state
 var taskLogData = [];        // full task-log data, newest first, up to TASK_LOG_MAX_SIZE
 var taskLogById = {};        // task_id -> entry, for in-place status updates
-// Numbered-page virtualization: each view keeps its full (received) data but renders only the current page,
-// so the DOM/canvas stays bounded to one page regardless of fleet or task count.
+// The worker views are paged by the server: it sends one page at a time and reports which page that was
+// and how many exist, so the browser never receives -- or parses -- the whole fleet. The task log is
+// small and bounded server-side, so it stays paged here with PAGE_SIZE.
 var PAGE_SIZE = 50;
 var workersPage = 0;
+var workersPages = 1;
 var taskLogPage = 0;
 var processorsPage = 0;
+var processorsPages = 1;
+var processorsTotal = 0;
 var streamPage = 0;
-var streamBars = [];       // bars for the current page (row index re-based to page-local)
+var streamPages = 1;
+var streamTotal = 0;
+var streamBars = [];       // bars for this page, row index already re-based page-local by the server
 var streamRows = [];       // row labels (truncated) for the current page
 var streamFullRows = [];   // row labels (full worker names) for the current page
 var streamRowManagers = []; // manager color per row, current page
-var streamBarsFull = [];       // full received stream data; sliced into the page vars above for drawing
-var streamRowsFull = [];
-var streamFullRowsFull = [];
-var streamRowManagersFull = [];
 var streamManagerColors = {}; // manager_id -> color
 var memoryPoints = [];     // memory chart points
 var memoryScale = "linear";
@@ -189,6 +191,15 @@ function sendSettings(settings) {
     }
 }
 
+// Tell the server what this browser is looking at (page, sort column). It answers with just that view,
+// so paging and sorting are immediate instead of waiting for the next scheduler update -- and because
+// the view lives on this socket, other browsers are unaffected.
+function sendView(view) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "view", view: view }));
+    }
+}
+
 // -- WebSocket --
 function connect() {
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
@@ -232,7 +243,7 @@ function handleMessage(data) {
         updateScheduler(data.scheduler);
     }
     if (data.workers) {
-        if (typeof data.workers_total === "number") workersTotal = data.workers_total;
+        applyPageInfo(data);
         updateWorkers(data.workers);
     }
     if (data.worker_managers) {
@@ -252,13 +263,28 @@ function handleMessage(data) {
         updateMemoryChart(data.memory_chart);
     }
     if (data.processors) {
+        applyPageInfo(data);
         updateProcessors(data.processors);
     }
+    if (data.settings) {
+        applySettings(data.settings);
+    }
+}
+
+// Page/sort bookkeeping the server owns: it clamps the page it actually served, so mirror that back
+// rather than trusting what this browser last asked for.
+function applyPageInfo(data) {
+    if (typeof data.workers_total === "number") workersTotal = data.workers_total;
+    if (typeof data.workers_page === "number") workersPage = data.workers_page;
+    if (typeof data.workers_pages === "number") workersPages = data.workers_pages;
+    if (typeof data.processors_total === "number") processorsTotal = data.processors_total;
+    if (typeof data.processors_page === "number") processorsPage = data.processors_page;
+    if (typeof data.processors_pages === "number") processorsPages = data.processors_pages;
 }
 
 function handleFullState(data) {
     if (data.scheduler) updateScheduler(data.scheduler);
-    if (typeof data.workers_total === "number") workersTotal = data.workers_total;
+    applyPageInfo(data);
     if (data.workers) updateWorkers(data.workers);
     if (data.worker_managers) updateWorkerManagers(data.worker_managers);
     if (typeof data.task_log_max_size === "number" && data.task_log_max_size > 0) {
@@ -382,10 +408,10 @@ function renderManagers() {
 }
 
 // -- Live Tab: Workers --
+// Column order of the workers table; the header click sends the field name to the server, which knows
+// which of them sort numerically.
 var WORKER_FIELDS = ["name", "manager_id", "agt_cpu", "agt_rss", "proc_cpu", "proc_rss", "mem_used_pct",
                      "free", "sent", "queued", "suspended", "lag", "itl", "last_seen", "capabilities"];
-var WORKER_NUMERIC_FIELDS = {"agt_cpu":1, "agt_rss":1, "proc_cpu":1, "proc_rss":1, "mem_used_pct":1,
-                             "free":1, "sent":1, "queued":1, "suspended":1, "itl":1};
 
 function updateWorkers(workers) {
     lastWorkersData = workers;
@@ -393,13 +419,9 @@ function updateWorkers(workers) {
 }
 
 function renderWorkers() {
-    var data = lastWorkersData.slice();
-    if (workerSortField) sortWorkerData(data);
-    var pg = pageSlice(workersPage, data.length);
-    workersPage = pg.page;
-    var pageRows = data.slice(pg.start, pg.end);
+    // lastWorkersData is already this browser's page, sorted by the server.
+    var pageRows = lastWorkersData;
 
-    // Rebuild just this page's rows (<= PAGE_SIZE) each update; the DOM never holds the whole fleet.
     workersBody.innerHTML = "";
     for (var i = 0; i < pageRows.length; i++) {
         var row = createWorkerRow(pageRows[i]);
@@ -407,31 +429,19 @@ function renderWorkers() {
         workersBody.appendChild(row);
     }
     updateWorkersCountBadge();
-    renderPager("workers-pager", workersPage, pg.totalPages, data.length, function(p) {
+    renderPager("workers-pager", workersPage, workersPages, workersTotal, function(p) {
         workersPage = p;
-        renderWorkers();
+        sendView({ workers_page: p });
     });
 }
 
-// The backend sends each browser only a bounded set of workers at scale; show "shown of total" (total is the
-// full fleet size) so a capped view is explicit rather than looking like the whole fleet.
+// The badge counts the whole fleet, of which this browser holds one page.
 function updateWorkersCountBadge() {
-    var shown = lastWorkersData.length;
-    workersCount.textContent = workersTotal > shown ? (shown + " of " + workersTotal) : shown;
+    workersCount.textContent = workersTotal;
 }
 
-// Sort the worker data array in place by the active column; renderWorkers then paints the current page.
-function sortWorkerData(data) {
-    var field = workerSortField, asc = workerSortAsc, isNumeric = WORKER_NUMERIC_FIELDS[field];
-    data.sort(function(a, b) {
-        var va = a[field], vb = b[field];
-        if (va == null) va = "";
-        if (vb == null) vb = "";
-        var cmp = isNumeric ? (Number(va) || 0) - (Number(vb) || 0) : String(va).localeCompare(String(vb));
-        return asc ? cmp : -cmp;
-    });
-}
-
+// Sorting runs on the server (it holds the whole fleet; this browser only has a page), so a header click
+// records the indicator and asks for page 0 of the new order.
 function setupWorkerSort() {
     var thead = workersBody.parentElement.querySelector("thead tr");
     if (!thead) return;
@@ -454,7 +464,7 @@ function setupWorkerSort() {
                 }
                 th.classList.add(workerSortAsc ? "sort-asc" : "sort-desc");
                 workersPage = 0;  // jump to the top of the new sort order
-                renderWorkers();
+                sendView({ workers_sort: field, workers_sort_ascending: workerSortAsc, workers_page: 0 });
             });
         })(ths[i], WORKER_FIELDS[i]);
     }
@@ -655,10 +665,14 @@ var STREAM_ROW_HEIGHT = 24;
 var STREAM_PADDING_TOP = 4;
 
 function updateTaskStream(data) {
-    streamBarsFull = data.bars || [];
-    streamRowsFull = data.rows || [];
-    streamFullRowsFull = data.full_rows || streamRowsFull;
-    streamRowManagersFull = data.row_managers || [];
+    // Already one page: the server slices the rows and re-bases each bar's row index to the page.
+    streamBars = data.bars || [];
+    streamRows = data.rows || [];
+    streamFullRows = data.full_rows || streamRows;
+    streamRowManagers = data.row_managers || [];
+    if (typeof data.page === "number") streamPage = data.page;
+    if (typeof data.pages === "number") streamPages = data.pages;
+    if (typeof data.total_rows === "number") streamTotal = data.total_rows;
     streamManagerColors = {};
     streamManagerLegendData = data.manager_legend || [];
     for (var ml = 0; ml < streamManagerLegendData.length; ml++) {
@@ -667,37 +681,15 @@ function updateTaskStream(data) {
     streamTicks = data.ticks || [];
     streamWindow = data.window || 300;
     streamLegendData = data.legend || [];
-    applyStreamPage();
+    renderPager("stream-pager", streamPage, streamPages, streamTotal, function(p) {
+        streamPage = p;
+        sendView({ stream_page: p });
+    });
 
     if (activeTab === "stream") {
         renderStreamStatic();
         streamNeedsRedraw = true;
     }
-}
-
-// Slice the full stream data into the current page's drawing vars, re-basing each bar's row to page-local so
-// the canvas height stays bounded to one page regardless of worker count.
-function applyStreamPage() {
-    var pg = pageSlice(streamPage, streamRowsFull.length);
-    streamPage = pg.page;
-    streamRows = streamRowsFull.slice(pg.start, pg.end);
-    streamFullRows = streamFullRowsFull.slice(pg.start, pg.end);
-    streamRowManagers = streamRowManagersFull.slice(pg.start, pg.end);
-    streamBars = [];
-    for (var i = 0; i < streamBarsFull.length; i++) {
-        var b = streamBarsFull[i];
-        if (b.r >= pg.start && b.r < pg.end) {
-            var nb = {};
-            for (var k in b) { if (Object.prototype.hasOwnProperty.call(b, k)) nb[k] = b[k]; }
-            nb.r = b.r - pg.start;
-            streamBars.push(nb);
-        }
-    }
-    renderPager("stream-pager", streamPage, pg.totalPages, streamRowsFull.length, function(p) {
-        streamPage = p;
-        applyStreamPage();
-        if (activeTab === "stream") streamNeedsRedraw = true;
-    });
 }
 
 // Rebuild the stream legend + time axis (DOM) from cached data; runs only while the stream tab is visible.
@@ -1146,43 +1138,29 @@ function updateProcessors(processors) {
     if (activeTab === "processors") renderProcessors();
 }
 
-var PROCESSORS_PAGE_SIZE = 20;  // worker detail tables are large, so page them smaller than the flat tables
-
 function renderProcessors() {
+    // Each group carries fleet-wide summary numbers, but only this page's worker detail.
     var groups = lastProcessorsData || [];
-    // Flatten workers across managers (keeping each worker's group, whose summary aggregates the full fleet).
-    var flat = [];
-    for (var g = 0; g < groups.length; g++) {
-        for (var i = 0; i < groups[g].workers.length; i++) {
-            flat.push({ group: groups[g], wp: groups[g].workers[i] });
-        }
-    }
 
     processorsContainer.innerHTML = "";
-    if (flat.length === 0) {
+    if (processorsTotal === 0) {
         processorsContainer.innerHTML = '<div class="card"><p style="color:#64748b">No workers connected</p></div>';
         renderPager("processors-pager", 0, 1, 0, function() {});
         return;
     }
 
-    var pg = pageSlice(processorsPage, flat.length, PROCESSORS_PAGE_SIZE);
-    processorsPage = pg.page;
-    var pageItems = flat.slice(pg.start, pg.end);
-
-    // Render only this page's worker detail, opening a manager section whenever the manager changes.
-    var currentMid = null, section = null;
-    for (var k = 0; k < pageItems.length; k++) {
-        var item = pageItems[k];
-        if (item.group.manager_id !== currentMid) {
-            currentMid = item.group.manager_id;
-            section = buildManagerSection(item.group);
-            processorsContainer.appendChild(section);
+    for (var g = 0; g < groups.length; g++) {
+        var group = groups[g];
+        if (!group.workers || group.workers.length === 0) continue;
+        var section = buildManagerSection(group);
+        processorsContainer.appendChild(section);
+        for (var i = 0; i < group.workers.length; i++) {
+            section.appendChild(buildWorkerProcessorDetail(group.workers[i]));
         }
-        section.appendChild(buildWorkerProcessorDetail(item.wp));
     }
-    renderPager("processors-pager", processorsPage, pg.totalPages, flat.length, function(p) {
+    renderPager("processors-pager", processorsPage, processorsPages, processorsTotal, function(p) {
         processorsPage = p;
-        renderProcessors();
+        sendView({ processors_page: p });
     });
 }
 

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -105,6 +105,13 @@ function renderActiveTab() {
     }
 }
 
+// Every paged view carries the same controls above and below its content, so paging a long table does
+// not mean scrolling to the bottom for every click.
+function renderPagers(elId, page, totalPages, total, onPage) {
+    renderPager(elId + "-top", page, totalPages, total, onPage);
+    renderPager(elId, page, totalPages, total, onPage);
+}
+
 // Numbered-page controls: renders "Prev  Page X / Y (N)  Next" into elId; onPage(newPage) re-renders the view.
 // Renders nothing (hidden via CSS) when there is only one page.
 function renderPager(elId, page, totalPages, total, onPage) {
@@ -424,7 +431,7 @@ function renderWorkers() {
         workersBody.appendChild(row);
     }
     updateWorkersCountBadge();
-    renderPager("workers-pager", workersPage, workersPages, workersTotal, function(p) {
+    renderPagers("workers-pager", workersPage, workersPages, workersTotal, function(p) {
         workersPage = p;
         sendView({ workers_page: p });
     });
@@ -602,7 +609,7 @@ function renderTaskLog() {
     tasklogBody.innerHTML = "";
     for (var i = 0; i < pageEntries.length; i++) tasklogBody.appendChild(makeTaskLogRow(pageEntries[i]));
     updateTaskLogBadge();
-    renderPager("tasklog-pager", taskLogPage, pg.totalPages, taskLogData.length, function(p) {
+    renderPagers("tasklog-pager", taskLogPage, pg.totalPages, taskLogData.length, function(p) {
         taskLogPage = p;
         renderTaskLog();
     });
@@ -675,7 +682,7 @@ function updateTaskStream(data) {
     streamTicks = data.ticks || [];
     streamWindow = data.window || 300;
     streamLegendData = data.legend || [];
-    renderPager("stream-pager", streamPage, streamPages, streamTotal, function(p) {
+    renderPagers("stream-pager", streamPage, streamPages, streamTotal, function(p) {
         streamPage = p;
         sendView({ stream_page: p });
     });
@@ -1139,7 +1146,7 @@ function renderProcessors() {
     processorsContainer.innerHTML = "";
     if (processorsTotal === 0) {
         processorsContainer.innerHTML = '<div class="card"><p style="color:#64748b">No workers connected</p></div>';
-        renderPager("processors-pager", 0, 1, 0, function() {});
+        renderPagers("processors-pager", 0, 1, 0, function() {});
         return;
     }
 
@@ -1152,7 +1159,7 @@ function renderProcessors() {
             section.appendChild(buildWorkerProcessorDetail(group.workers[i]));
         }
     }
-    renderPager("processors-pager", processorsPage, processorsPages, processorsTotal, function(p) {
+    renderPagers("processors-pager", processorsPage, processorsPages, processorsTotal, function(p) {
         processorsPage = p;
         sendView({ processors_page: p });
     });

--- a/src/scaler/ui/static/app.js
+++ b/src/scaler/ui/static/app.js
@@ -12,9 +12,8 @@ var taskLogTotal = 0;  // completed tasks seen by the server since it started, u
 var TASK_LOG_MAX_SIZE = 100;  // overridden by server's task_log_max_size on initial state
 var taskLogData = [];        // full task-log data, newest first, up to TASK_LOG_MAX_SIZE
 var taskLogById = {};        // task_id -> entry, for in-place status updates
-// The worker views are paged by the server: it sends one page at a time and reports which page that was
-// and how many exist, so the browser never receives -- or parses -- the whole fleet. The task log is
-// small and bounded server-side, so it stays paged here with PAGE_SIZE.
+// The worker views are paged by the server, so the browser never receives the whole fleet. The task
+// log is small and bounded server-side, so it stays paged here with PAGE_SIZE.
 var PAGE_SIZE = 50;
 var workersPage = 0;
 var workersPages = 1;
@@ -191,9 +190,7 @@ function sendSettings(settings) {
     }
 }
 
-// Tell the server what this browser is looking at (page, sort column). It answers with just that view,
-// so paging and sorting are immediate instead of waiting for the next scheduler update -- and because
-// the view lives on this socket, other browsers are unaffected.
+// Tell the server what this browser is looking at; it answers immediately with just that view.
 function sendView(view) {
     if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "view", view: view }));
@@ -271,8 +268,7 @@ function handleMessage(data) {
     }
 }
 
-// Page/sort bookkeeping the server owns: it clamps the page it actually served, so mirror that back
-// rather than trusting what this browser last asked for.
+// The server clamps the page it actually served, so mirror that back rather than what we asked for.
 function applyPageInfo(data) {
     if (typeof data.workers_total === "number") workersTotal = data.workers_total;
     if (typeof data.workers_page === "number") workersPage = data.workers_page;
@@ -408,8 +404,7 @@ function renderManagers() {
 }
 
 // -- Live Tab: Workers --
-// Column order of the workers table; the header click sends the field name to the server, which knows
-// which of them sort numerically.
+// Column order of the workers table; a header click sends the field name to the server.
 var WORKER_FIELDS = ["name", "manager_id", "agt_cpu", "agt_rss", "proc_cpu", "proc_rss", "mem_used_pct",
                      "free", "sent", "queued", "suspended", "lag", "itl", "last_seen", "capabilities"];
 
@@ -440,8 +435,7 @@ function updateWorkersCountBadge() {
     workersCount.textContent = workersTotal;
 }
 
-// Sorting runs on the server (it holds the whole fleet; this browser only has a page), so a header click
-// records the indicator and asks for page 0 of the new order.
+// Sorting runs on the server, so a click just sets the indicator and asks for page 0 of the new order.
 function setupWorkerSort() {
     var thead = workersBody.parentElement.querySelector("thead tr");
     if (!thead) return;

--- a/src/scaler/ui/static/index.html
+++ b/src/scaler/ui/static/index.html
@@ -74,7 +74,7 @@
         </div>
 
         <div class="card">
-            <h3>Workers</h3>
+            <h3>Workers <span class="badge" id="workers-count">0</span></h3>
             <div class="table-wrap">
                 <!-- Agt/Proc memory is PSS (proportional set size) on Linux, RSS on macOS/Windows; see get_process_memory. -->
                 <table class="data-table" id="workers-table">

--- a/src/scaler/ui/static/index.html
+++ b/src/scaler/ui/static/index.html
@@ -100,6 +100,7 @@
                     <tbody id="workers-body"></tbody>
                 </table>
             </div>
+            <div class="pager" id="workers-pager"></div>
         </div>
     </div>
 
@@ -124,6 +125,7 @@
                     <tbody id="tasklog-body"></tbody>
                 </table>
             </div>
+            <div class="pager" id="tasklog-pager"></div>
         </div>
     </div>
 
@@ -139,6 +141,7 @@
                 <canvas id="stream-canvas"></canvas>
             </div>
             <div class="stream-axis" id="stream-axis"></div>
+            <div class="pager" id="stream-pager"></div>
         </div>
         <div class="card" id="memory-card">
             <h3>Memory Usage</h3>
@@ -151,6 +154,7 @@
     <!-- Tab: Worker Processors -->
     <div class="tab-panel" id="panel-processors">
         <div id="processors-container"></div>
+        <div class="pager" id="processors-pager"></div>
     </div>
 
     <!-- Tab: Settings -->

--- a/src/scaler/ui/static/index.html
+++ b/src/scaler/ui/static/index.html
@@ -75,6 +75,7 @@
 
         <div class="card">
             <h3>Workers <span class="badge" id="workers-count">0</span></h3>
+            <div class="pager pager-top" id="workers-pager-top"></div>
             <div class="table-wrap">
                 <!-- Agt/Proc memory is PSS (proportional set size) on Linux, RSS on macOS/Windows; see get_process_memory. -->
                 <table class="data-table" id="workers-table">
@@ -108,6 +109,7 @@
     <div class="tab-panel" id="panel-tasklog">
         <div class="card">
             <h3>Task Log <span class="badge" id="tasklog-count">0</span></h3>
+            <div class="pager pager-top" id="tasklog-pager-top"></div>
             <div class="table-wrap">
                 <table class="data-table" id="tasklog-table">
                     <thead>
@@ -137,6 +139,7 @@
                 <button class="fit-page-btn" id="fit-page-btn" title="Toggle fit-to-page layout">Fit Page</button>
             </div>
             <div class="legend" id="stream-legend"></div>
+            <div class="pager pager-top" id="stream-pager-top"></div>
             <div class="stream-container" id="stream-container">
                 <canvas id="stream-canvas"></canvas>
             </div>
@@ -153,6 +156,7 @@
 
     <!-- Tab: Worker Processors -->
     <div class="tab-panel" id="panel-processors">
+        <div class="pager pager-top" id="processors-pager-top"></div>
         <div id="processors-container"></div>
         <div class="pager" id="processors-pager"></div>
     </div>

--- a/src/scaler/ui/static/style.css
+++ b/src/scaler/ui/static/style.css
@@ -630,3 +630,38 @@ body.fit-page #memory-card .memory-container {
 ::-webkit-scrollbar-thumb:hover {
     background: #94a3b8;
 }
+
+/* -- Pager (numbered pages for large views) -- */
+.pager {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 8px 4px 0;
+}
+.pager:empty {
+    display: none;
+}
+.pager-btn {
+    font-family: var(--font);
+    font-size: 12px;
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-card);
+    color: var(--text);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.pager-btn:hover:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+.pager-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+.pager-info {
+    font-size: 12px;
+    color: var(--text-muted);
+}

--- a/src/scaler/ui/static/style.css
+++ b/src/scaler/ui/static/style.css
@@ -642,6 +642,10 @@ body.fit-page #memory-card .memory-container {
 .pager:empty {
     display: none;
 }
+/* the copy above the content pads below itself instead of above, so it hugs the heading */
+.pager-top {
+    padding: 0 4px 8px;
+}
 .pager-btn {
     font-family: var(--font);
     font-size: 12px;

--- a/tests/ui/test_client_view.py
+++ b/tests/ui/test_client_view.py
@@ -1,0 +1,157 @@
+"""Per-browser view state: paging, sorting and settings are served per socket.
+
+The web GUI sends each browser one page of workers rather than the whole fleet, so the page index,
+the sort column and the chart settings all live on the connection instead of in shared server state.
+"""
+
+import unittest
+
+from scaler.config.types.address import AddressConfig
+from scaler.ui.app import (
+    PROCESSORS_PAGE_SIZE,
+    WORKERS_PAGE_SIZE,
+    ClientView,
+    WebGUIConfig,
+    WebUIApp,
+    _RenderCache,
+    paginate,
+)
+
+
+def make_app(worker_count: int) -> WebUIApp:
+    app = WebUIApp(WebGUIConfig(monitor_address=AddressConfig.from_string("tcp://127.0.0.1:6380")))
+    app._workers_data = {
+        f"worker-{index}": {
+            "name": f"worker-{index}",
+            "manager_id": "pod-1",
+            "sent": index,
+            "lag": f"{worker_count - index}us",
+            "lag_us": worker_count - index,
+            "last_s": index,
+            "last_seen": f"{index}s",
+        }
+        for index in range(worker_count)
+    }
+    app._total_workers = worker_count
+    return app
+
+
+class TestPaginate(unittest.TestCase):
+    def test_pages_are_clamped_to_what_exists(self) -> None:
+        items = list(range(120))
+        rows, page, total_pages = paginate(items, page=99, size=50)
+        self.assertEqual((page, total_pages), (2, 3))
+        self.assertEqual(rows, list(range(100, 120)))
+
+    def test_negative_page_clamps_to_first(self) -> None:
+        rows, page, total_pages = paginate(list(range(10)), page=-5, size=50)
+        self.assertEqual((page, total_pages), (0, 1))
+        self.assertEqual(rows, list(range(10)))
+
+    def test_empty_still_reports_one_page(self) -> None:
+        rows, page, total_pages = paginate([], page=0, size=50)
+        self.assertEqual((rows, page, total_pages), ([], 0, 1))
+
+
+class TestClientView(unittest.TestCase):
+    def test_unknown_sort_column_is_ignored(self) -> None:
+        view = ClientView()
+        view.apply_view({"workers_sort": "not_a_column"})
+        self.assertIsNone(view.workers_sort)
+
+    def test_known_sort_column_and_direction_are_kept(self) -> None:
+        view = ClientView()
+        view.apply_view({"workers_sort": "sent", "workers_sort_ascending": False})
+        self.assertEqual(view.workers_sort, "sent")
+        self.assertFalse(view.workers_sort_ascending)
+
+    def test_negative_page_is_rejected(self) -> None:
+        view = ClientView()
+        view.apply_view({"workers_page": -3})
+        self.assertEqual(view.workers_page, 0)
+
+    def test_invalid_settings_are_ignored(self) -> None:
+        view = ClientView()
+        view.apply_settings({"stream_window": 7, "memory_scale": "sideways"})
+        self.assertEqual(view.settings(), {"stream_window": 5, "memory_scale": "linear"})
+
+    def test_valid_settings_are_applied(self) -> None:
+        view = ClientView()
+        view.apply_settings({"stream_window": 30, "memory_scale": "log"})
+        self.assertEqual(view.settings(), {"stream_window": 30, "memory_scale": "log"})
+
+
+class TestWorkersSection(unittest.TestCase):
+    def test_browser_receives_one_page_but_the_whole_fleet_count(self) -> None:
+        app = make_app(WORKERS_PAGE_SIZE * 2 + 3)
+        section = app._workers_section(ClientView(), _RenderCache())
+
+        self.assertEqual(len(section["workers"]), WORKERS_PAGE_SIZE)
+        self.assertEqual(section["workers_total"], WORKERS_PAGE_SIZE * 2 + 3)
+        self.assertEqual(section["workers_pages"], 3)
+        self.assertEqual(section["workers_page"], 0)
+
+    def test_out_of_range_page_is_clamped_and_reported_back(self) -> None:
+        app = make_app(60)
+        view = ClientView(workers_page=99)
+        section = app._workers_section(view, _RenderCache())
+
+        self.assertEqual(section["workers_page"], 1)
+        self.assertEqual(view.workers_page, 1)  # the clamp sticks, so the next tick agrees
+        self.assertEqual(len(section["workers"]), 10)
+
+    def test_sorting_runs_over_the_whole_fleet_not_the_page(self) -> None:
+        app = make_app(120)
+        view = ClientView(workers_sort="sent", workers_sort_ascending=False)
+        section = app._workers_section(view, _RenderCache())
+
+        # highest "sent" in the fleet leads, even though it is not in the unsorted first page
+        self.assertEqual([worker["sent"] for worker in section["workers"]][:3], [119, 118, 117])
+
+    def test_preformatted_column_sorts_by_its_raw_value(self) -> None:
+        app = make_app(12)
+        view = ClientView(workers_sort="lag", workers_sort_ascending=True)
+        section = app._workers_section(view, _RenderCache())
+
+        # lag renders as "1us".."12us"; sorting the display strings would put "10us" before "2us"
+        self.assertEqual([worker["lag_us"] for worker in section["workers"]][:3], [1, 2, 3])
+
+    def test_two_browsers_get_their_own_page_and_order(self) -> None:
+        app = make_app(120)
+        cache = _RenderCache()
+        first = app._workers_section(ClientView(workers_page=1), cache)
+        second = app._workers_section(ClientView(workers_sort="sent", workers_sort_ascending=False), cache)
+
+        self.assertEqual(first["workers_page"], 1)
+        self.assertEqual(second["workers_page"], 0)
+        self.assertNotEqual(first["workers"][0]["name"], second["workers"][0]["name"])
+
+
+class TestProcessorsSection(unittest.TestCase):
+    def test_detail_is_paged_while_summaries_cover_the_fleet(self) -> None:
+        app = make_app(0)
+        worker_count = PROCESSORS_PAGE_SIZE * 2
+        app._worker_processors = {
+            f"worker-{index}": {
+                "name": f"worker-{index}",
+                "full_name": f"worker-{index}",
+                "manager_id": "pod-1",
+                "rss_free": 0,
+                "processors": [{"rss": 10, "cpu": 1.0, "has_task": True}],
+            }
+            for index in range(worker_count)
+        }
+        app._worker_managers_data = {"pod-1": {"manager_id": "pod-1"}}
+
+        section = app._processors_section(ClientView(), _RenderCache())
+        group = section["processors"][0]
+
+        self.assertEqual(len(group["workers"]), PROCESSORS_PAGE_SIZE)  # one page of detail
+        self.assertEqual(group["worker_count"], worker_count)  # summary still covers every worker
+        self.assertEqual(group["total_processors"], worker_count)
+        self.assertEqual(section["processors_total"], worker_count)
+        self.assertEqual(section["processors_pages"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Sorting and paging move to the backend. A browser is sent one page (50 workers) whatever the fleet
  size, and can still reach every worker by paging; sorting spans the whole fleet, not the subset the
  browser happened to hold.
- Each socket owns its view — page, sort column, stream window, memory scale. Previously the stream
  window and memory scale were global server state, so one viewer's click moved every other viewer.
- Whole-fleet work (sort, processor grouping, stream render) is memoized per tick, so N browsers on
  the same sort column cost one sort, not N.
- Pager controls now appear above each paged view as well as below, so paging a 50-row table does not
  mean scrolling to the bottom for every click.
- Broadcast interval 0.1s -> 0.5s: measured 194 KB/s -> 47 KB/s per browser, ~93% of which is the task
  stream. Nothing visible is lost — one tick is about a pixel over the stream's 5 minute window.
- New options: `scaler_gui --broadcast-interval-seconds/-bi`, `--task-log-max-size/-tl`,
  `--status-report-interval-seconds/-sri`, and `-sri` on the scheduler (default unchanged at 1s).
- Fixes found on the way: the "N of M" worker count read 0 when no worker manager is registered
  (fixed-mode fleets); `lag` and `last seen` sorted their formatted display strings, so "10us" ordered
  before "2us"; per-manager worker counts read stale capnp list references and reported 0 for every
  manager past the first.