### PR TITLE
test: bound the dead worker test's setup wait and always tear its cluster down

### DIFF
--- a/tests/scheduler/test_dead_worker.py
+++ b/tests/scheduler/test_dead_worker.py
@@ -39,6 +39,7 @@ class TestDeadWorker(unittest.TestCase):
         combo = SchedulerClusterCombo(
             address=address, n_workers=N_WORKERS, worker_timeout_seconds=WORKER_TIMEOUT_SECONDS
         )
+        self.addCleanup(combo.shutdown)
 
         with Client(address=address) as client:
             # Ensures the workers are connected and registered by the scheduler.
@@ -58,14 +59,18 @@ class TestDeadWorker(unittest.TestCase):
 
             self.__assert_new_client_can_run_task(address)
 
-        combo.shutdown()
-
     def __wait_for_worker_processes(self, worker_manager_pid: int, expected_count: int) -> List[psutil.Process]:
         """Waits until the worker manager has spawned expected_count worker processes, and returns them."""
 
+        WORKER_SPAWN_TIMEOUT_SECONDS = 30.0
+
+        deadline = time.time() + WORKER_SPAWN_TIMEOUT_SECONDS
         worker_processes: List[psutil.Process] = []
 
         while len(worker_processes) < expected_count:
+            if time.time() > deadline:
+                self.fail(f"only {len(worker_processes)} of {expected_count} workers started in time")
+
             worker_processes = psutil.Process(worker_manager_pid).children()
             time.sleep(0.1)
 


### PR DESCRIPTION
The wait for the worker processes to appear had no deadline, so a worker manager that never spawns them hangs the run instead of failing it, and the cluster was only shut down on the path where every assertion held -- a failing one leaves a scheduler, a worker manager and its workers behind for the rest of the suite.

Neither is what makes this test flaky today. It kills a worker, and once the scheduler times that worker out it reroutes its tasks; if one of them is being cancelled at that moment the scheduler dies of an unrelated bug, and the test then wedges in teardown rather than failing. This only makes sure that when it does fail, it fails.