### PR TITLE
fix: don't scale a worker manager up from zero on a low task ratio

### DIFF
--- a/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
+++ b/src/scaler/scheduler/controllers/policies/simple_policy/scaling/vanilla.py
@@ -64,7 +64,10 @@ class VanillaScalingPolicy(ScalingPolicy):
             if task_ratio > self._upper_task_ratio:
                 desired = current + 1
             elif task_ratio < self._lower_task_ratio:
-                desired = 0 if task_count == 0 else max(1, ceil(task_count / self._upper_task_ratio))
+                if task_count == 0 or current == 0:
+                    desired = 0
+                else:
+                    desired = max(1, ceil(task_count / self._upper_task_ratio))
             else:
                 desired = current
 

--- a/tests/scheduler/test_scaling.py
+++ b/tests/scheduler/test_scaling.py
@@ -234,6 +234,20 @@ class TestVanillaScalingPolicy(unittest.TestCase):
         # ceil(5 / 10) = 1 minimum to keep
         self.assertEqual(request.taskConcurrency, 1)
 
+    def test_low_ratio_with_no_managed_workers_targets_zero(self):
+        """Low task/worker ratio and current=0: don't scale up via the low-ratio branch.
+        This prevents oscillation when another manager's workers cover the load but their
+        ratio momentarily drops below the lower threshold (e.g. one task left, two OCI workers)."""
+        tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(1)}
+        other_workers = {WorkerID(f"w{i}".encode()): _create_mock_worker_heartbeat({}) for i in range(2)}
+        snapshot = InformationSnapshot(tasks=tasks, workers=other_workers)
+        heartbeat = _create_worker_manager_heartbeat(b"mgr")
+
+        request = self._single_request(snapshot, heartbeat, [])
+
+        # task_ratio = 1/2 = 0.5 < lower_task_ratio=1, but current=0 -> desired=0, not 1
+        self.assertEqual(request.taskConcurrency, 0)
+
     def test_max_concurrency_clamps_then_emits(self):
         """Ratio asks for current+1 but cap clamps to current -> emits setDesired(current)."""
         tasks = {TaskID.generate_task_id(): _create_mock_task(TaskID.generate_task_id(), {}) for _ in range(50)}


### PR DESCRIPTION
`VanillaScalingPolicy`'s low-ratio branch computed a desired count from the task count alone, so a worker manager with no connected workers was asked for one whenever the ratio dipped below the lower threshold. The ratio is computed across the whole snapshot, so it can dip because *another* manager's workers are already covering the load: one task left with two OCI workers on a different manager was enough to spin an idle manager up, which then drained again on the next tick.

Treat a manager that currently has no workers the same as no tasks at all -- the low-ratio branch targets zero, and scale-up is left to the upper-ratio branch that bootstraps a manager when work genuinely needs it.

Split out of #847, where it had been bundled into an unrelated commit.
