### PR TITLE
fix: log why a processor exits instead of surfacing it as a zombie

### DIFF
--- a/src/scaler/utility/exitcode.py
+++ b/src/scaler/utility/exitcode.py
@@ -1,0 +1,16 @@
+import signal
+from typing import Optional
+
+
+def describe_exitcode(exitcode: Optional[int]) -> str:
+    """Render a process exit code, naming the signal for signal-terminated processes.
+
+    multiprocessing reports a process killed by signal N as exit code -N, so an OOM kill (SIGKILL) shows
+    as -9. Turn that into e.g. "-9 (SIGKILL)" so the cause is legible in logs.
+    """
+    if exitcode is not None and exitcode < 0:
+        try:
+            return f"{exitcode} ({signal.Signals(-exitcode).name})"
+        except ValueError:
+            pass
+    return str(exitcode)

--- a/src/scaler/worker/agent/processor/processor.py
+++ b/src/scaler/worker/agent/processor/processor.py
@@ -263,8 +263,10 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
 
         if self._interrupted:
             # __interrupt destroyed the connectors because the agent asked us to stop, so anything raised out
-            # of an in-flight call is expected teardown, not a fault worth an error and a traceback
-            logger.debug(f"Processor[{self.pid}]: {reason}{task_context}, stopped on agent request")
+            # of an in-flight call is expected teardown, not a fault worth an error and a traceback. Still name
+            # the exception, so a genuine fault that races with the teardown is not invisible at every level.
+            exception_context = f" ({exception!r})" if exception is not None else ""
+            logger.debug(f"Processor[{self.pid}]: stopped on agent request; {reason}{exception_context}{task_context}")
         elif exception is not None:
             logger.error(f"Processor[{self.pid}]: {reason}{task_context}, shutting down", exc_info=exception)
         elif task is not None:

--- a/src/scaler/worker/agent/processor/processor.py
+++ b/src/scaler/worker/agent/processor/processor.py
@@ -211,19 +211,27 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
                 self.__on_connector_receive(message)
 
         except ymq.SocketStopRequestedError:
-            pass
+            self.__log_exit("agent connector stop requested")
 
-        except ObjectStorageException:
-            pass
+        except ObjectStorageException as e:
+            # Never swallow this silently: a storage error mid-task orphans the task (no result is ever
+            # sent) and the process exits 0, which the agent can only observe later as a zombie.
+            self.__log_exit("object storage error", exception=e)
 
         except (KeyboardInterrupt, InterruptedError):
-            pass
+            self.__log_exit("interrupted")
+
+        except SystemExit as e:
+            # SystemExit is a BaseException, so none of the handlers above catch it; log it (with the
+            # originating traceback) rather than let the interpreter exit silently with the exit code.
+            self.__log_exit("received SystemExit", exception=e)
 
         except Exception as e:
             if self.__is_closed_zmq_socket_exception(e):
+                self.__log_exit("agent connector socket closed")
                 return
 
-            logger.exception(f"Processor[{self.pid}]: failed with unhandled exception:\n{e}")
+            self.__log_exit("unhandled exception", exception=e)
 
         finally:
             # Wake the suspend listener (if running on Windows) and let it exit before the connectors go away,
@@ -240,6 +248,18 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
 
             self._object_cache.join()
             self._connector_storage.destroy()
+
+    def __log_exit(self, reason: str, exception: Optional[BaseException] = None) -> None:
+        """Logs why the processor's main loop is exiting, escalating severity if a task was in flight."""
+        task = self._current_task
+        task_context = f" while task_id={task.taskId.hex()} was in flight" if task is not None else ""
+
+        if exception is not None:
+            logger.error(f"Processor[{self.pid}]: {reason}{task_context}, shutting down", exc_info=exception)
+        elif task is not None:
+            logger.warning(f"Processor[{self.pid}]: {reason}{task_context}; no task result will be sent, shutting down")
+        else:
+            logger.debug(f"Processor[{self.pid}]: {reason}, shutting down")
 
     def __on_connector_receive(self, message: BaseMessage):
         if isinstance(message, ObjectInstruction):

