### PR TITLE
docs: enable scaling in the all-in-one scaler example config

### DIFF
--- a/docs/source/tutorials/commands.rst
+++ b/docs/source/tutorials/commands.rst
@@ -94,7 +94,7 @@ Scaler examples
             # advertised_object_storage_address = "tcp://203.0.113.10:6379"
             monitor_address = "tcp://127.0.0.1:6380"
             policy_engine_type = "simple"
-            policy_content = "allocate=even_load; scaling=no"
+            policy_content = "allocate=even_load; scaling=vanilla"
             logging_level = "INFO"
 
             [gui]


### PR DESCRIPTION
The example `config.toml` in the `scaler` section pairs a `[[worker_manager]]` with `scaling=no`, so the scheduler never asks the manager for workers and a cluster copied from the docs starts none. Switch it to `scaling=vanilla`, the default in `SchedulerConfig`.

Fixes #973