### PR TITLE
fix: scale to the work, not to a task-to-worker ratio

### DIFF
--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/capability_scaling.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from math import ceil
 from typing import Dict, FrozenSet, List, Tuple
 
 from scaler.protocol.capnp import ScalingManagerStatus, WorkerManagerCommand, WorkerManagerHeartbeat
@@ -14,13 +13,10 @@ class CapabilityScalingPolicy(ScalingPolicy):
     """
     A stateless scaling policy that scales workers based on task-required capabilities.
 
-    For each distinct capability set observed in pending tasks, it computes a desired worker
-    count using a task-to-worker ratio threshold. The desired counts are sent declaratively
+    For each distinct capability set observed in pending tasks, it asks for one worker per task,
+    bounded by the manager's maximum task concurrency. The desired counts are sent declaratively
     via setDesiredTaskConcurrency; the worker manager is responsible for making it so.
     """
-
-    def __init__(self):
-        self._upper_task_ratio = 5
 
     def get_scaling_commands(
         self,
@@ -55,15 +51,18 @@ class CapabilityScalingPolicy(ScalingPolicy):
     ) -> List[Tuple[Dict[str, int], int]]:
         """Compute desired worker count per capability set from observed tasks.
 
+        A worker runs one task at a time, so the worker count is the cluster's parallelism: ask for
+        one worker per outstanding task. maxTaskConcurrency is what bounds that, and asking for less
+        than it while tasks are outstanding leaves capacity the operator paid for standing idle.
+
         Capsets with zero tasks are omitted (declarative "no opinion" for that capset).
-        Each desired count is clamped by the manager's maxTaskConcurrency.
         """
         max_concurrency = worker_manager_heartbeat.maxTaskConcurrency
         result: List[Tuple[Dict[str, int], int]] = []
         for _capability_keys, tasks in tasks_by_capability.items():
             if not tasks:
                 continue
-            desired = max(1, ceil(len(tasks) / self._upper_task_ratio))
+            desired = len(tasks)
             if max_concurrency != -1:
                 desired = min(desired, max_concurrency)
             # Use first task's concrete capability dict as the representative for the capset.

--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
@@ -1,4 +1,3 @@
-from math import ceil
 from typing import Dict, List, Tuple
 
 from scaler.protocol.capnp import ScalingManagerStatus, WorkerManagerCommand, WorkerManagerHeartbeat
@@ -11,12 +10,9 @@ from scaler.utility.snapshot import InformationSnapshot
 
 class VanillaScalingPolicy(ScalingPolicy):
     """
-    Stateless scaling policy that scales workers based on task-to-worker ratio.
+    Stateless scaling policy that asks for one worker per outstanding task, bounded by the manager's
+    maximum task concurrency.
     """
-
-    def __init__(self):
-        self._lower_task_ratio = 1
-        self._upper_task_ratio = 10
 
     def get_scaling_commands(
         self,
@@ -38,21 +34,13 @@ class VanillaScalingPolicy(ScalingPolicy):
         worker_manager_heartbeat: WorkerManagerHeartbeat,
         managed_worker_ids: List[WorkerID],
     ) -> int:
-        """Compute the target worker count for this manager from current task and worker observations."""
-        current = len(managed_worker_ids)
-        task_count = len(information_snapshot.tasks)
-        worker_count = len(information_snapshot.workers)
+        """Compute the target worker count for this manager from the current task observation.
 
-        if worker_count == 0:
-            desired = current + 1 if task_count > 0 else current
-        else:
-            task_ratio = task_count / worker_count
-            if task_ratio > self._upper_task_ratio:
-                desired = current + 1
-            elif task_ratio < self._lower_task_ratio:
-                desired = 0 if task_count == 0 else max(1, ceil(task_count / self._upper_task_ratio))
-            else:
-                desired = current
+        A worker runs one task at a time, so the worker count is the cluster's parallelism: ask for one
+        worker per outstanding task. maxTaskConcurrency is what bounds that, and asking for less than it
+        while tasks are outstanding leaves capacity the operator paid for standing idle.
+        """
+        desired = len(information_snapshot.tasks)
 
         max_concurrency = worker_manager_heartbeat.maxTaskConcurrency
         if max_concurrency != -1:

