### PR TITLE
fix: Detached send() for Scaler connectors

### DIFF
--- a/src/scaler/client/agent/bridge.py
+++ b/src/scaler/client/agent/bridge.py
@@ -676,7 +676,7 @@ class _InProcessAsyncConnector(AsyncConnector):
     def address(self) -> Optional[AddressConfig]:
         return self._address
 
-    async def send(self, message: BaseMessage, *, detached: bool = True) -> None:
+    async def send(self, message: BaseMessage, *, detached: bool) -> None:
         if self._destroyed:
             return
         await self._outgoing.put(message)

--- a/src/scaler/client/agent/bridge.py
+++ b/src/scaler/client/agent/bridge.py
@@ -676,7 +676,7 @@ class _InProcessAsyncConnector(AsyncConnector):
     def address(self) -> Optional[AddressConfig]:
         return self._address
 
-    async def send(self, message: BaseMessage) -> None:
+    async def send(self, message: BaseMessage, *, detached: bool = True) -> None:
         if self._destroyed:
             return
         await self._outgoing.put(message)

--- a/src/scaler/client/agent/disconnect_manager.py
+++ b/src/scaler/client/agent/disconnect_manager.py
@@ -17,13 +17,13 @@ class ClientDisconnectManager(DisconnectManager):
 
     async def on_client_disconnect(self, disconnect: ClientDisconnect):
         assert self._connector_external is not None
-        await self._connector_external.send(disconnect)
+        await self._connector_external.send(disconnect, detached=True)
 
         if disconnect.disconnectType == ClientDisconnect.DisconnectType.disconnect:
             raise ClientQuitException("client disconnecting")
 
     async def on_client_shutdown_response(self, response: ClientShutdownResponse):
         assert self._connector_internal is not None
-        await self._connector_internal.send(response)
+        await self._connector_internal.send(response, detached=True)
 
         raise ClientShutdownException("cluster shutting down")

--- a/src/scaler/client/agent/heartbeat_manager.py
+++ b/src/scaler/client/agent/heartbeat_manager.py
@@ -43,7 +43,7 @@ class ClientHeartbeatManager(Looper, HeartbeatManager):
             cpu = 0
             rss = 0
         await self._connector_external.send(
-            ClientHeartbeat(resource=Resource(cpu=cpu, rss=rss), latencyUS=self._latency_us)
+            ClientHeartbeat(resource=Resource(cpu=cpu, rss=rss), latencyUS=self._latency_us), detached=True
         )
 
     async def on_heartbeat_echo(self, heartbeat: ClientHeartbeatEcho):

--- a/src/scaler/client/agent/object_manager.py
+++ b/src/scaler/client/agent/object_manager.py
@@ -46,7 +46,8 @@ class ClientObjectManager(ObjectManager):
                 instructionType=ObjectInstruction.ObjectInstructionType.delete,
                 objectUser=self._identity,
                 objectMetadata=ObjectMetadata(objectIds=tuple(cleared_object_ids)),
-            )
+            ),
+            detached=True,
         )
 
     async def __send_object_creation(self, instruction: ObjectInstruction):
@@ -92,7 +93,8 @@ class ClientObjectManager(ObjectManager):
                 instructionType=ObjectInstruction.ObjectInstructionType.create,
                 objectUser=instruction.objectUser,
                 objectMetadata=new_object_content,
-            )
+            ),
+            detached=True,
         )
 
     async def __delete_objects(self, instruction: ObjectInstruction):
@@ -105,4 +107,4 @@ class ClientObjectManager(ObjectManager):
             ObjectID(object_id) for object_id in instruction.objectMetadata.objectIds
         )
 
-        await self._connector_external.send(instruction)
+        await self._connector_external.send(instruction, detached=True)

--- a/src/scaler/client/agent/task_manager.py
+++ b/src/scaler/client/agent/task_manager.py
@@ -23,7 +23,7 @@ class ClientTaskManager(TaskManager):
 
     async def on_new_task(self, task: Task):
         self._task_ids.add(task.taskId)
-        await self._connector_external.send(task)
+        await self._connector_external.send(task, detached=True)
 
     async def on_cancel_task(self, task_cancel: TaskCancel):
         # We might receive a cancel task event on a previously finished task if:
@@ -36,12 +36,12 @@ class ClientTaskManager(TaskManager):
         if task_cancel.taskId not in self._task_ids:
             return
 
-        await self._connector_external.send(task_cancel)
+        await self._connector_external.send(task_cancel, detached=True)
 
     async def on_new_graph_task(self, task: GraphTask):
         self._task_ids.add(task.taskId)
         self._task_ids.update(set(task.targets))
-        await self._connector_external.send(task)
+        await self._connector_external.send(task, detached=True)
 
     async def on_task_result(self, result: TaskResult):
         # All task result objects must be propagated to the object manager, even if we do not track the task anymore

