### PR TITLE
fix: two cancel races that crash the proxy worker manager

### DIFF
--- a/src/scaler/worker_manager_adapter/task_manager.py
+++ b/src/scaler/worker_manager_adapter/task_manager.py
@@ -82,7 +82,13 @@ class TaskManager(Looper, TaskManagerMixin):
 
         if self._executor_semaphore.locked():
             for acquired_task_id in self._acquiring_task_ids:
-                acquired_task = self._task_id_to_task[acquired_task_id]
+                acquired_task = self._task_id_to_task.get(acquired_task_id)
+                if acquired_task is None:
+                    # Only a bookkeeping bug puts an id here without its task. Skipping it costs one
+                    # priority comparison, where raising would take down the worker and every task on it.
+                    logger.error(f"Acquired task is not in the worker queue: task_id={acquired_task_id.hex()}")
+                    continue
+
                 acquired_task_priority = self._get_task_priority(acquired_task)
                 if task_priority <= acquired_task_priority:
                     break
@@ -135,9 +141,6 @@ class TaskManager(Looper, TaskManagerMixin):
     async def on_task_result(self, result: TaskResult) -> None:
         # Required by TaskManagerMixin but not dispatched from WorkerProcess.__on_receive_external.
         # WorkerProcess drives result handling via resolve_tasks() instead.
-        # NOTE: _queued_task_ids is not cleaned up by resolve_tasks(), so completed tasks whose IDs
-        # are still in _queued_task_ids will be cleared here if this method is ever called, but in
-        # normal operation those IDs accumulate until the WorkerProcess exits.
         if result.taskId in self._queued_task_ids:
             self._queued_task_ids.remove(result.taskId)
             self._queued_task_id_queue.remove(result.taskId)
@@ -161,57 +164,73 @@ class TaskManager(Looper, TaskManagerMixin):
         done, _ = await asyncio.wait(self._task_id_to_future.values(), return_when=asyncio.FIRST_COMPLETED)
         for future in done:
             task_id = self._task_id_to_future.inv.pop(future)
-            task = self._task_id_to_task.get(task_id)
+            try:
+                await self._report_task_outcome(task_id, future)
+            finally:
+                self._release_task(task_id)
 
-            if task is None:
-                logger.warning(f"Cannot find task in worker queue: task_id={task_id.hex()}")
-                continue
+    async def _report_task_outcome(self, task_id: TaskID, future: asyncio.Future) -> None:
+        task = self._task_id_to_task.get(task_id)
 
-            if task_id in self._processing_task_ids:
-                self._processing_task_ids.remove(task_id)
+        if task is None:
+            logger.warning(f"Cannot find task in worker queue: task_id={task_id.hex()}")
+            return
 
-                if future.exception() is None:
-                    serializer_id = ObjectID.generate_serializer_object_id(task.source)
-                    serializer = self._serializers[serializer_id]
-                    result_bytes = serializer.serialize(future.result())
-                    result_type = TaskResultType.success
-                else:
-                    result_bytes = serialize_failure(cast(Exception, future.exception()))
-                    result_type = TaskResultType.failed
+        if task_id in self._processing_task_ids:
+            self._processing_task_ids.remove(task_id)
+            await self._send_task_result(task_id, task, future)
+            return
 
-                result_object_id = ObjectID.generate_object_id(task.source)
+        if task_id in self._canceled_task_ids:
+            self._canceled_task_ids.remove(task_id)
+            return
 
-                await self._connector_storage.set_object(result_object_id, result_bytes)
-                await self._connector_external.send(
-                    ObjectInstruction(
-                        instructionType=ObjectInstruction.ObjectInstructionType.create,
-                        objectUser=task.source,
-                        objectMetadata=ObjectMetadata(
-                            objectIds=(result_object_id,),
-                            objectTypes=(ObjectMetadata.ObjectContentType.object,),
-                            objectNames=(f"<res {result_object_id.hex()[:6]}>".encode(),),
-                        ),
-                    ),
-                    detached=True,
-                )
+        raise ValueError(f"task_id {task_id.hex()} not found in processing or canceled tasks")
 