--- a/tests/scheduler/test_scaling.py
+++ b/tests/scheduler/test_scaling.py
@@ -184,18 +184,22 @@ class TestVanillaScalingPolicy(unittest.TestCase):
 
         self.assertEqual(request.taskConcurrency, 0)
 
-    def test_tasks_with_no_workers_targets_one(self):
-        """Tasks present but no workers: desired = 1 to bootstrap."""
+    def test_tasks_with_no_workers_targets_one_worker_per_task(self):
+        """Tasks present but no workers: every task gets a worker straight away."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(5)}
         snapshot = InformationSnapshot(tasks=tasks, workers={})
         heartbeat = _create_worker_manager_heartbeat(b"mgr")
 
         request = self._single_request(snapshot, heartbeat, [])
 
-        self.assertEqual(request.taskConcurrency, 1)
+        self.assertEqual(request.taskConcurrency, 5)
 
-    def test_high_task_ratio_targets_current_plus_one(self):
-        """Task/worker ratio above upper threshold scales by +1 toward equilibrium."""
+    def test_more_tasks_than_capacity_targets_the_maximum(self):
+        """More tasks than the manager can run: desired is the manager's maximum task concurrency.
+
+        A worker runs one task at a time, so anything less caps the run's parallelism and leaves the
+        rest of the fleet idle.
+        """
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(20)}
         managed = [WorkerID(b"w0")]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=5) for wid in managed}
@@ -204,7 +208,7 @@ class TestVanillaScalingPolicy(unittest.TestCase):
 
         request = self._single_request(snapshot, heartbeat, managed)
 
-        self.assertEqual(request.taskConcurrency, 2)
+        self.assertEqual(request.taskConcurrency, 10)
 
     def test_no_tasks_with_workers_targets_zero(self):
         """No tasks but managers exist: desired drains to 0."""
@@ -221,8 +225,8 @@ class TestVanillaScalingPolicy(unittest.TestCase):
 
         self.assertEqual(request.taskConcurrency, 0)
 
-    def test_few_tasks_with_many_workers_targets_min_keep(self):
-        """Low task ratio shrinks toward ceil(tasks / upper_task_ratio) min_keep."""
+    def test_few_tasks_with_many_workers_shrinks_to_the_task_count(self):
+        """More workers than tasks: shrink to the outstanding task count, never below it."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(5)}
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(10)}
         managed = list(workers.keys())
@@ -231,11 +235,10 @@ class TestVanillaScalingPolicy(unittest.TestCase):
 
         request = self._single_request(snapshot, heartbeat, managed)
 
-        # ceil(5 / 10) = 1 minimum to keep
-        self.assertEqual(request.taskConcurrency, 1)
+        self.assertEqual(request.taskConcurrency, 5)
 
     def test_max_concurrency_clamps_then_emits(self):
-        """Ratio asks for current+1 but cap clamps to current -> emits setDesired(current)."""
+        """The manager's maximum task concurrency bounds the request."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(50)}
         managed = [WorkerID(b"w0"), WorkerID(b"w1")]
         workers = {wid: _create_mock_worker_heartbeat({}, queued_tasks=20) for wid in managed}
@@ -244,8 +247,17 @@ class TestVanillaScalingPolicy(unittest.TestCase):
 
         request = self._single_request(snapshot, heartbeat, managed)
 
-        # Ratio would say desired=3, cap clamps to 2; emits setDesired(2).
         self.assertEqual(request.taskConcurrency, 2)
+
+    def test_unlimited_concurrency_asks_for_one_worker_per_task(self):
+        """maxTaskConcurrency of -1 means no limit, so nothing bounds the request but the task count."""
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(7)}
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=-1)
+
+        request = self._single_request(snapshot, heartbeat, [])
+
+        self.assertEqual(request.taskConcurrency, 7)
 
 
 class TestAtCapacityEmission(unittest.TestCase):
@@ -257,7 +269,7 @@ class TestAtCapacityEmission(unittest.TestCase):
         setup_logger()
 
     def test_vanilla_at_cap_emits_current(self):
-        """Vanilla: ratio asks for current+1, cap clamps to current -> emits setDesired(current)."""
+        """Vanilla: already at the manager's maximum -> re-emits that maximum."""
         policy = VanillaScalingPolicy()
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
         managed = [WorkerID(f"w{i}".encode()) for i in range(10)]