--- a/src/scaler/io/mixins.py
+++ b/src/scaler/io/mixins.py
@@ -97,7 +97,7 @@ class AsyncBinder(Looper, Reporter, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def send(self, to: bytes, message: BaseMessage, *, detached: bool = True):
+    async def send(self, to: bytes, message: BaseMessage, *, detached: bool):
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -131,7 +131,7 @@ class AsyncConnector(Looper, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def send(self, message: BaseMessage, *, detached: bool = True):
+    async def send(self, message: BaseMessage, *, detached: bool):
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/src/scaler/io/mixins.py
+++ b/src/scaler/io/mixins.py
@@ -97,7 +97,7 @@ class AsyncBinder(Looper, Reporter, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def send(self, to: bytes, message: BaseMessage):
+    async def send(self, to: bytes, message: BaseMessage, *, detached: bool = True):
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -131,7 +131,7 @@ class AsyncConnector(Looper, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def send(self, message: BaseMessage):
+    async def send(self, message: BaseMessage, *, detached: bool = True):
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/src/scaler/io/ymq/utils.py
+++ b/src/scaler/io/ymq/utils.py
@@ -62,9 +62,7 @@ def call_sync(  # type: ignore[valid-type]
 
 
 def run_detached(
-    awaitable: Awaitable[Any],
-    description: str,
-    on_done_callback: Optional[Callable[[asyncio.Task], None]] = None,
+    awaitable: Awaitable[Any], description: str, on_done_callback: Optional[Callable[[asyncio.Task], None]] = None
 ) -> asyncio.Task:
     """Schedule an awaitable on the running event loop without waiting for its completion.
 

--- a/src/scaler/io/ymq/utils.py
+++ b/src/scaler/io/ymq/utils.py
@@ -64,8 +64,8 @@ def call_sync(  # type: ignore[valid-type]
 def run_detached(
     awaitable: Awaitable[Any],
     description: str,
-    on_done_callback: Optional[Callable[["asyncio.Task"], None]] = None,
-) -> "asyncio.Task":
+    on_done_callback: Optional[Callable[[asyncio.Task], None]] = None,
+) -> asyncio.Task:
     """Schedule an awaitable on the running event loop without waiting for its completion.
 
     This turns an otherwise blocking asyncio operation into a fire-and-forget one.
@@ -81,7 +81,7 @@ def run_detached(
 
     task = asyncio.ensure_future(awaitable)
 
-    def on_done(completed: "asyncio.Task") -> None:
+    def on_done(completed: asyncio.Task) -> None:
         if on_done_callback is not None:
             on_done_callback(completed)
 

--- a/src/scaler/io/ymq/utils.py
+++ b/src/scaler/io/ymq/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
-from typing import Any, Callable, Optional, TypeVar, Union
+import logging
+from typing import Any, Awaitable, Callable, Optional, TypeVar, Union
 
 try:
     from typing import Concatenate, ParamSpec  # type: ignore[attr-defined]
@@ -9,6 +10,8 @@ except ImportError:
 
 from scaler.config.common.security import SecurityConfig
 from scaler.io.ymq import TLSConfig
+
+logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -56,6 +59,42 @@ def call_sync(  # type: ignore[valid-type]
 
     func(callback, *args, **kwargs)
     return future.result(timeout)
+
+
+def run_detached(
+    awaitable: Awaitable[Any],
+    description: str,
+    on_done_callback: Optional[Callable[["asyncio.Task"], None]] = None,
+) -> "asyncio.Task":
+    """Schedule an awaitable on the running event loop without waiting for its completion.
+
+    This turns an otherwise blocking asyncio operation into a fire-and-forget one.
+
+    Failures are logged instead of being propagated, as the caller does not wait for the result.
+
+    If provided, `on_done_callback` is called with the completed task once it finishes, including
+    when it is cancelled. It is typically used to remove the task from the caller's pending set.
+
+    The returned task must be kept referenced by the caller until completion, as asyncio only keeps weak references to
+    running tasks. Callers are also responsible for cancelling it on teardown.
+    """
+
+    task = asyncio.ensure_future(awaitable)
+
+    def on_done(completed: "asyncio.Task") -> None:
+        if on_done_callback is not None:
+            on_done_callback(completed)
+
+        if completed.cancelled():
+            return
+
+        exception = completed.exception()
+        if exception is not None:
+            logger.debug(f"{description}: detached operation failed: {exception!r}")
+
+    task.add_done_callback(on_done)
+
+    return task
 
 
 def _safe_set_result(future: asyncio.Future, result: Any) -> None:

--- a/src/scaler/io/ymq_async_binder.py
+++ b/src/scaler/io/ymq_async_binder.py
@@ -1,13 +1,14 @@
+import asyncio
 import logging
 from collections import defaultdict
-from typing import Awaitable, Callable, Dict, Optional
+from typing import Awaitable, Callable, Dict, Optional, Set
 
 from scaler.config.common.security import SecurityConfig
 from scaler.config.types.address import AddressConfig
 from scaler.io.mixins import AsyncBinder
 from scaler.io.utility import deserialize, serialize
 from scaler.io.ymq import BinderSocket, Bytes, ConnectorSocketClosedByRemoteEndError, IOContext
-from scaler.io.ymq.utils import to_tls_config
+from scaler.io.ymq.utils import run_detached, to_tls_config
 from scaler.protocol.capnp import BaseMessage, BinderStatus
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,8 @@ class YMQAsyncBinder(AsyncBinder):
 
         self._received: Dict[str, int] = defaultdict(lambda: 0)
         self._sent: Dict[str, int] = defaultdict(lambda: 0)
+
+        self._pending_tasks: Set["asyncio.Task"] = set()
 
     def __del__(self):
         self.destroy()
@@ -45,6 +48,9 @@ class YMQAsyncBinder(AsyncBinder):
     def destroy(self):
         if self._socket is None:
             return
+
+        for task in self._pending_tasks.copy():
+            task.cancel()
 
         self._socket.shutdown()
 
@@ -71,14 +77,19 @@ class YMQAsyncBinder(AsyncBinder):
             # tear down the whole scheduler for what is a normal peer departure.
             pass
 
-    async def send(self, to: bytes, message: BaseMessage):
-        # Errors (including ConnectorSocketClosedByRemoteEndError when the peer is gone) propagate
-        # up to whoever drove this send - the AsyncBinder send/recv API maps 1:1 to the underlying
-        # C++ BinderSocket. The scheduler-side swallow lives in routine() above, which is the loop
-        # that actually has to stay alive across peer departures.
+    async def send(self, to: bytes, message: BaseMessage, *, detached: bool = True):
         assert self._socket is not None
         self.__count_sent(message.__class__.__name__)
-        await self._socket.send_message(to.decode(), Bytes(serialize(message)))
+
+        awaitable = self._socket.send_message(to.decode(), Bytes(serialize(message)))
+
+        if not detached:
+            await awaitable
+            return
+
+        self._pending_tasks.add(
+            run_detached(awaitable, f"{self.__get_prefix()} send to {to!r}", self._pending_tasks.discard)
+        )
 
     def get_status(self) -> BinderStatus:
         return BinderStatus(
@@ -93,3 +104,6 @@ class YMQAsyncBinder(AsyncBinder):
 
     def __count_sent(self, message_type: str):
         self._sent[message_type] += 1
+
+    def __get_prefix(self) -> str:
+        return f"{self.__class__.__name__}[{self._identity!r}]:"

--- a/src/scaler/io/ymq_async_binder.py
+++ b/src/scaler/io/ymq_async_binder.py
@@ -77,7 +77,7 @@ class YMQAsyncBinder(AsyncBinder):
             # tear down the whole scheduler for what is a normal peer departure.
             pass
 
-    async def send(self, to: bytes, message: BaseMessage, *, detached: bool = True):
+    async def send(self, to: bytes, message: BaseMessage, *, detached: bool):
         assert self._socket is not None
         self.__count_sent(message.__class__.__name__)
 

--- a/src/scaler/io/ymq_async_binder.py
+++ b/src/scaler/io/ymq_async_binder.py
@@ -27,7 +27,7 @@ class YMQAsyncBinder(AsyncBinder):
         self._received: Dict[str, int] = defaultdict(lambda: 0)
         self._sent: Dict[str, int] = defaultdict(lambda: 0)
 
-        self._pending_tasks: Set["asyncio.Task"] = set()
+        self._pending_tasks: Set[asyncio.Task] = set()
 
     def __del__(self):
         self.destroy()

--- a/src/scaler/io/ymq_async_connector.py
+++ b/src/scaler/io/ymq_async_connector.py
@@ -94,7 +94,7 @@ class YMQAsyncConnector(AsyncConnector):
 
         return result
 
-    async def send(self, message: BaseMessage, *, detached: bool = True):
+    async def send(self, message: BaseMessage, *, detached: bool):
         if self._socket is None:
             return
 

--- a/src/scaler/io/ymq_async_connector.py
+++ b/src/scaler/io/ymq_async_connector.py
@@ -22,7 +22,7 @@ class YMQAsyncConnector(AsyncConnector):
         self._callback: Callable[[BaseMessage], Awaitable[None]] = callback
         self._socket: Optional[ConnectorSocket] = None
 
-        self._pending_tasks: Set["asyncio.Task"] = set()
+        self._pending_tasks: Set[asyncio.Task] = set()
 
     def __del__(self):
         self.destroy()

--- a/src/scaler/io/ymq_async_connector.py
+++ b/src/scaler/io/ymq_async_connector.py
@@ -1,12 +1,13 @@
+import asyncio
 import logging
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, Set
 
 from scaler.config.common.security import SecurityConfig
 from scaler.config.types.address import AddressConfig
 from scaler.io.mixins import AsyncConnector, ConnectorRemoteType
 from scaler.io.utility import deserialize, serialize
 from scaler.io.ymq import Bytes, ConnectorSocket, IOContext
-from scaler.io.ymq.utils import to_tls_config
+from scaler.io.ymq.utils import run_detached, to_tls_config
 from scaler.protocol.capnp import BaseMessage
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,8 @@ class YMQAsyncConnector(AsyncConnector):
 
         self._callback: Callable[[BaseMessage], Awaitable[None]] = callback
         self._socket: Optional[ConnectorSocket] = None
+
+        self._pending_tasks: Set["asyncio.Task"] = set()
 
     def __del__(self):
         self.destroy()
@@ -48,6 +51,9 @@ class YMQAsyncConnector(AsyncConnector):
     def destroy(self):
         if self._socket is None:
             return
+
+        for task in self._pending_tasks.copy():
+            task.cancel()
 
         self._socket.shutdown()
 
@@ -88,8 +94,17 @@ class YMQAsyncConnector(AsyncConnector):
 
         return result
 
-    async def send(self, message: BaseMessage):
+    async def send(self, message: BaseMessage, *, detached: bool = True):
         if self._socket is None:
             return
 
-        await self._socket.send_message(Bytes(serialize(message)))
+        awaitable = self._socket.send_message(Bytes(serialize(message)))
+
+        if not detached:
+            await awaitable
+            return
+
+        self._pending_tasks.add(run_detached(awaitable, self.__get_prefix(), self._pending_tasks.discard))
+
+    def __get_prefix(self) -> str:
+        return f"{self.__class__.__name__}[{self._identity!r}]:"

--- a/src/scaler/io/zmq_async_binder.py
+++ b/src/scaler/io/zmq_async_binder.py
@@ -77,7 +77,8 @@ class ZMQAsyncBinder(AsyncBinder):
         self.__count_received(message.__class__.__name__)
         await self._callback(source.bytes, message)
 
-    async def send(self, to: bytes, message: BaseMessage):
+    async def send(self, to: bytes, message: BaseMessage, *, detached: bool = True):
+        # `detached` is ignored: a ZMQ ROUTER socket is always fire-and-forget.
         self.__count_sent(message.__class__.__name__)
         await self._socket.send_multipart([to, serialize(message)], copy=False)
 

--- a/src/scaler/io/zmq_async_binder.py
+++ b/src/scaler/io/zmq_async_binder.py
@@ -77,7 +77,7 @@ class ZMQAsyncBinder(AsyncBinder):
         self.__count_received(message.__class__.__name__)
         await self._callback(source.bytes, message)
 
-    async def send(self, to: bytes, message: BaseMessage, *, detached: bool = True):
+    async def send(self, to: bytes, message: BaseMessage, *, detached: bool):
         # `detached` is ignored: a ZMQ ROUTER socket is always fire-and-forget.
         self.__count_sent(message.__class__.__name__)
         await self._socket.send_multipart([to, serialize(message)], copy=False)

--- a/src/scaler/io/zmq_async_connector.py
+++ b/src/scaler/io/zmq_async_connector.py
@@ -98,7 +98,7 @@ class ZMQAsyncConnector(AsyncConnector):
 
         return result
 
-    async def send(self, message: BaseMessage, *, detached: bool = True):
+    async def send(self, message: BaseMessage, *, detached: bool):
         # `detached` is ignored: ZMQ sockets are always fire-and-forget
         if self._socket is None:
             return

--- a/src/scaler/io/zmq_async_connector.py
+++ b/src/scaler/io/zmq_async_connector.py
@@ -98,7 +98,8 @@ class ZMQAsyncConnector(AsyncConnector):
 
         return result
 
-    async def send(self, message: BaseMessage):
+    async def send(self, message: BaseMessage, *, detached: bool = True):
+        # `detached` is ignored: ZMQ sockets are always fire-and-forget
         if self._socket is None:
             return
 

--- a/src/scaler/scheduler/controllers/client_controller.py
+++ b/src/scaler/scheduler/controllers/client_controller.py
@@ -86,6 +86,7 @@ class VanillaClientController(ClientController, Looper, Reporter):
                     scheme=object_storage_address.type.value,
                 )
             ),
+            detached=True,
         )
         if client_id not in self._client_last_seen:
             logger.info(f"{client_id!r} connected")
@@ -114,7 +115,7 @@ class VanillaClientController(ClientController, Looper, Reporter):
             logger.info(f"shutdown scheduler and all clusters as received signal from {client_id!r}")
             accepted = True
 
-        await self._binder.send(client_id, ClientShutdownResponse(accepted=accepted))
+        await self._binder.send(client_id, ClientShutdownResponse(accepted=accepted), detached=True)
 
         if self._config_controller.get_config("protected"):
             return

--- a/src/scaler/scheduler/controllers/graph_controller.py
+++ b/src/scaler/scheduler/controllers/graph_controller.py
@@ -379,7 +379,9 @@ class VanillaGraphTaskController(GraphTaskController, Looper, Reporter):
         self._task_id_to_graph_task_id.pop(graph_task_id)
         info = self._graph_task_id_to_graph.pop(graph_task_id)
         await self._binder.send(
-            info.client, TaskCancelConfirm(taskId=graph_task_id, cancelConfirmType=TaskCancelConfirmType.canceled)
+            info.client,
+            TaskCancelConfirm(taskId=graph_task_id, cancelConfirmType=TaskCancelConfirmType.canceled),
+            detached=True,
         )
 
     async def __done_graph_umbrella_task(self, graph_task_id: TaskID, result_type: TaskResultType):
@@ -387,7 +389,9 @@ class VanillaGraphTaskController(GraphTaskController, Looper, Reporter):
         self._task_id_to_graph_task_id.pop(graph_task_id)
         info = self._graph_task_id_to_graph.pop(graph_task_id)
         await self._binder.send(
-            info.client, TaskResult(taskId=graph_task_id, resultType=result_type, metadata=b"", results=[])
+            info.client,
+            TaskResult(taskId=graph_task_id, resultType=result_type, metadata=b"", results=[]),
+            detached=True,
         )
 
     def __is_graph_finished(self, graph_task_id: TaskID):
@@ -459,9 +463,12 @@ class VanillaGraphTaskController(GraphTaskController, Looper, Reporter):
         )
 
     async def __send_results(self, client_id: ClientID, results: List[TaskResult]):
-        await asyncio.gather(*[self._binder.send(client_id, result) for result in results])
+        await asyncio.gather(*[self._binder.send(client_id, result, detached=True) for result in results])
 
     async def __send_task_cancel_confirms(self, client_id: ClientID, task_cancel_confirms: List[TaskCancelConfirm]):
         await asyncio.gather(
-            *[self._binder.send(client_id, task_cancel_confirm) for task_cancel_confirm in task_cancel_confirms]
+            *[
+                self._binder.send(client_id, task_cancel_confirm, detached=True)
+                for task_cancel_confirm in task_cancel_confirms
+            ]
         )

--- a/src/scaler/scheduler/controllers/object_controller.py
+++ b/src/scaler/scheduler/controllers/object_controller.py
@@ -125,6 +125,7 @@ class VanillaObjectController(ObjectController, Looper, Reporter):
                     objectUser=b"",
                     objectMetadata=ObjectMetadata(objectIds=tuple(deleted_object_ids)),
                 ),
+                detached=True,
             )
 
         for object_id in deleted_object_ids:

--- a/src/scaler/scheduler/controllers/task_controller.py
+++ b/src/scaler/scheduler/controllers/task_controller.py
@@ -118,7 +118,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
             if self._graph_controller.is_graph_subtask(task_cancel.taskId):
                 await self._graph_controller.on_graph_sub_task_cancel_confirm(task_cancel_confirm)
 
-            await self._binder.send(client_id, task_cancel_confirm)
+            await self._binder.send(client_id, task_cancel_confirm, detached=True)
             return
 
         if state_machine.current_state() == TaskState.inactive:
@@ -220,7 +220,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
         assert state_machine.current_state() == TaskState.running
 
         task = self._task_id_to_task[task_id]
-        await self._binder.send(worker_id, task)
+        await self._binder.send(worker_id, task, detached=True)
         await self.__send_monitor(task_id, self._object_controller.get_object_name(task.funcObjectId))
 
     async def __state_canceling(
@@ -329,7 +329,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
             )
             return
 
-        await self._binder.send(worker, task_cancel)
+        await self._binder.send(worker, task_cancel, detached=True)
         await self.__send_monitor(task_cancel.taskId, b"")
 
     async def __send_task_result_to_client(self, task_result: TaskResult):
@@ -341,7 +341,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
                 f"(likely disconnected via client_timeout_seconds while the task was running)"
             )
         else:
-            await self._binder.send(client, task_result)
+            await self._binder.send(client, task_result, detached=True)
 
         func_name = b""
         task = self._task_id_to_task.get(task_result.taskId)
@@ -365,7 +365,7 @@ class VanillaTaskController(TaskController, Looper, Reporter):
                 f"longer registered"
             )
         else:
-            await self._binder.send(client, task_cancel_confirm)
+            await self._binder.send(client, task_cancel_confirm, detached=True)
         await self.__send_monitor(task_cancel_confirm.taskId, b"")
         self._task_state_manager.remove_state_machine(task_cancel_confirm.taskId)
         self._task_id_to_task.pop(task_cancel_confirm.taskId)

--- a/src/scaler/scheduler/controllers/worker_controller.py
+++ b/src/scaler/scheduler/controllers/worker_controller.py
@@ -95,6 +95,7 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
                     scheme=object_storage_address.type.value,
                 )
             ),
+            detached=True,
         )
 
     async def on_client_shutdown(self, client_id: ClientID):
@@ -103,7 +104,7 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
 
     async def on_disconnect(self, worker_id: WorkerID, request: DisconnectRequest):
         await self.__disconnect_worker(request.worker)
-        await self._binder.send(worker_id, DisconnectResponse(worker=request.worker))
+        await self._binder.send(worker_id, DisconnectResponse(worker=request.worker), detached=True)
 
     async def routine(self):
         await self.__clean_workers()
@@ -201,5 +202,7 @@ class VanillaWorkerController(WorkerController, Looper, Reporter):
             await self._task_controller.on_worker_disconnect(task_id, worker_id)
 
     async def __shutdown_worker(self, worker_id: WorkerID):