--- a/src/scaler/worker/agent/processor/processor.py
+++ b/src/scaler/worker/agent/processor/processor.py
@@ -92,6 +92,9 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
 
         self._current_task: Optional[Task] = None
 
+        # set by __interrupt so __log_exit can tell an agent-requested teardown apart from a real fault
+        self._interrupted = False
+
     def run(self) -> None:
         self.__initialize()
         self.__run_forever()
@@ -168,6 +171,7 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
             self.__register_signal(SUSPEND_SIGNAL, self.__suspend)
 
     def __interrupt(self, *args):
+        self._interrupted = True
         self._connector_agent.destroy()  # interrupts any blocking socket.
         self._connector_storage.destroy()
 
@@ -223,8 +227,9 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
 
         except SystemExit as e:
             # SystemExit is a BaseException, so none of the handlers above catch it; log it (with the
-            # originating traceback) rather than let the interpreter exit silently with the exit code.
+            # originating traceback), then re-raise so multiprocessing still reports the requested exit code.
             self.__log_exit("received SystemExit", exception=e)
+            raise
 
         except Exception as e:
             if self.__is_closed_zmq_socket_exception(e):
@@ -252,12 +257,18 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
     def __log_exit(self, reason: str, exception: Optional[BaseException] = None) -> None:
         """Logs why the processor's main loop is exiting, escalating severity if a task was in flight."""
         task = self._current_task
-        task_context = f" while task_id={task.taskId.hex()} was in flight" if task is not None else ""
+        task_context = (
+            f" while task_id={task.taskId.hex()} was in flight; no task result will be sent" if task is not None else ""
+        )
 
-        if exception is not None:
+        if self._interrupted:
+            # __interrupt destroyed the connectors because the agent asked us to stop, so anything raised out
+            # of an in-flight call is expected teardown, not a fault worth an error and a traceback
+            logger.debug(f"Processor[{self.pid}]: {reason}{task_context}, stopped on agent request")
+        elif exception is not None:
             logger.error(f"Processor[{self.pid}]: {reason}{task_context}, shutting down", exc_info=exception)
         elif task is not None:
-            logger.warning(f"Processor[{self.pid}]: {reason}{task_context}; no task result will be sent, shutting down")
+            logger.warning(f"Processor[{self.pid}]: {reason}{task_context}, shutting down")
         else:
             logger.debug(f"Processor[{self.pid}]: {reason}, shutting down")
 
@@ -339,8 +350,6 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
         self.__send_result(task.source, task.taskId, task_result_type, result_bytes)
 
     def __send_result(self, source: ClientID, task_id: TaskID, task_result_type: TaskResultType, result_bytes: bytes):
-        self._current_task = None
-
         result_object_id = ObjectID.generate_object_id(source)
 
         self._connector_storage.set_object(result_object_id, result_bytes)
@@ -358,6 +367,10 @@ class Processor(multiprocessing.get_context("spawn").Process):  # type: ignore
         self._connector_agent.send(
             TaskResult(taskId=task_id, resultType=task_result_type, metadata=b"", results=[bytes(result_object_id)])
         )
+
+        # only once the result is fully handed off is the task no longer in flight, so a failure above still
+        # reports which task got orphaned
+        self._current_task = None
 
     @staticmethod
     def __set_current_processor(context: Optional["Processor"]) -> Token:

--- a/src/scaler/worker/agent/processor_holder.py
+++ b/src/scaler/worker/agent/processor_holder.py
@@ -74,6 +74,13 @@ class ProcessorHolder:
     def process(self) -> psutil.Process:
         return self._process
 