-                await self._connector_external.send(
-                    TaskResult(taskId=task_id, resultType=result_type, metadata=b"", results=[bytes(result_object_id)]),
-                    detached=True,
-                )
+    async def _send_task_result(self, task_id: TaskID, task: Task, future: asyncio.Future) -> None:
+        if future.exception() is None:
+            serializer_id = ObjectID.generate_serializer_object_id(task.source)
+            serializer = self._serializers[serializer_id]
+            result_bytes = serializer.serialize(future.result())
+            result_type = TaskResultType.success
+        else:
+            result_bytes = serialize_failure(cast(Exception, future.exception()))
+            result_type = TaskResultType.failed
 
-            elif task_id in self._canceled_task_ids:
-                self._canceled_task_ids.remove(task_id)
+        result_object_id = ObjectID.generate_object_id(task.source)
 
-            else:
-                raise ValueError(f"task_id {task_id.hex()} not found in processing or canceled tasks")
+        await self._connector_storage.set_object(result_object_id, result_bytes)
+        await self._connector_external.send(
+            ObjectInstruction(
+                instructionType=ObjectInstruction.ObjectInstructionType.create,
+                objectUser=task.source,
+                objectMetadata=ObjectMetadata(
+                    objectIds=(result_object_id,),
+                    objectTypes=(ObjectMetadata.ObjectContentType.object,),
+                    objectNames=(f"<res {result_object_id.hex()[:6]}>".encode(),),
+                ),
+            ),
+            detached=True,
+        )
 
-            if task_id in self._acquiring_task_ids:
-                self._acquiring_task_ids.remove(task_id)
-                self._executor_semaphore.release()
+        await self._connector_external.send(
+            TaskResult(taskId=task_id, resultType=result_type, metadata=b"", results=[bytes(result_object_id)]),
+            detached=True,
+        )
 
-            self._task_id_to_task.pop(task_id)
-            self._execution_backend.on_cleanup(task_id)
+    def _release_task(self, task_id: TaskID) -> None:
+        """Drop what the worker still holds for a finished task and give back the permit it took.
+
+        Every way a task can end runs through here, including the ones that report nothing. An id left
+        in _acquiring_task_ids after its task is gone is what on_task_new looks up, and a permit left
+        unreleased costs the worker one unit of concurrency for the rest of its life.
+        """
+        if task_id in self._acquiring_task_ids:
+            self._acquiring_task_ids.remove(task_id)
+            self._executor_semaphore.release()
+
+        self._task_id_to_task.pop(task_id, None)
+        self._execution_backend.on_cleanup(task_id)
 
     async def routine(self) -> None:
         pass
@@ -224,7 +243,10 @@ class TaskManager(Looper, TaskManagerMixin):
 
         self._acquiring_task_ids.add(task_id)
         self._processing_task_ids.add(task_id)
-        # _queued_task_ids intentionally not cleared here; on_cancel_task and on_task_result clear it.
+        # A task that has been picked up is no longer queued. Leaving it in _queued_task_ids made
+        # on_cancel_task treat a task already in flight as one still waiting, and drop the task its
+        # future would later be resolved against.
+        self._queued_task_ids.discard(task_id)
         self._task_id_to_future[task.taskId] = await self._execution_backend.execute(task)
 
     @property

--- a/src/scaler/worker_manager_adapter/task_manager.py
+++ b/src/scaler/worker_manager_adapter/task_manager.py
@@ -84,10 +84,13 @@ class TaskManager(Looper, TaskManagerMixin):
             for acquired_task_id in self._acquiring_task_ids:
                 acquired_task = self._task_id_to_task.get(acquired_task_id)
                 if acquired_task is None:
-                    # Only a bookkeeping bug puts an id here without its task. Skipping it costs one
-                    # priority comparison, where raising would take down the worker and every task on it.
+                    # Only a bookkeeping bug puts an id here without its task, and this loop is the
+                    # wrong place to pay for it: raising takes down the worker and every task on it,
+                    # and skipping the id lets the loop finish without a break, which bypasses the
+                    # concurrency limit. Stop instead, so the task queues the way it would have if the
+                    # id had belonged to a task of at least its priority.
                     logger.error(f"Acquired task is not in the worker queue: task_id={acquired_task_id.hex()}")
-                    continue
+                    break
 
                 acquired_task_priority = self._get_task_priority(acquired_task)
                 if task_priority <= acquired_task_priority:

--- a/src/scaler/worker_manager_adapter/task_manager.py
+++ b/src/scaler/worker_manager_adapter/task_manager.py
@@ -127,8 +127,13 @@ class TaskManager(Looper, TaskManagerMixin):
             self._task_id_to_task.pop(task_cancel.taskId)
 
         if task_processing:
-            future = self._task_id_to_future[task_cancel.taskId]
-            future.cancel()
+            # A task counts as processing from before execute() returns, so its future may not be
+            # recorded yet. Marking it cancelled is enough either way: resolve_tasks drops a cancelled
+            # task when its future arrives, whether or not the cancel got to reach into it.
+            future = self._task_id_to_future.get(task_cancel.taskId)
+            if future is not None:
+                future.cancel()
+
             await self._execution_backend.on_cancel(task_cancel)
             self._processing_task_ids.remove(task_cancel.taskId)
             self._canceled_task_ids.add(task_cancel.taskId)

--- a/tests/worker_manager_adapter/test_task_manager.py
+++ b/tests/worker_manager_adapter/test_task_manager.py
@@ -510,6 +510,56 @@ class TestTaskManagerTaskRelease(unittest.IsolatedAsyncioTestCase):
 
         await self.tm.on_task_new(_make_task())
 
+    async def test_a_cancel_that_beats_the_future_being_recorded_is_still_accepted(self) -> None:
+        """execute() is awaited, so a force cancel can arrive while a task has no future yet."""
+        task = _make_task()
+        await self.tm.on_task_new(task)
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_execute(_: Task) -> asyncio.Future:
+            started.set()
+            await release.wait()
+            return asyncio.get_running_loop().create_future()
+
+        self.backend.execute = AsyncMock(side_effect=slow_execute)
+        processing = asyncio.get_running_loop().create_task(self.tm.process_task())
+        await started.wait()
+
+        await self.tm.on_cancel_task(_make_task_cancel(task.taskId, force=True))
+
+        self.assertIn(task.taskId, self.tm._canceled_task_ids)
+        self.assertNotIn(task.taskId, self.tm._processing_task_ids)
+        release.set()
+        await processing
+
+    async def test_the_future_of_a_task_cancelled_that_early_is_still_resolved_away(self) -> None:
+        task = _make_task()
+        await self.tm.on_task_new(task)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+
+        async def slow_execute(_: Task) -> asyncio.Future:
+            started.set()
+            await release.wait()
+            return future
+
+        self.backend.execute = AsyncMock(side_effect=slow_execute)
+        processing = asyncio.get_running_loop().create_task(self.tm.process_task())
+        await started.wait()
+        await self.tm.on_cancel_task(_make_task_cancel(task.taskId, force=True))
+        release.set()
+        await processing
+
+        future.set_result(None)
+        await self.tm.resolve_tasks()
+
+        self.assertNotIn(task.taskId, self.tm._canceled_task_ids)
+        self.assertNotIn(task.taskId, self.tm._acquiring_task_ids)
+        self.assertNotIn(task.taskId, self.tm._task_id_to_task)
+        self.connector_external.send.assert_called()
+
     async def test_a_task_whose_task_is_already_gone_still_gives_back_its_permit(self) -> None:
         task = _make_task()
 