-        await self._binder.send(worker_id, ClientDisconnect(disconnectType=ClientDisconnect.DisconnectType.shutdown))
+        await self._binder.send(
+            worker_id, ClientDisconnect(disconnectType=ClientDisconnect.DisconnectType.shutdown), detached=True
+        )
         await self.__disconnect_worker(worker_id)

--- a/src/scaler/scheduler/controllers/worker_manager_controller.py
+++ b/src/scaler/scheduler/controllers/worker_manager_controller.py
@@ -65,7 +65,7 @@ class WorkerManagerController(Looper, Reporter):
 
         self._manager_alive_since[source] = (time.time(), heartbeat)
 
-        await self._binder.send(source, WorkerManagerHeartbeatEcho())
+        await self._binder.send(source, WorkerManagerHeartbeatEcho(), detached=True)
 
         information_snapshot = self._build_snapshot()
         managed_worker_ids = self._worker_controller.get_workers_by_manager_id(heartbeat.workerManagerID)
@@ -115,7 +115,7 @@ class WorkerManagerController(Looper, Reporter):
         return result
 
     async def _send_command(self, source: bytes, command: WorkerManagerCommand):
-        await self._binder.send(source, command)
+        await self._binder.send(source, command, detached=True)
 
     def _build_manager_snapshots(self) -> Dict[bytes, WorkerManagerSnapshot]:
         """Build cross-manager snapshots from all known managers, keyed by worker_manager_id."""