+    def exitcode(self) -> Optional[int]:
+        """The processor's exit code, once it has exited. Reaps it if it terminated but was not yet joined,
+        so a processor that died on its own (e.g. OOM -> SIGKILL) reports how it died, not a signal we sent."""
+        if self._processor.exitcode is None:
+            self._processor.join(timeout=0.1)
+        return self._processor.exitcode
+
     def processor_id(self) -> ProcessorID:
         assert self._processor_id is not None
         return self._processor_id

--- a/src/scaler/worker/agent/processor_holder.py
+++ b/src/scaler/worker/agent/processor_holder.py
@@ -75,8 +75,8 @@ class ProcessorHolder:
         return self._process
 
     def exitcode(self) -> Optional[int]:
-        """The processor's exit code, once it has exited. Reaps it if it terminated but was not yet joined,
-        so a processor that died on its own (e.g. OOM -> SIGKILL) reports how it died, not a signal we sent."""
+        """The processor's exit code, or None if it has not exited yet: `Process.exitcode` reaps on read, so a
+        processor that died on its own reports how it died even though `kill()` never joined it."""
         if self._processor.exitcode is None:
             self._processor.join(timeout=0.1)
         return self._processor.exitcode

--- a/src/scaler/worker/agent/processor_manager.py
+++ b/src/scaler/worker/agent/processor_manager.py
@@ -17,6 +17,7 @@ from scaler.protocol.capnp import (
     TaskResultType,
 )
 from scaler.utility.exceptions import ProcessorDiedError
+from scaler.utility.exitcode import describe_exitcode
 from scaler.utility.identifiers import ObjectID, ProcessorID, TaskID, WorkerID
 from scaler.utility.metadata.profile_result import ProfileResult
 from scaler.utility.serialization import serialize_failure
@@ -168,12 +169,18 @@ class VanillaProcessorManager(ProcessorManager):
         else:
             self.__kill_processor(reason, holder)
 
+        # The kill/restart above reaped the dead process, so its exit code is now available. Name the signal
+        # so an OOM kill (SIGKILL) is obvious in the logs instead of just "zombie".
+        death = f"process_status={process_status!r} exitcode={describe_exitcode(holder.exitcode())}"
+        task_note = f", task_id={task.taskId.hex()}" if task is not None else ""
+        logger.warning(f"{self._identity!r}: Processor[{holder.pid()}] died: {death}{task_note}")
+
         if task is not None:
             source = task.source
             task_id = task.taskId
 
             result_object_id = ObjectID.generate_object_id(source)