@@ -272,7 +284,7 @@ class TestAtCapacityEmission(unittest.TestCase):
         self.assertEqual(requests[0].taskConcurrency, 10)
 
     def test_vanilla_changes_emit(self):
-        """Vanilla: when ratio's desired differs from current connected, emit."""
+        """Vanilla: when the desired count differs from current connected, emit."""
         policy = VanillaScalingPolicy()
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(100)}
         managed = [WorkerID(b"w0")]
@@ -284,7 +296,7 @@ class TestAtCapacityEmission(unittest.TestCase):
 
         self.assertEqual(len(commands), 1)
         requests = list(commands[0].setDesiredTaskConcurrencyRequests)
-        self.assertEqual(requests[0].taskConcurrency, 2)
+        self.assertEqual(requests[0].taskConcurrency, 10)
 
     def test_capability_at_cap_emits_current(self):
         """Capability: ratio's per-capset desired equals current connected -> emits setDesired(current)."""
@@ -399,7 +411,7 @@ class TestCapabilityScalingPolicy(unittest.TestCase):
         self.assertIn(frozenset({"tpu"}), caps_in_requests)
 
     def test_high_task_count_scales_per_capset(self):
-        """Many tasks for one capset: desired = ceil(task_count / upper_task_ratio)."""
+        """More tasks than the manager can run: desired is the manager's maximum task concurrency."""
         tasks = {}
         for _ in range(20):
             tid = TaskID.generate_task_id()
@@ -411,8 +423,56 @@ class TestCapabilityScalingPolicy(unittest.TestCase):
 
         requests = list(command.setDesiredTaskConcurrencyRequests)
         self.assertEqual(len(requests), 1)
-        # ceil(20 / 5) = 4
-        self.assertEqual(requests[0].taskConcurrency, 4)
+        self.assertEqual(requests[0].taskConcurrency, 10)  # the heartbeat's maxTaskConcurrency
+
+    def test_desired_covers_every_task_the_manager_can_run(self):
+        """Fewer tasks than the fleet allows: every task gets a worker.
+
+        A worker runs one task at a time, so asking for fewer workers than there are tasks caps the
+        run's parallelism and leaves the rest of the fleet idle.
+        """
+        tasks = {}
+        for _ in range(6):
+            tid = TaskID.generate_task_id()
+            tasks[tid] = _create_mock_task(tid, {})
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=20)
+
+        command = self._commands(snapshot, heartbeat, [])
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].taskConcurrency, 6)
+
+    def test_desired_never_drops_below_the_outstanding_task_count(self):
+        """Workers already running the tasks must not be scaled away underneath them."""
+        tasks = {}
+        for _ in range(4):
+            tid = TaskID.generate_task_id()
+            tasks[tid] = _create_mock_task(tid, {})
+        managed = [WorkerID(f"w{i}".encode()) for i in range(4)]
+        workers = {worker_id: _create_mock_worker_heartbeat({}, queued_tasks=1) for worker_id in managed}
+        snapshot = InformationSnapshot(tasks=tasks, workers=workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=20)
+
+        command = self._commands(snapshot, heartbeat, managed)
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertGreaterEqual(requests[0].taskConcurrency, len(tasks))
+
+    def test_unlimited_concurrency_asks_for_one_worker_per_task(self):
+        """maxTaskConcurrency of -1 means no limit, so nothing bounds the request but the task count."""
+        tasks = {}
+        for _ in range(7):
+            tid = TaskID.generate_task_id()
+            tasks[tid] = _create_mock_task(tid, {})
+        snapshot = InformationSnapshot(tasks=tasks, workers={})
+        heartbeat = _create_worker_manager_heartbeat(b"mgr", max_task_concurrency=-1)
+
+        command = self._commands(snapshot, heartbeat, [])
+
+        requests = list(command.setDesiredTaskConcurrencyRequests)
+        self.assertEqual(requests[0].taskConcurrency, 7)
 
     def test_max_concurrency_clamps_per_capset(self):
         """Per-capset desired clamped by manager's maxTaskConcurrency."""