--- a/src/scaler/scheduler/scheduler.py
+++ b/src/scaler/scheduler/scheduler.py
@@ -220,7 +220,7 @@ class Scheduler:
         if isinstance(message, TaskLog):
             client = self._client_manager.get_client_id(message.taskId)
             if client is not None:
-                await self._binder.send(client, message)
+                await self._binder.send(client, message, detached=True)
             return
 
         # =====================================================================================

--- a/src/scaler/worker/agent/heartbeat_manager.py
+++ b/src/scaler/worker/agent/heartbeat_manager.py
@@ -105,7 +105,8 @@ class VanillaHeartbeatManager(Looper, HeartbeatManager):
                 processors=[self.__get_processor_status_from_holder(processor) for processor in processors],
                 capabilities=dict_to_capabilities(self._capabilities),
                 workerManagerID=self._worker_manager_id,
-            )
+            ),
+            detached=True,
         )
         self._start_timestamp_ns = time.time_ns()
 

--- a/src/scaler/worker/agent/processor_manager.py
+++ b/src/scaler/worker/agent/processor_manager.py
@@ -129,7 +129,7 @@ class VanillaProcessorManager(ProcessorManager):
 
         self._profiling_manager.on_task_start(holder.pid(), task.taskId)
 
-        await self._binder_internal.send(holder.processor_id(), task)
+        await self._binder_internal.send(holder.processor_id(), task, detached=True)
 
         return True
 
