### PR TITLE
fix: fall back to RSS when psutil USS read is permission-denied

### DIFF
--- a/src/scaler/utility/memory.py
+++ b/src/scaler/utility/memory.py
@@ -21,8 +21,16 @@ def get_process_memory(process: psutil.Process) -> int:
     psutil only exposes ``pss`` where the kernel does (Linux, via smaps), so on Linux this is always PSS;
     on macOS/Windows ``memory_full_info()`` has no ``pss`` field and RSS is used. psutil errors (e.g. the
     process has exited) propagate for the caller to handle.
+
+    On macOS ``memory_full_info()`` reads USS through ``task_for_pid``, which requires elevated privileges
+    and raises a permission error under System Integrity Protection / the hardened runtime even for the
+    caller's own process. ``memory_info().rss`` reads through ``proc_pidinfo`` and needs no such privilege,
+    so we fall back to RSS on a permission denial rather than let the heartbeat routine crash.
     """
-    memory = process.memory_full_info()
+    try:
+        memory = process.memory_full_info()
+    except (psutil.AccessDenied, PermissionError):
+        return int(process.memory_info().rss)
     return int(getattr(memory, "pss", memory.rss))
 
 

--- a/tests/utility/test_memory.py
+++ b/tests/utility/test_memory.py
@@ -28,6 +28,20 @@ class TestGetProcessMemory(unittest.TestCase):
         with self.assertRaises(psutil.NoSuchProcess):
             get_process_memory(process)
 
+    def test_falls_back_to_rss_on_access_denied(self) -> None:
+        # macOS: reading USS via task_for_pid is denied under SIP/hardened runtime; RSS still works.
+        process = mock.Mock()
+        process.memory_full_info.side_effect = psutil.AccessDenied(1)
+        process.memory_info.return_value = mock.Mock(rss=4321)
+        self.assertEqual(get_process_memory(process), 4321)
+
+    def test_falls_back_to_rss_on_permission_error(self) -> None:
+        # Some psutil paths surface the raw task_for_pid EPERM as a plain PermissionError.
+        process = mock.Mock()
+        process.memory_full_info.side_effect = PermissionError(13, "force permission denied")
+        process.memory_info.return_value = mock.Mock(rss=8765)
+        self.assertEqual(get_process_memory(process), 8765)
+
 
 class TestGetMemoryLimitAndAvailable(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Problem

Worker heartbeats crash on macOS with:

```
PermissionError: [Errno 13] force permission denied (originated from task_for_pid)
  ...psutil/_psosx.py in memory_full_info
    uss = cext.proc_memory_uss(self.pid)
```

`psutil.Process.memory_full_info()` computes USS via `task_for_pid`, a privileged Mach call that returns `EPERM` under System Integrity Protection and the hardened runtime -- even for the caller's own process. `get_process_memory` (used by the worker heartbeat routine, the worker-manager adapter, and the scheduler information controller) only guarded against `NoSuchProcess`/`ZombieProcess`, so this permission denial crashed the loop.

## Fix

`memory_info().rss` reads via `proc_pidinfo` and needs no such privilege, and RSS is already the documented fallback where PSS is unavailable (macOS/Windows). Fall back to RSS on `psutil.AccessDenied` / `PermissionError` while still propagating process-gone errors for callers to handle.

On an affected macOS box PSS is unavailable regardless, so those processes report RSS -- the same as Windows already does. This slightly over-counts copy-on-write pages shared between a worker and its forked processors, but it is the only privilege-free option.