@@ -487,10 +547,9 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
         requests = list(commands[0].setDesiredTaskConcurrencyRequests)
         self.assertEqual(requests[0].taskConcurrency, 0)
 
-    def test_shrink_to_ratio_floor(self):
-        """With few tasks relative to workers (ratio below lower threshold), the policy
-        targets ceil(tasks/upper_task_ratio) and emits setDesired with that smaller count."""
-        # 5 tasks, 10 connected workers -> ratio 0.5 < 1; floor = max(1, ceil(5/10)) = 1.
+    def test_shrink_to_the_outstanding_task_count(self):
+        """With fewer tasks than connected workers, the policy shrinks to the task count."""
+        # 5 tasks, 10 connected workers, manager maximum 10 -> 5 workers still have work.
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(5)}
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(10)}
         managed = list(workers.keys())
@@ -501,12 +560,14 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
 
         self.assertEqual(len(commands), 1)
         requests = list(commands[0].setDesiredTaskConcurrencyRequests)
-        self.assertEqual(requests[0].taskConcurrency, 1)
+        self.assertEqual(requests[0].taskConcurrency, 5)
 
-    def test_no_action_when_ratio_is_in_band(self):
-        """With the task/worker ratio inside [lower, upper], the policy targets the current
-        worker count and emits setDesired(current) unconditionally."""
-        # 15 tasks, 5 workers -> ratio 3, in [1, 10]; desired = current = 5.
+    def test_grows_to_the_maximum_while_tasks_outnumber_workers(self):
+        """With more tasks than connected workers, the policy grows to the manager's maximum.
+
+        The old ratio band left 15 tasks running on 5 workers indefinitely even though the manager
+        was allowed 10.
+        """
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(15)}
         workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}, queued_tasks=i) for i in range(5)}
         managed = list(workers.keys())
@@ -517,7 +578,7 @@ class TestVanillaDeclarativeEquivalents(unittest.TestCase):
 
         self.assertEqual(len(commands), 1)
         requests = list(commands[0].setDesiredTaskConcurrencyRequests)
-        self.assertEqual(requests[0].taskConcurrency, 5)
+        self.assertEqual(requests[0].taskConcurrency, 10)  # the heartbeat's maxTaskConcurrency
 
     def test_get_status_returns_scaling_manager_status(self):
         """VanillaScalingPolicy.get_status returns a ScalingManagerStatus object."""


### PR DESCRIPTION
A worker runs one task at a time, so the number of workers is the cluster's parallelism. Both simple scaling policies instead target a fixed tasks-per-worker ratio, which caps a run well below the capacity the fleet was configured to allow and shrinks the fleet while work is still outstanding.

Measured with 15 six-second tasks against a manager permitted 10 workers:

  capability  asks for ceil(tasks / 5), so 3 workers; only 3 ever ran anything, and it scaled down
              to 2 and then to 1 while 9 and then 5 tasks were still queued. 57s instead of 12s.
  vanilla     grows by one worker only while tasks outnumber workers ten to one, then parks: the
              ratio lands inside its [1, 10] band and it re-targets its current count forever. It
              stopped at 2 workers. 50s.

Stopping a worker that still has queued tasks also reroutes them and re-executes anything already in flight, so the shrink is not merely wasteful.

Both now ask for one worker per outstanding task, still bounded by the manager's maxTaskConcurrency -- the knob that exists to cap how much capacity a manager may create. The same run asks for 10 and finishes in 22s (worker startup dominates the rest). Shrinking falls out of the same rule, so a fleet still drains to zero when the work is done, but never below the number of tasks still outstanding.

WaterfallScalingPolicy has the same defect and is left alone: it also distributes a cluster-wide target across managers in priority order, so it needs its own change.