@@ -194,7 +194,8 @@ class VanillaProcessorManager(ProcessorManager):
                         objectTypes=(ObjectMetadata.ObjectContentType.object,),
                         objectNames=(b"",),
                     ),
-                )
+                ),
+                detached=True,
             )
 
             await self._task_manager.on_task_result(
@@ -290,13 +291,13 @@ class VanillaProcessorManager(ProcessorManager):
             if processor_id not in self._holders_by_processor_id:
                 continue  # processor got killed while we were iterating over the list
 
-            await self._binder_internal.send(processor_id, instruction)
+            await self._binder_internal.send(processor_id, instruction, detached=True)
 
     async def on_internal_object_instruction(self, processor_id: ProcessorID, instruction: ObjectInstruction):
         if not self.__processor_ready_to_process_object(processor_id):
             return
 
-        await self._connector_external.send(instruction)
+        await self._connector_external.send(instruction, detached=True)
 
     def destroy(self, reason: str):
         if self._connector_storage is not None:

--- a/src/scaler/worker/agent/task_manager.py
+++ b/src/scaler/worker/agent/task_manager.py
@@ -48,14 +48,16 @@ class VanillaTaskManager(Looper, TaskManager):
         )
         if task_not_found:
             await self._connector_external.send(
-                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelNotFound)
+                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelNotFound),
+                detached=True,
             )
             return
 
         if task_cancel.taskId in self._processing_task_ids and not task_cancel.flags.force:
             # ignore cancel task while in processing if is not force cancel
             await self._connector_external.send(
-                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelFailed)
+                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelFailed),
+                detached=True,
             )
             return
 
@@ -72,7 +74,8 @@ class VanillaTaskManager(Looper, TaskManager):
             _ = self._queued_task_id_to_task.pop(task_cancel.taskId)
 
         await self._connector_external.send(
-            TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.canceled)
+            TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.canceled),
+            detached=True,
         )
 
     async def on_task_result(self, result: TaskResult):
@@ -83,7 +86,7 @@ class VanillaTaskManager(Looper, TaskManager):
 
         self._processing_task_ids.remove(result.taskId)
 
-        await self._connector_external.send(result)
+        await self._connector_external.send(result, detached=True)
 
     async def routine(self):
         await self.__processing_task()

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -292,7 +292,7 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
             return
 
         if isinstance(message, TaskLog):
-            await self._connector_external.send(message)
+            await self._connector_external.send(message, detached=True)
             return
 
         if isinstance(message, TaskResult):

--- a/src/scaler/worker/worker.py
+++ b/src/scaler/worker/worker.py
@@ -359,7 +359,7 @@ class Worker(multiprocessing.get_context("spawn").Process):  # type: ignore
             return
 
         try:
-            await self._connector_external.send(DisconnectRequest(worker=self.identity))
+            await self._connector_external.send(DisconnectRequest(worker=self.identity), detached=False)
         except ymq.YMQException:
             pass
 

--- a/src/scaler/worker_manager_adapter/heartbeat_manager.py
+++ b/src/scaler/worker_manager_adapter/heartbeat_manager.py
@@ -101,6 +101,7 @@ class HeartbeatManager(Looper, HeartbeatManagerMixin):
                 processors=self._processor_status_provider.get_processor_statuses(),
                 capabilities=dict_to_capabilities(self._capabilities),
                 workerManagerID=self._worker_manager_id,
-            )
+            ),
+            detached=True,
         )
         self._start_timestamp_ns = time.time_ns()