--- a/tests/worker_manager_adapter/test_task_manager.py
+++ b/tests/worker_manager_adapter/test_task_manager.py
@@ -351,7 +351,7 @@ class TestTaskManagerProcessTask(unittest.IsolatedAsyncioTestCase):
         self.assertIn(task.taskId, self.tm._acquiring_task_ids)
         self.assertIs(self.tm._task_id_to_future[task.taskId], fut)
         self.assertEqual(self.tm.get_queued_size(), 0)
-        self.assertIn(task.taskId, self.tm._queued_task_ids)
+        self.assertNotIn(task.taskId, self.tm._queued_task_ids)
         self.assertTrue(self.tm._executor_semaphore.locked())
 
 
@@ -444,6 +444,94 @@ class TestTaskManagerResolveTasks(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(task.taskId, self.tm._task_id_to_task)
         self.backend.on_cleanup.assert_called_once_with(task.taskId)
         self.assertFalse(self.tm._executor_semaphore.locked())
+
+
+class TestTaskManagerTaskRelease(unittest.IsolatedAsyncioTestCase):
+    """Pins that a task never leaves its id behind in _acquiring_task_ids.
+
+    on_task_new looks every id there up in _task_id_to_task, so an id that outlives its task raises
+    KeyError on the next incoming task, which takes down the worker and every other task on it.
+    """
+
+    def setUp(self) -> None:
+        setup_logger()
+        logging_test_name(self)
+        self.backend = _make_backend()
+        self.connector_external = AsyncMock(spec=AsyncConnector)
+        self.connector_storage = AsyncMock(spec=AsyncObjectStorageConnector)
+        self.heartbeat_manager = MagicMock(spec=HeartbeatManager)
+        self.tm = TaskManager(1, self.backend)
+        self.tm.register(self.connector_external, self.connector_storage, self.heartbeat_manager)
+
+    async def _start_task(self, task: Task) -> asyncio.Future:
+        await self.tm.on_task_new(task)
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self.backend.execute = AsyncMock(return_value=future)
+        await self.tm.process_task()
+        return future
+
+    async def test_a_task_in_flight_is_no_longer_treated_as_queued(self) -> None:
+        task = _make_task()
+
+        await self._start_task(task)
+
+        self.assertNotIn(task.taskId, self.tm._queued_task_ids)
+        self.assertIn(task.taskId, self.tm._processing_task_ids)
+
+    async def test_force_cancelling_a_task_in_flight_keeps_its_task_until_the_future_resolves(self) -> None:
+        """The cancel used to take the queued branch as well, dropping the task the future needs."""
+        task = _make_task()
+
+        await self._start_task(task)
+        await self.tm.on_cancel_task(_make_task_cancel(task.taskId, force=True))
+
+        self.assertIn(task.taskId, self.tm._task_id_to_task)
+        self.assertIn(task.taskId, self.tm._canceled_task_ids)
+
+    async def test_a_force_cancelled_task_leaves_nothing_behind_and_gives_back_its_permit(self) -> None:
+        task = _make_task()
+
+        await self._start_task(task)
+        await self.tm.on_cancel_task(_make_task_cancel(task.taskId, force=True))
+        await self.tm.resolve_tasks()
+
+        self.assertNotIn(task.taskId, self.tm._acquiring_task_ids)
+        self.assertNotIn(task.taskId, self.tm._task_id_to_task)
+        self.assertNotIn(task.taskId, self.tm._canceled_task_ids)
+        self.assertFalse(self.tm._executor_semaphore.locked())
+
+    async def test_a_later_task_arrives_without_raising_after_a_force_cancel(self) -> None:
+        """This is the crash: on_task_new resolving a stranded id against a task that is gone."""
+        cancelled = _make_task()
+
+        await self._start_task(cancelled)
+        await self.tm.on_cancel_task(_make_task_cancel(cancelled.taskId, force=True))
+        await self.tm.resolve_tasks()
+
+        await self.tm.on_task_new(_make_task())
+
+    async def test_a_task_whose_task_is_already_gone_still_gives_back_its_permit(self) -> None:
+        task = _make_task()
+
+        future = await self._start_task(task)
+        future.set_result(None)
+        self.tm._task_id_to_task.pop(task.taskId)
+
+        await self.tm.resolve_tasks()
+
+        self.assertNotIn(task.taskId, self.tm._acquiring_task_ids)
+        self.assertFalse(self.tm._executor_semaphore.locked())
+
+    async def test_an_id_without_its_task_is_skipped_rather_than_raising(self) -> None:
+        """A stranded id has no priority to compare against, so the task goes on rather than the worker down."""
+        stranded = _make_task()
+        self.tm._acquiring_task_ids.add(stranded.taskId)
+        await self.tm._executor_semaphore.acquire()
+        task = _make_task()
+
+        await self.tm.on_task_new(task)
+
+        self.assertIn(task.taskId, self.tm._task_id_to_task)
 
 
 class TestExecutionBackendSentinel(unittest.IsolatedAsyncioTestCase):

--- a/tests/worker_manager_adapter/test_task_manager.py
+++ b/tests/worker_manager_adapter/test_task_manager.py
@@ -572,8 +572,12 @@ class TestTaskManagerTaskRelease(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(task.taskId, self.tm._acquiring_task_ids)
         self.assertFalse(self.tm._executor_semaphore.locked())
 
-    async def test_an_id_without_its_task_is_skipped_rather_than_raising(self) -> None:
-        """A stranded id has no priority to compare against, so the task goes on rather than the worker down."""
+    async def test_an_id_without_its_task_queues_the_next_task_rather_than_raising(self) -> None:
+        """A stranded id has no priority to compare against, so the task queues rather than the worker dying.
+
+        Queuing is the conservative reading: an id that cannot be resolved is no evidence that the
+        arriving task outranks what is in flight, and treating it as such would run the task outside
+        base_concurrency."""
         stranded = _make_task()
         self.tm._acquiring_task_ids.add(stranded.taskId)
         await self.tm._executor_semaphore.acquire()
@@ -581,7 +585,8 @@ class TestTaskManagerTaskRelease(unittest.IsolatedAsyncioTestCase):
 
         await self.tm.on_task_new(task)
 
-        self.assertIn(task.taskId, self.tm._task_id_to_task)
+        self.assertIn(task.taskId, self.tm._queued_task_ids)
+        self.assertNotIn(task.taskId, self.tm._processing_task_ids)
 
 
 class TestExecutionBackendSentinel(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Two ways a task cancel kills a proxy worker manager's worker process, taking every other task on it. Both are reproducible against IBM Spectrum Symphony 7.3.2, and both predate the worker manager reorganisation in #996.

**`on_task_new` KeyError.** `process_task` left a picked-up task in `_queued_task_ids`, so an in-flight task looked both queued and processing. A force cancel took the queued branch too and popped `_task_id_to_task` out from under the pending future; `resolve_tasks` then found no task and continued without dropping the id from `_acquiring_task_ids` or releasing the semaphore. The next task to arrive looked that id up and raised. The missing-task path also leaked one unit of concurrency for the life of the worker even where it did not crash.

**`on_cancel_task` KeyError.** A task counts as processing from before `execute()` returns, so a force cancel landing during that await found no future recorded yet.

Cleanup now runs through `_release_task` in a `finally`, so no exit path can strand an id or leak a permit, and both lookups tolerate the gap they cannot rule out. The body of the resolve loop moves into `_report_task_outcome` and `_send_task_result` unchanged.

The eight new tests all fail against the current code, four of them with the exact `KeyError`.