-            result_object_bytes = serialize_failure(ProcessorDiedError(f"{process_status=}"))
+            result_object_bytes = serialize_failure(ProcessorDiedError(death))
 
             await self._connector_storage.set_object(result_object_id, result_object_bytes)
             await self._connector_external.send(

--- a/src/scaler/worker/agent/processor_manager.py
+++ b/src/scaler/worker/agent/processor_manager.py
@@ -163,17 +163,19 @@ class VanillaProcessorManager(ProcessorManager):
         else:
             profile_result = None
 
-        reason = f"process died {process_status=}"
+        # This only fires for zombie or dead processors, so the exit code is already readable here
+        # (`Process.exitcode` reaps on read). Name the signal so an OOM kill (SIGKILL) is obvious in the logs
+        # instead of just "zombie". Logged before the kill below, so the diagnosis is not separated from the
+        # processor it describes by the restart's own logging.
+        death = f"process_status={process_status!r} exitcode={describe_exitcode(holder.exitcode())}"
+        task_note = f", task_id={task.taskId.hex()}" if task is not None else ""
+        logger.warning(f"{self._identity!r}: Processor[{holder.pid()}] died: {death}{task_note}")
+
+        reason = "process died"
         if holder == self._current_holder:
             self.__restart_current_processor(reason)
         else:
             self.__kill_processor(reason, holder)
-
-        # The kill/restart above reaped the dead process, so its exit code is now available. Name the signal
-        # so an OOM kill (SIGKILL) is obvious in the logs instead of just "zombie".
-        death = f"process_status={process_status!r} exitcode={describe_exitcode(holder.exitcode())}"
-        task_note = f", task_id={task.taskId.hex()}" if task is not None else ""
-        logger.warning(f"{self._identity!r}: Processor[{holder.pid()}] died: {death}{task_note}")
 
         if task is not None:
             source = task.source

--- a/src/scaler/worker_manager_adapter/baremetal/native.py
+++ b/src/scaler/worker_manager_adapter/baremetal/native.py
@@ -6,11 +6,12 @@ import os
 import signal
 import sys
 import uuid
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 
 import psutil
 
 from scaler.config.section.native_worker_manager import NativeWorkerManagerConfig, NativeWorkerManagerMode
+from scaler.utility.exitcode import describe_exitcode
 from scaler.worker.worker import Worker
 from scaler.worker_manager_adapter.capacity_coordinator import CapacityCoordinator
 from scaler.worker_manager_adapter.common import extract_desired_count
@@ -21,15 +22,6 @@ if TYPE_CHECKING:
     from scaler.protocol.capnp import WorkerManagerCommand
 
 logger = logging.getLogger(__name__)
-
-
-def _describe_exitcode(exitcode: Optional[int]) -> str:
-    if exitcode is not None and exitcode < 0:
-        try:
-            return f"{exitcode} ({signal.Signals(-exitcode).name})"
-        except ValueError:
-            pass
-    return str(exitcode)
 
 
 class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
@@ -119,7 +111,7 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
 
                 if worker in terminated_by_us:
                     logger.info(
-                        f"native worker {worker.identity!r} stopped (exitcode={_describe_exitcode(worker.exitcode)})"
+                        f"native worker {worker.identity!r} stopped (exitcode={describe_exitcode(worker.exitcode)})"
                     )
                 elif worker.exitcode == 0:
                     # A worker exits 0 only when it was told to stop (by the scheduler or a
@@ -129,7 +121,7 @@ class NativeWorkerProvisioner(DeclarativeWorkerProvisioner):
                 else:
                     logger.warning(
                         f"native worker {worker.identity!r} exited unexpectedly "
-                        f"(exitcode={_describe_exitcode(worker.exitcode)})"
+                        f"(exitcode={describe_exitcode(worker.exitcode)})"
                     )
 
     async def set_desired_task_concurrency(

--- a/tests/utility/test_exitcode.py
+++ b/tests/utility/test_exitcode.py
@@ -1,0 +1,22 @@
+import sys
+import unittest
+
+from scaler.utility.exitcode import describe_exitcode
+
+
+class TestDescribeExitcode(unittest.TestCase):
+    def test_clean_exit_is_the_number(self) -> None:
+        self.assertEqual(describe_exitcode(0), "0")
+        self.assertEqual(describe_exitcode(1), "1")
+
+    @unittest.skipIf(sys.platform == "win32", "negative signal exit codes and their names are POSIX-specific")
+    def test_signal_death_is_named(self) -> None:
+        self.assertEqual(describe_exitcode(-9), "-9 (SIGKILL)")  # e.g. OOM kill
+        self.assertEqual(describe_exitcode(-15), "-15 (SIGTERM)")
+        self.assertEqual(describe_exitcode(-6), "-6 (SIGABRT)")
+
+    def test_unknown_signal_falls_back_to_number(self) -> None:
+        self.assertEqual(describe_exitcode(-999), "-999")
+
+    def test_none_when_not_exited(self) -> None:
+        self.assertEqual(describe_exitcode(None), "None")

--- a/tests/worker/agent/processor/test_processor.py
+++ b/tests/worker/agent/processor/test_processor.py
@@ -1,0 +1,192 @@
+import logging
+import unittest
+from typing import Any, Optional
+from unittest.mock import Mock
+
+from scaler.config.types.address import AddressConfig
+from scaler.protocol.capnp import Task, TaskResultType
+from scaler.utility.exceptions import ObjectStorageException
+from scaler.utility.identifiers import ClientID, ObjectID, TaskID
+from scaler.worker.agent.processor.processor import Processor
+
+_LOGGER_NAME = "scaler.worker.agent.processor.processor"
+
+
+def _make_processor() -> Processor:
+    # The processor is never started: these tests exercise the pure logic of __log_exit and __send_result with
+    # the connectors mocked out, so nothing here needs a live child process.
+    address = AddressConfig.from_string("tcp://127.0.0.1:0")
+    return Processor(
+        event_loop="builtin",
+        agent_address=address,
+        scheduler_address=address,
+        object_storage_address=address,
+        preload=None,
+        resume_event=None,
+        resumed_event=None,
+        suspend_trigger=None,
+        garbage_collect_interval_seconds=60,
+        trim_memory_threshold_bytes=10**9,
+        logging_paths=("/dev/stdout",),
+        logging_level="INFO",
+    )
+
+
+def _make_task() -> Task:
+    return Task(
+        taskId=TaskID.generate_task_id(),
+        source=ClientID.generate_client_id("test"),
+        metadata=b"",
+        funcObjectId=ObjectID(b"\x00" * 16 + b"\x01" * 16),
+        functionArgs=[],
+    )
+
+
+def _log_exit(processor: Processor, reason: str, exception: Optional[BaseException] = None) -> logging.LogRecord:
+    with unittest.TestCase().assertLogs(_LOGGER_NAME, level=logging.DEBUG) as captured:
+        processor._Processor__log_exit(reason, exception=exception)  # type: ignore[attr-defined]
+
+    assert len(captured.records) == 1
+    return captured.records[0]
+
+
+class ProcessorLogExitTest(unittest.TestCase):
+    """__log_exit is the processor's only report of why its main loop stopped, so it must name the orphaned task,
+    keep the traceback for genuine faults, and stay quiet for a teardown the agent itself requested."""
+
+    def setUp(self) -> None:
+        self.processor = _make_processor()
+
+    def test_idle_exit_is_debug_without_traceback(self) -> None:
+        record = _log_exit(self.processor, "agent connector stop requested")
+
+        self.assertEqual(record.levelno, logging.DEBUG)
+        self.assertIsNone(record.exc_info)
+        self.assertIn("agent connector stop requested", record.getMessage())
+
+    def test_exception_is_error_with_traceback(self) -> None:
+        exception = ObjectStorageException("storage went away")
+
+        record = _log_exit(self.processor, "object storage error", exception=exception)
+
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertIsNotNone(record.exc_info)
+        self.assertIs(record.exc_info[1], exception)  # type: ignore[index]
+
+    def test_in_flight_task_is_named_when_an_exception_is_present(self) -> None:
+        # Regression: __send_result used to clear _current_task before writing to storage, so the PR's headline
+        # scenario -- a storage failure mid-result -- logged without saying which task was orphaned.
+        task = _make_task()
+        self.processor._current_task = task
+
+        record = _log_exit(self.processor, "object storage error", exception=ObjectStorageException("boom"))
+
+        message = record.getMessage()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertIn(task.taskId.hex(), message)
+        self.assertIn("no task result will be sent", message)
+
+    def test_in_flight_task_without_exception_is_warning(self) -> None:
+        task = _make_task()
+        self.processor._current_task = task
+
+        record = _log_exit(self.processor, "interrupted")
+
+        message = record.getMessage()
+        self.assertEqual(record.levelno, logging.WARNING)
+        self.assertIsNone(record.exc_info)
+        self.assertIn(task.taskId.hex(), message)
+        self.assertIn("no task result will be sent", message)
+
+    def test_interrupted_exit_is_quiet_even_with_an_exception(self) -> None:
+        # A deliberate kill sends SIGTERM, whose handler destroys the connectors on purpose; a processor mid
+        # storage call then raises "connector is closed." That is expected teardown, not an error, so it must
+        # not be reported as ERROR with a traceback for something the agent asked for.
+        self.processor._current_task = _make_task()
+        self.processor._interrupted = True
+
+        record = _log_exit(self.processor, "object storage error", exception=ObjectStorageException("closed"))
+
+        self.assertEqual(record.levelno, logging.DEBUG)
+        self.assertIsNone(record.exc_info)
+        self.assertIn("stopped on agent request", record.getMessage())
+
+    def test_interrupt_sets_the_interrupted_flag(self) -> None:
+        self.processor._connector_agent = Mock()
+        self.processor._connector_storage = Mock()
+
+        self.assertFalse(self.processor._interrupted)
+
+        self.processor._Processor__interrupt()  # type: ignore[attr-defined]
+
+        self.assertTrue(self.processor._interrupted)
+        self.processor._connector_agent.destroy.assert_called_once()
+        self.processor._connector_storage.destroy.assert_called_once()
+
+
+class ProcessorSendResultTest(unittest.TestCase):
+    """_current_task must stay set until the result is fully handed off, so a failure part-way through can still
+    report which task was orphaned."""
+
+    def setUp(self) -> None:
+        self.processor = _make_processor()
+        self.processor._connector_agent = Mock()
+        self.processor._connector_storage = Mock()
+
+        self.task = _make_task()
+        self.processor._current_task = self.task
+
+    def __send_result(self) -> None:
+        self.processor._Processor__send_result(  # type: ignore[attr-defined]
+            self.task.source, self.task.taskId, TaskResultType.success, b"result-bytes"
+        )
+
+    def test_current_task_is_cleared_once_the_result_is_sent(self) -> None:
+        self.__send_result()
+
+        self.assertIsNone(self.processor._current_task)
+
+    def test_current_task_survives_a_storage_failure(self) -> None:
+        storage: Any = self.processor._connector_storage
+        storage.set_object.side_effect = ObjectStorageException("storage went away")
+
+        with self.assertRaises(ObjectStorageException):
+            self.__send_result()
+
+        self.assertIs(self.processor._current_task, self.task)
+
+
+class ProcessorRunForeverTest(unittest.TestCase):
+    """SystemExit must reach multiprocessing's _bootstrap, otherwise the processor exits 0 and the exit code
+    this PR surfaces is destroyed."""
+
+    def setUp(self) -> None:
+        self.processor = _make_processor()
+        self.processor._connector_agent = Mock()
+        self.processor._connector_storage = Mock()
+        self.processor._object_cache = Mock()
+
+    def test_system_exit_is_logged_and_re_raised(self) -> None:
+        # A task calling sys.exit(3) raises SystemExit, which __process_task's `except Exception` does not
+        # catch, so it unwinds into __run_forever.
+        agent: Any = self.processor._connector_agent
+        agent.receive.side_effect = SystemExit(3)
+
+        with self.assertLogs(_LOGGER_NAME, level=logging.DEBUG):
+            with self.assertRaises(SystemExit) as context:
+                self.processor._Processor__run_forever()  # type: ignore[attr-defined]
+
+        self.assertEqual(context.exception.code, 3)
+
+    def test_storage_error_does_not_escape_the_loop(self) -> None:
+        agent: Any = self.processor._connector_agent
+        agent.receive.side_effect = ObjectStorageException("storage went away")
+
+        with self.assertLogs(_LOGGER_NAME, level=logging.DEBUG) as captured:
+            self.processor._Processor__run_forever()  # type: ignore[attr-defined]
+
+        self.assertEqual(captured.records[0].levelno, logging.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/worker/agent/processor/test_processor.py
+++ b/tests/worker/agent/processor/test_processor.py
@@ -42,14 +42,6 @@ def _make_task() -> Task:
     )
 
 
-def _log_exit(processor: Processor, reason: str, exception: Optional[BaseException] = None) -> logging.LogRecord:
-    with unittest.TestCase().assertLogs(_LOGGER_NAME, level=logging.DEBUG) as captured:
-        processor._Processor__log_exit(reason, exception=exception)  # type: ignore[attr-defined]
-
-    assert len(captured.records) == 1
-    return captured.records[0]
-
-
 class ProcessorLogExitTest(unittest.TestCase):
     """__log_exit is the processor's only report of why its main loop stopped, so it must name the orphaned task,
     keep the traceback for genuine faults, and stay quiet for a teardown the agent itself requested."""
@@ -57,8 +49,15 @@ class ProcessorLogExitTest(unittest.TestCase):
     def setUp(self) -> None:
         self.processor = _make_processor()
 
+    def __log_exit(self, reason: str, exception: Optional[BaseException] = None) -> logging.LogRecord:
+        with self.assertLogs(_LOGGER_NAME, level=logging.DEBUG) as captured:
+            self.processor._Processor__log_exit(reason, exception=exception)  # type: ignore[attr-defined]
+
+        self.assertEqual(len(captured.records), 1)
+        return captured.records[0]
+
     def test_idle_exit_is_debug_without_traceback(self) -> None:
-        record = _log_exit(self.processor, "agent connector stop requested")
+        record = self.__log_exit("agent connector stop requested")
 
         self.assertEqual(record.levelno, logging.DEBUG)
         self.assertIsNone(record.exc_info)
@@ -67,7 +66,7 @@ class ProcessorLogExitTest(unittest.TestCase):
     def test_exception_is_error_with_traceback(self) -> None:
         exception = ObjectStorageException("storage went away")
 
-        record = _log_exit(self.processor, "object storage error", exception=exception)
+        record = self.__log_exit("object storage error", exception=exception)
 
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIsNotNone(record.exc_info)
@@ -79,7 +78,7 @@ class ProcessorLogExitTest(unittest.TestCase):
         task = _make_task()
         self.processor._current_task = task
 
-        record = _log_exit(self.processor, "object storage error", exception=ObjectStorageException("boom"))
+        record = self.__log_exit("object storage error", exception=ObjectStorageException("boom"))
 
         message = record.getMessage()
         self.assertEqual(record.levelno, logging.ERROR)
@@ -90,7 +89,7 @@ class ProcessorLogExitTest(unittest.TestCase):
         task = _make_task()
         self.processor._current_task = task
 
-        record = _log_exit(self.processor, "interrupted")
+        record = self.__log_exit("interrupted")
 
         message = record.getMessage()
         self.assertEqual(record.levelno, logging.WARNING)
@@ -105,7 +104,7 @@ class ProcessorLogExitTest(unittest.TestCase):
         self.processor._current_task = _make_task()
         self.processor._interrupted = True
 
-        record = _log_exit(self.processor, "object storage error", exception=ObjectStorageException("closed"))
+        record = self.__log_exit("object storage error", exception=ObjectStorageException("closed"))
 
         self.assertEqual(record.levelno, logging.DEBUG)
         self.assertIsNone(record.exc_info)


### PR DESCRIPTION
When a native-worker processor dies on its own (e.g. object storage drops while fetching a task's inputs, or the process is OOM-killed), the only trace was a later, cryptic `process died process_status='zombie'` from the agent's poll -- the real cause was invisible because the processor exited silently and the agent discarded the exit code.

- Route every exit path in `Processor.__run_forever` through a `__log_exit` helper: ERROR (with traceback) for real exceptions, WARNING naming the orphaned `task_id` when a task was in flight, DEBUG for routine shutdowns. `SystemExit` is now logged instead of exiting silently.
- Surface the real exit code: add `scaler.utility.exitcode.describe_exitcode` (naming the signal, e.g. `-9 (SIGKILL)`), expose `ProcessorHolder.exitcode()`, and use it in `on_failing_processor` for the log and `ProcessorDiedError`.

The `describe_exitcode` implementation and its test (`tests/utility/test_exitcode.py`) are taken verbatim from #900, and the shared exit-code pieces mirror it, so the two branches merge without conflict.