--- a/src/scaler/worker_manager_adapter/task_manager.py
+++ b/src/scaler/worker_manager_adapter/task_manager.py
@@ -103,13 +103,15 @@ class TaskManager(Looper, TaskManagerMixin):
 
         if not task_queued and not task_processing:
             await self._connector_external.send(
-                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelNotFound)
+                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelNotFound),
+                detached=True,
             )
             return
 
         if task_processing and not task_cancel.flags.force:
             await self._connector_external.send(
-                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelFailed)
+                TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.cancelFailed),
+                detached=True,
             )
             return
 
@@ -126,7 +128,8 @@ class TaskManager(Looper, TaskManagerMixin):
             self._canceled_task_ids.add(task_cancel.taskId)
 
         await self._connector_external.send(
-            TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.canceled)
+            TaskCancelConfirm(taskId=task_cancel.taskId, cancelConfirmType=TaskCancelConfirmType.canceled),
+            detached=True,
         )
 
     async def on_task_result(self, result: TaskResult) -> None:
@@ -142,7 +145,7 @@ class TaskManager(Looper, TaskManagerMixin):
         self._processing_task_ids.remove(result.taskId)
         self._task_id_to_task.pop(result.taskId)
 
-        await self._connector_external.send(result)
+        await self._connector_external.send(result, detached=True)
 
     def get_queued_size(self) -> int:
         return self._queued_task_id_queue.qsize()
@@ -188,11 +191,13 @@ class TaskManager(Looper, TaskManagerMixin):
                             objectTypes=(ObjectMetadata.ObjectContentType.object,),
                             objectNames=(f"<res {result_object_id.hex()[:6]}>".encode(),),
                         ),
-                    )
+                    ),
+                    detached=True,
                 )
 
                 await self._connector_external.send(
-                    TaskResult(taskId=task_id, resultType=result_type, metadata=b"", results=[bytes(result_object_id)])
+                    TaskResult(taskId=task_id, resultType=result_type, metadata=b"", results=[bytes(result_object_id)]),
+                    detached=True,
                 )
 
             elif task_id in self._canceled_task_ids:

--- a/src/scaler/worker_manager_adapter/worker_manager_runner.py
+++ b/src/scaler/worker_manager_adapter/worker_manager_runner.py
@@ -84,7 +84,8 @@ class WorkerManagerRunner:
                 maxTaskConcurrency=self._max_provisioner_units * self._workers_per_provisioner_unit,
                 capabilities=dict_to_capabilities(self._capabilities),
                 workerManagerID=self._worker_manager_id,
-            )
+            ),
+            detached=True,
         )
 
     async def _get_loops(self) -> None:

--- a/src/scaler/worker_manager_adapter/worker_process.py
+++ b/src/scaler/worker_manager_adapter/worker_process.py
@@ -277,7 +277,7 @@ class WorkerProcess(_SpawnProcess):  # type: ignore[valid-type, misc]
             return
 
         try:
-            await self._connector_external.send(DisconnectRequest(worker=self.identity))
+            await self._connector_external.send(DisconnectRequest(worker=self.identity), detached=False)
         except ymq.YMQException:
             pass
 

--- a/tests/client/test_bridge.py
+++ b/tests/client/test_bridge.py
@@ -103,7 +103,7 @@ class InProcessConnectorPairTest(unittest.TestCase):
         async_conn, sync_conn, _ = self._make_pair()
         msg = ClientDisconnect(disconnectType=ClientDisconnect.DisconnectType.shutdown)
 
-        self._loop.run_until_complete(async_conn.send(msg))
+        self._loop.run_until_complete(async_conn.send(msg, detached=True))
 
         with _patched_run_sync(self._driver):
             got = sync_conn.receive()

