### PR TITLE
fix: isolate Python extension module symbols so modules cannot interpose each other

### DIFF
--- a/cmake/ScalerPythonModule.cmake
+++ b/cmake/ScalerPythonModule.cmake
@@ -1,3 +1,6 @@
+# Directory holding this module, used to locate the linker version script below.
+set(SCALER_PYMOD_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
 # Find Python3 development components for the active build interpreter.
 # Rely on CMake/scikit-build selection instead of the system python3-config,
 # which can point at a different ABI than the environment running the build.
@@ -81,6 +84,14 @@ function(scaler_add_python_module)
         # Hide symbols from statically linked 3rd-party library (e.g. OpenSSL), avoiding conflicts when loading multiple
         # modules from the same Python process.
         target_link_options(${PYMOD_TARGET} PRIVATE "LINKER:--exclude-libs,ALL")
+
+        # --exclude-libs and CXX_VISIBILITY_PRESET do not reach OBJECT libraries (ymq_objs, protocol_objs,
+        # object_storage_server_objs), whose objects are linked in directly rather than through an archive. The version
+        # script is applied to the final link, so it keeps every symbol but PyInit_<module> local.
+        target_link_options(${PYMOD_TARGET} PRIVATE
+            "LINKER:--version-script=${SCALER_PYMOD_CMAKE_DIR}/scaler_pymod_exports.map")
+        set_property(TARGET ${PYMOD_TARGET} APPEND PROPERTY
+            LINK_DEPENDS "${SCALER_PYMOD_CMAKE_DIR}/scaler_pymod_exports.map")
     endif()
 
     if(WIN32)

--- a/cmake/ScalerPythonModule.cmake
+++ b/cmake/ScalerPythonModule.cmake
@@ -1,4 +1,4 @@
-# Directory holding this module, used to locate the linker version script below.
+# Directory holding this module, used to locate the linker symbol scripts below.
 set(SCALER_PYMOD_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 # Find Python3 development components for the active build interpreter.
@@ -80,18 +80,24 @@ function(scaler_add_python_module)
         VISIBILITY_INLINES_HIDDEN ON
     )
 
+    # CXX_VISIBILITY_PRESET misses the static archives and the OBJECT libraries linked into the module, so ymq
+    # and its OpenSSL stay exported and one module ends up driving another module's OpenSSL, corrupting its TLS
+    # state. The linker scripts apply to the final link and cover both.
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-        # Hide symbols from statically linked 3rd-party library (e.g. OpenSSL), avoiding conflicts when loading multiple
-        # modules from the same Python process.
         target_link_options(${PYMOD_TARGET} PRIVATE "LINKER:--exclude-libs,ALL")
-
-        # --exclude-libs and CXX_VISIBILITY_PRESET do not reach OBJECT libraries (ymq_objs, protocol_objs,
-        # object_storage_server_objs), whose objects are linked in directly rather than through an archive. The version
-        # script is applied to the final link, so it keeps every symbol but PyInit_<module> local.
         target_link_options(${PYMOD_TARGET} PRIVATE
             "LINKER:--version-script=${SCALER_PYMOD_CMAKE_DIR}/scaler_pymod_exports.map")
         set_property(TARGET ${PYMOD_TARGET} APPEND PROPERTY
             LINK_DEPENDS "${SCALER_PYMOD_CMAKE_DIR}/scaler_pymod_exports.map")
+    endif()
+
+    if(APPLE)
+        # A two-level namespace does not save us here: dyld coalesces weak definitions (inline functions and
+        # variables, templates, vtables) across images. Private externs are not coalesced.
+        target_link_options(${PYMOD_TARGET} PRIVATE
+            "LINKER:-exported_symbols_list,${SCALER_PYMOD_CMAKE_DIR}/scaler_pymod_exports.sym")
+        set_property(TARGET ${PYMOD_TARGET} APPEND PROPERTY
+            LINK_DEPENDS "${SCALER_PYMOD_CMAKE_DIR}/scaler_pymod_exports.sym")
     endif()
 
     if(WIN32)

--- a/cmake/scaler_pymod_exports.map
+++ b/cmake/scaler_pymod_exports.map
@@ -1,0 +1,19 @@
+# Linker version script for Scaler's Python extension modules.
+#
+# A Python extension module only needs to expose its PyInit_<module> entry-point. Everything else stays
+# local so that two modules loaded into the same interpreter cannot interpose each other's symbols.
+#
+# This matters because several modules statically link the same code (ymq, the OpenSSL wrapper, the
+# Cap'n Proto protocol objects) and each gets its own copy of the third-party global state. With default
+# ELF visibility the copy that is loaded first wins for every duplicated symbol, so one module ends up
+# calling into another module's OpenSSL instance and corrupting its TLS state.
+#
+# CXX_VISIBILITY_PRESET and --exclude-libs cover the module's own sources and the static archives it
+# links, but not CMake OBJECT libraries, whose objects are linked in directly. The version script covers
+# every case because it is applied to the final link.
+{
+    global:
+        PyInit_*;
+    local:
+        *;
+};

--- a/cmake/scaler_pymod_exports.map
+++ b/cmake/scaler_pymod_exports.map
@@ -1,16 +1,5 @@
-# Linker version script for Scaler's Python extension modules.
-#
-# A Python extension module only needs to expose its PyInit_<module> entry-point. Everything else stays
-# local so that two modules loaded into the same interpreter cannot interpose each other's symbols.
-#
-# This matters because several modules statically link the same code (ymq, the OpenSSL wrapper, the
-# Cap'n Proto protocol objects) and each gets its own copy of the third-party global state. With default
-# ELF visibility the copy that is loaded first wins for every duplicated symbol, so one module ends up
-# calling into another module's OpenSSL instance and corrupting its TLS state.
-#
-# CXX_VISIBILITY_PRESET and --exclude-libs cover the module's own sources and the static archives it
-# links, but not CMake OBJECT libraries, whose objects are linked in directly. The version script covers
-# every case because it is applied to the final link.
+# Keep every symbol but the PyInit_<module> entry-point local, so that two modules loaded into the same
+# interpreter cannot interpose each other. See ScalerPythonModule.cmake.
 {
     global:
         PyInit_*;

--- a/cmake/scaler_pymod_exports.sym
+++ b/cmake/scaler_pymod_exports.sym
@@ -1,0 +1,2 @@
+# Mach-O counterpart of scaler_pymod_exports.map. See ScalerPythonModule.cmake.
+_PyInit_*

--- a/tests/client/test_tls.py
+++ b/tests/client/test_tls.py
@@ -37,7 +37,6 @@ class TestClientTLS(unittest.TestCase):
     def tearDown(self) -> None:
         self.combo.shutdown()
 
-    @unittest.skip("OSS fail with EPROTO when started as a Combo")
     def test_submit(self):
         self.assertTrue(self.address.startswith("tls://"))
 


### PR DESCRIPTION
Fixes #869.

`_ymq.so`, `object_storage_server.so` and `capnp.so` all statically link ymq and its OpenSSL wrapper, and `ObjectStorageServerProcess` loads the first two into one interpreter. Duplicated symbols leak out of both, so the object storage server drives the other module's OpenSSL instance, corrupting the server-side TLS state and failing the handshake with `EPROTO`.

Diagnosis credit to @e117649 in https://github.com/finos/opengris-scaler/issues/842#issuecomment-4877547237.

`CXX_VISIBILITY_PRESET hidden` and `--exclude-libs,ALL` from #885 hide the module's own sources and its static archives, which is enough to make the reported failure go away today, but not the OBJECT libraries (`ymq_objs`, `protocol_objs`, `object_storage_server_objs`). On `main`, 189 `scaler::ymq` / `scaler::wrapper` symbols still leak from both modules, including ones that carry an `SSL*` or `SSL_CTX*` across the boundary:

```
scaler::ymq::internal::Client::Client(scaler::wrapper::openssl::SecureSocket)
scaler::ymq::internal::WebSocketStream::init(uv::Loop&, std::optional<openssl::SSLContext>)
```

So instead of chasing visibility per source, restrict the export list at the final link, where every object is covered: `--version-script` on Linux, `-exported_symbols_list` on macOS. On Linux the three modules go from 568 / 833 / 132 exported symbols to exactly one each, `PyInit_<module>`.

macOS needs this too. A two-level namespace stops one module from interposing another's *strong* symbols, but dyld coalesces *weak* definitions (inline functions and variables, templates, vtables) across images regardless. `SSLContext::defaultSSLMethod` is an `inline static` initialized from `TLS_method()`: both modules define it, dyld keeps one, and the loser's `SSL_CTX_new` gets the winner's method table. Private externs are not coalesced.

The TLS combo test is un-skipped, which puts it back under CI on all three platforms.