--- a/tests/io/test_ymq_async_binder.py
+++ b/tests/io/test_ymq_async_binder.py
@@ -41,7 +41,9 @@ class TestYMQAsyncBinderSend(unittest.IsolatedAsyncioTestCase):
         destroyed. The native socket fails the pending send with ``SocketStopRequested``, which the
         io layer propagates as-is (fail fast). This is the exception the worker boundary must handle.
         """
-        send_task = asyncio.ensure_future(self._binder.send(b"peer-that-never-connects", self._make_message()))
+        send_task = asyncio.ensure_future(
+            self._binder.send(b"peer-that-never-connects", self._make_message(), detached=False)
+        )
 
         # Let the send reach the binder's event-loop thread and park in its pending-send queue.
         await asyncio.sleep(0.2)
@@ -58,7 +60,7 @@ class TestYMQAsyncBinderSend(unittest.IsolatedAsyncioTestCase):
         connector = ConnectorSocket.connect(self._context, "peer", repr(self._binder.address))
 
         message = self._make_message()
-        await self._binder.send(b"peer", message)  # completes once the peer identifies itself
+        await self._binder.send(b"peer", message, detached=False)  # completes once the peer identifies itself
 
         ymq_msg = await asyncio.wait_for(connector.recv_message(), timeout=5.0)
         received = deserialize(ymq_msg.payload.data)

--- a/tests/scheduler/test_dead_worker.py
+++ b/tests/scheduler/test_dead_worker.py
@@ -1,0 +1,114 @@
+import concurrent.futures
+import threading
+import time
+import unittest
+from typing import List
+
+import psutil
+
+from scaler import Client, SchedulerClusterCombo
+from scaler.utility.logging.utility import setup_logger
+from scaler.utility.network_util import get_available_tcp_port
+from tests.utility.utility import logging_test_name
+
+
+class TestDeadWorker(unittest.TestCase):
+    def setUp(self) -> None:
+        setup_logger()
+        logging_test_name(self)
+
+    def test_scheduler_responsive_after_worker_death(self):
+        """
+        Regression test: the scheduler must not block because of a dead worker.
+
+        Sending to a disconnected (or disconnecting) peer used to block the scheduler's event loop indefinitely, which
+        stopped it from processing any other request.
+
+        Clients could then no longer submit tasks and eventually timed out.
+        """
+
+        # The scheduler must keep believing the killed worker is alive, so that it still routes tasks to it.
+        WORKER_TIMEOUT_SECONDS = 5
+
+        # One worker is killed, the other will remain able to run the new client's tasks.
+        N_WORKERS = 2
+
+        N_TASKS = 10
+
+        address = f"tcp://127.0.0.1:{get_available_tcp_port()}"
+        combo = SchedulerClusterCombo(
+            address=address, n_workers=N_WORKERS, worker_timeout_seconds=WORKER_TIMEOUT_SECONDS
+        )
+
+        with Client(address=address) as client:
+            # Ensures the workers are connected and registered by the scheduler.
+            self.assertEqual(client.submit(round, 3.14).result(), 3)
+
+            worker_processes = self.__wait_for_worker_processes(combo._worker_manager_process.pid, N_WORKERS)
+
+            # Kill the first worker
+            self._kill_process_tree(worker_processes[0])
+
+            # The scheduler still considers the killed worker alive (see WORKER_TIMEOUT_SECONDS) and keeps routing it a
+            # share of these tasks.
+            for _ in range(N_TASKS):
+                client.submit(round, 3.14)
+
+            time.sleep(1.0)  # let the scheduler process the submitted tasks
+
+            self.__assert_new_client_can_run_task(address)
+
+        combo.shutdown()
+
+    def __wait_for_worker_processes(self, worker_manager_pid: int, expected_count: int) -> List[psutil.Process]:
+        """Waits until the worker manager has spawned expected_count worker processes, and returns them."""
+
+        worker_processes: List[psutil.Process] = []
+
+        while len(worker_processes) < expected_count:
+            worker_processes = psutil.Process(worker_manager_pid).children()
+            time.sleep(0.1)
+
+        return worker_processes
+
+    def __assert_new_client_can_run_task(self, address: str) -> None:
+        """
+        Fails if a new client cannot connect to the scheduler, submit a task and get its result within
+        CLIENT_TIMEOUT_SECONDS.
+        """
+
+        CLIENT_TIMEOUT_SECONDS = 2.0
+
+        outcome = concurrent.futures.Future()
+
+        def connect_and_run_task() -> None:
+            try:
+                with Client(address=address) as new_client:
+                    outcome.set_result(new_client.submit(round, 3.14).result())
+            except BaseException as exception:
+                outcome.set_exception(exception)
+
+        # A daemon thread, as connecting blocks forever if the scheduler is unresponsive.
+        threading.Thread(target=connect_and_run_task, daemon=True).start()
+
+        try:
+            self.assertEqual(outcome.result(timeout=CLIENT_TIMEOUT_SECONDS), 3)
+        except concurrent.futures.TimeoutError:
+            self.fail("a new client could not run a task: the scheduler is stuck sending to the dead worker")
+
+    @staticmethod
+    def _kill_process_tree(process: psutil.Process) -> None:
+        """Abruptly kills a process and all of its descendants with SIGKILL, so that none of them can clean up."""
+
+        try:
+            members = [process, *process.children(recursive=True)]
+        except psutil.NoSuchProcess:
+            return
+
+        for member in members:
+            try:
+                member.kill()
+            except psutil.NoSuchProcess:
+                pass
+
+        psutil.wait_procs(members)

--- a/tests/scheduler/test_dead_worker.py
+++ b/tests/scheduler/test_dead_worker.py
@@ -79,7 +79,7 @@ class TestDeadWorker(unittest.TestCase):
 
         CLIENT_TIMEOUT_SECONDS = 2.0
 
-        outcome = concurrent.futures.Future()
+        outcome: concurrent.futures.Future = concurrent.futures.Future()
 
         def connect_and_run_task() -> None:
             try:

--- a/tests/worker_manager_adapter/test_task_manager.py
+++ b/tests/worker_manager_adapter/test_task_manager.py
@@ -501,7 +501,7 @@ class TestTaskManagerOnTaskResult(unittest.IsolatedAsyncioTestCase):
         result = TaskResult(taskId=task.taskId, resultType=TaskResultType.success, metadata=b"", results=[])
         await self.tm.on_task_result(result)
 
-        self.connector_external.send.assert_called_once_with(result)
+        self.connector_external.send.assert_called_once_with(result, detached=True)
         self.assertNotIn(task.taskId, self.tm._processing_task_ids)
         self.assertNotIn(task.taskId, self.tm._task_id_to_task)
         self.backend.on_cleanup.assert_not_called()


### PR DESCRIPTION
Allows `send()` calls to be executed asynchronously, preventing the scheduler to be unresponsive in some events (e.g. during a worker being unexpectedly killed).

The unit-test I added seems to surface another issue: https://github.com/finos/opengris-scaler/issues/924 (will be solved in another PR).
